### PR TITLE
Generate Scaladoc with inheritance diagrams and documentation about members inherited by implicit conversions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val commonSettings = Seq(
   version := "1.9",
 
   scalaVersion := "2.11.5",
+  scalacOptions in (Compile, doc) ++= Seq("-diagrams","-implicits"),
   testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console"),
   libraryDependencies ++= testDependencies map(_ % Test)
 )


### PR DESCRIPTION
Scaladoc has a very convenient feature that show inheritance diagrams for free.
This is a great improvement over Javadoc and there is no reason to not use this feature.
It help the new comers to understand how the code is articulate.
A paper about the birth of this feature is available here : http://lamp.epfl.ch/files/content/sites/lamp/files/teaching/student-project-reports/semester/DamienObrist-SemesterProjectReport.pdf
Scaladoc can also show documentation  about members inherited by implicit conversions.

This pull request add both.
The same sbt doc command is used, the only requirement is that graphviz need to be installed.
graphviz is a very common package available in all distribution.

Look for example at the at.logic.language.fol.FOLExpression scaladoc and see the two new sections generated
* Type Hierarchy with clickable inheritance diagrams
* Implicitly where you can select the implicits you wan't to see

![capture d ecran 2015-02-03 a 23 12 24](https://cloud.githubusercontent.com/assets/543542/6030790/4a0452f0-abfa-11e4-9f65-c141c15e3883.png)


The scaladoc of Scala language is generated that way.