### PR TITLE
Fix deprecations

### DIFF
--- a/src/main/scala/at/logic/gui/prooftool/gui/Main.scala
+++ b/src/main/scala/at/logic/gui/prooftool/gui/Main.scala
@@ -46,6 +46,8 @@ import at.logic.gui.prooftool.parser.ChangeFormulaColor
 import at.logic.algorithms.rewriting.DefinitionElimination
 import at.logic.algorithms.llk.HybridLatexExporter
 import at.logic.parsing.language.tptp.TPTPFOLExporter
+import com.itextpdf.awt.PdfGraphics2D
+import com.itextpdf.awt.DefaultFontMapper
 
 object Main extends SimpleSwingApplication {
   val body = new MyScrollPane
@@ -245,7 +247,7 @@ object Main extends SimpleSwingApplication {
           document.open()
           val content = writer.getDirectContent
           val template = content.createTemplate( width, height )
-          val g2 = template.createGraphicsShapes( width, height )
+          val g2 = new PdfGraphics2D( template, width, height, true )
           component.paint( g2 )
           g2.dispose()
           content.addTemplate( template, 0, 10 )

--- a/src/main/scala/at/logic/language/fol/fol.scala
+++ b/src/main/scala/at/logic/language/fol/fol.scala
@@ -210,7 +210,7 @@ private class ExQ extends FOLLambdaConst( ExistsSymbol, ->( ->( Ti, To ), To ) )
 private object ExQ {
   def apply() = new ExQ
   def unapply( v: FOLLambdaConst ) = v match {
-    case vo: ExQ => Some()
+    case vo: ExQ => Some( () )
     case _       => None
   }
 }
@@ -219,7 +219,7 @@ private class AllQ extends FOLLambdaConst( ForallSymbol, ->( ->( Ti, To ), To ) 
 private object AllQ {
   def apply() = new AllQ
   def unapply( v: FOLLambdaConst ) = v match {
-    case vo: AllQ => Some()
+    case vo: AllQ => Some( () )
     case _        => None
   }
 }

--- a/src/main/scala/at/logic/language/schema/schema.scala
+++ b/src/main/scala/at/logic/language/schema/schema.scala
@@ -550,8 +550,8 @@ object SchemaSubTerms {
     case Or( x, y )        => ( apply( x.asInstanceOf[SchemaExpression] ) ++ apply( y.asInstanceOf[HOLExpression] ) )
     case Imp( x, y )       => ( apply( x.asInstanceOf[SchemaExpression] ) ++ apply( y.asInstanceOf[HOLExpression] ) )
     case Neg( x )          => apply( x.asInstanceOf[SchemaExpression] )
-    case Ex( x )           => apply( x.asInstanceOf[SchemaExpression] )
-    case All( x )          => apply( x.asInstanceOf[SchemaExpression] )
+    case Ex( x, _ )        => apply( x.asInstanceOf[SchemaExpression] )
+    case All( x, _ )       => apply( x.asInstanceOf[SchemaExpression] )
 
     case SchemaAbs( _, x ) => apply( x.asInstanceOf[SchemaExpression] )
     case SchemaApp( x, y ) => List( f ).toSeq

--- a/src/main/scala/at/logic/utils/executionModels/timeout.scala
+++ b/src/main/scala/at/logic/utils/executionModels/timeout.scala
@@ -1,8 +1,11 @@
 package at.logic.utils.executionModels
 
-package timeout {
+import scala.concurrent._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import ExecutionContext.Implicits.global
 
-  class TimeOutException extends Exception
+package timeout {
 
   /**
    * runs f with timeout to
@@ -20,29 +23,8 @@ package timeout {
    * }
    */
   object withTimeout {
-    def apply[T]( to: Long )( f: => T ): T = {
-      var result: Either[Throwable, T] = Left( new TimeOutException() )
-
-      val r = new Runnable {
-        def run() {
-          try {
-            result = Right( f )
-          } catch {
-            case e: Exception =>
-              result = Left( e )
-          }
-        }
-      }
-
-      val t = new Thread( r )
-      t.start()
-      t.join( to )
-      if ( t.isAlive() ) {
-        t.stop()
-      }
-
-      if ( result.isLeft ) throw result.left.get
-      else result.right.get
+    def apply[T]( to: Duration )( f: => T ): T = {
+      Await.result( Future { f }, to )
     }
   }
 

--- a/testing/runOnProver9Proofs.scala
+++ b/testing/runOnProver9Proofs.scala
@@ -2,6 +2,7 @@ import java.io.{FileWriter, File}
 import at.logic.calculi.lk.base.LKRuleCreationException
 import at.logic.cli.GAPScalaInteractiveShellLibrary.loadProver9LKProof
 import at.logic.utils.executionModels.timeout._
+import scala.concurrent.duration._
 
 object runOnProver9Proofs {
   /** The base prover9 path.
@@ -17,7 +18,7 @@ object runOnProver9Proofs {
   /** The maximum time (in seconds) a test is allowed to take.
    *
    */
-  val timeOut = 60
+  val timeOut = 60 second
 
   /** Returns a list of files, sorted by file size in ascending order.
    *
@@ -90,7 +91,7 @@ object runOnProver9Proofs {
 
     // Try importing the given file for at most timeOut seconds
     try {
-      withTimeout(1000 * timeOut)
+      withTimeout(timeOut)
       {loadProver9LKProof(path)}
     }
 

--- a/testing/testCutIntro.scala
+++ b/testing/testCutIntro.scala
@@ -10,6 +10,9 @@ import at.logic.algorithms.lk._
 import at.logic.provers.eqProver._
 import at.logic.provers._
 
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
 // for testCutIntro.compressProofSequences
 :load examples/ProofSequences.scala
 
@@ -20,19 +23,19 @@ import at.logic.provers._
  *
  * scala> :load testing/testCutIntro.scala
  *
- * scala> testCutIntro.findNonTrivialTSTPExamples( "testing/TSTP/prover9/", 60 )
+ * scala> testCutIntro.findNonTrivialTSTPExamples( "testing/TSTP/prover9/", 60 seconds)
  *
  * test the tests by
- * scala> testCutIntro.compressTSTP ("testing/resultsCutIntro/tstp_minitest.csv", timeout: Int, method: Int)
- * scala> testCutIntro.compressVeriT ("testing/veriT-SMT-LIB/QF_UF/eq_diamond/", timeout: Int, method: Int)
- * scala> testCutIntro.compressProofSequences (timeout: Int, method: Int)
+ * scala> testCutIntro.compressTSTP ("testing/resultsCutIntro/tstp_minitest.csv", timeout: Duration, method: Int)
+ * scala> testCutIntro.compressVeriT ("testing/veriT-SMT-LIB/QF_UF/eq_diamond/", timeout: Duration, method: Int)
+ * scala> testCutIntro.compressProofSequences (timeout: Duration, method: Int)
  * Where method is:
  * 0: introduce one cut with one quantifier
  * 1: introduce one cut with as many quantifiers as possible
  * 2: introduce many cuts with one quantifier each
  *
  * run the tests by
- * scala> testCutIntro.compressAll(timeout: Int)
+ * scala> testCutIntro.compressAll(timeout: Duration)
  * see compressAll for how to call specific tests
  **********/
 
@@ -82,7 +85,7 @@ object testCutIntro {
     println("Usage: for example calls please see the implementation of testCutIntro.compressAll()")
   }
 
-  def compressAll (timeout: Int) = {
+  def compressAll (timeout: Duration) = {
 
     compressProofSequences (timeout, 0)
     compressProofSequences (timeout, 1)
@@ -105,7 +108,7 @@ object testCutIntro {
    * All calls to cut-introduction and logging are done exclusively here
    *
    */
-  def compressLKProof (proof: Option[LKProof], timeout: Int, method: Int, name: String, status: String) = {
+  def compressLKProof (proof: Option[LKProof], timeout: Duration, method: Int, name: String, status: String) = {
     val method_name = method match {
       case 0 => "one_cut_one_quant"
       case 1 => "one_cut_many_quant"
@@ -130,7 +133,7 @@ object testCutIntro {
     }
   }
 
-  def compressExpansionProof (ep: Option[ExpansionSequent], hasEquality: Boolean, timeout: Int, method: Int, name: String, status: String) = 
+  def compressExpansionProof (ep: Option[ExpansionSequent], hasEquality: Boolean, timeout: Duration, method: Int, name: String, status: String) =
   status match {
     case "ok" =>
       val (cut_intro_status, info_tuple) = method match {
@@ -155,7 +158,7 @@ object testCutIntro {
   // Hashmap containing proofs with non-trivial termsets
   var termsets = HashMap[String, TermSet]()
 
-  def findNonTrivialTSTPExamples ( str : String, timeout : Int ) = {
+  def findNonTrivialTSTPExamples ( str : String, timeout : Duration ) = {
     
     nonTrivialTermset(str, timeout)
     val file = new File("testing/resultsCutIntro/tstp_non_trivial_termset.csv")
@@ -194,7 +197,7 @@ object testCutIntro {
     bw_s.close()
 
   }
-  def nonTrivialTermset(str : String, timeout : Int) : Unit = {
+  def nonTrivialTermset(str : String, timeout : Duration) : Unit = {
     val file = new File(str)
     if (file.isDirectory) {
       val children = file.listFiles
@@ -202,8 +205,8 @@ object testCutIntro {
     }
     else if (file.getName.endsWith(".out")) {
       total += 1
-      try { withTimeout(timeout * 1000) { loadProver9LKProof(file.getAbsolutePath) match {
-        case p: LKProof => try { withTimeout(timeout * 1000) { 
+      try { withTimeout(timeout) { loadProver9LKProof(file.getAbsolutePath) match {
+        case p: LKProof => try { withTimeout(timeout) {
           val ts = extractTerms(p)
           val tssize = ts.set.size
           val n_functions = ts.formulaFunction.size
@@ -223,7 +226,7 @@ object testCutIntro {
   }
 
   // Compress the prover9-TSTP proofs whose names are in the csv-file passed as parameter str
-  def compressTSTP (str: String, timeout: Int, method: Int) = {
+  def compressTSTP (str: String, timeout: Duration, method: Int) = {
     
     // Process each file in parallel
     val lines = Source.fromFile(str).getLines().toList
@@ -236,16 +239,16 @@ object testCutIntro {
   }
 
   /// compress the prover9-TSTP proof found in file fn
-  def compressTSTPProof (fn: String, timeout: Int, method: Int) = {
+  def compressTSTPProof (fn: String, timeout: Duration, method: Int) = {
     var status = "ok"
 
     val file = new File (fn)
     if (file.getName.endsWith(".out")) {
-      val proof = try { withTimeout( timeout * 1000 ) {
+      val proof = try { withTimeout( timeout ) {
         val p = loadProver9LKProof( file.getAbsolutePath )
         Some (p)
       } } catch {
-        case e: TimeOutException =>
+        case e: TimeoutException =>
           status = "parsing_timeout"
           None
         case e: OutOfMemoryError =>
@@ -266,7 +269,7 @@ object testCutIntro {
   /****************************** VeriT SMT-LIB ******************************/
 
   // Compress all veriT-proofs found in the directory str and beyond
-  def compressVeriT (str: String, timeout: Int, method: Int) = {
+  def compressVeriT (str: String, timeout: Duration, method: Int) = {
     val proofs = getVeriTProofs (str)
     //proofs.par.foreach { case p => 
     proofs.foreach { case p => 
@@ -288,10 +291,10 @@ object testCutIntro {
   }
 
   // Compress the veriT-proof in file str
-  def compressVeriTProof (str: String, timeout: Int, method: Int) {
+  def compressVeriTProof (str: String, timeout: Duration, method: Int) {
     var status = "ok"
 
-    val expproof = try { withTimeout( timeout * 1000 ) {
+    val expproof = try { withTimeout( timeout ) {
       val ep = loadVeriTProof (str)
 
       if ( ep.isEmpty ) {
@@ -300,7 +303,7 @@ object testCutIntro {
 
       ep
     } } catch {
-      case e: TimeOutException =>
+      case e: TimeoutException =>
         status = "parsing_timeout"
         None
       case e: OutOfMemoryError =>
@@ -320,7 +323,7 @@ object testCutIntro {
 
   /***************************** Proof Sequences ******************************/
 
-  def compressProofSequences (timeout: Int, method: Int) = {
+  def compressProofSequences (timeout: Duration, method: Int) = {
 
     var i = 0
     var status = ""


### PR DESCRIPTION
This remove all deprecations in gapt (excepted runOnProver9Proofs which would better be rewritten)
Note the use of Duration instead of Long/Int as it is the natural type used by Await.result and the natural type to use for duration anyway.