### PR TITLE
Fix issues when external binaries are not found

### DIFF
--- a/src/test/scala/at/logic/integration_tests/MiscTest.scala
+++ b/src/test/scala/at/logic/integration_tests/MiscTest.scala
@@ -273,6 +273,7 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
     "load Prover9 proof without equality reasoning, extract expansion tree E, verify deep formula of E with minisat" in {
       if (!(new MiniSATProver).isInstalled()) skipped("MiniSAT is not installed")
+      if(!Prover9.isInstalled ()) skipped("Prover9 is not installed")
       for (testBaseName <- "PUZ002-1.out" :: Nil) {
         val (resproof, endsequent, _) = Prover9.parse_prover9( tempCopyOfClasspathFile( testBaseName ))
 

--- a/src/test/scala/at/logic/provers/prover9/ReplayTest.scala
+++ b/src/test/scala/at/logic/provers/prover9/ReplayTest.scala
@@ -51,7 +51,7 @@ class ReplayTest extends SpecificationWithJUnit {
 
   def getRefutation2(ls: Iterable[FSequent]) = MyProver.refute(Stream(SetTargetClause(FSequent(List(),List())), Prover9InitCommand(ls), SetStreamCommand())).next
 
-
+  args (skipAll = !Prover9.isInstalled ())
   "replay" should {
     /*"prove (with para) SKKx = Ix : { :- f(a,x) = x; :- f(f(f(b,x),y),z) = f(f(x,z), f(y,z)); :- f(f(c,x),y) = x; f(f(f(b,c),c),x) = f(a,x) :- }" in {
 


### PR DESCRIPTION
Using public continuous integration service has revealed two leftover requirements on external binaries.