### PR TITLE
Fix a regression regarding requirement on external binaries for Prover9Test and avoid more.

### DIFF
--- a/src/main/scala/at/logic/provers/prover9/Prover9.scala
+++ b/src/main/scala/at/logic/provers/prover9/Prover9.scala
@@ -382,21 +382,26 @@ object Prover9 extends at.logic.utils.logging.Logger {
 
   def isInstalled(): Boolean = {
     if ( !isLadrToTptpInstalled() ) {
-      println( "ladr_to_tptp not found!" )
+      warn( "ladr_to_tptp not found!" )
       return false
     }
     if ( !isProver9Installed() ) {
-      println( "prover9 not found!" )
+      warn( "prover9 not found!" )
       return false
     }
     if ( !isProoftransInstalled() ) {
-      println( "prooftrans not found!" )
+      warn( "prooftrans not found!" )
+      return false
+    }
+    if ( !isTptpToLadrInstalled() ) {
+      warn( "tptp_to_ladr not found!" )
       return false
     }
     true
   }
 
   private def isLadrToTptpInstalled(): Boolean = callBinary( "ladr_to_tptp" ) == 1
+  private def isTptpToLadrInstalled(): Boolean = callBinary( "tptp_to_ladr" ) == 0
   private def isProver9Installed(): Boolean = callBinary( "prover9" ) == 2
   private def isProoftransInstalled(): Boolean = callBinary( "prooftrans" ) == 1
 

--- a/src/test/scala/at/logic/provers/prover9/Prover9Test.scala
+++ b/src/test/scala/at/logic/provers/prover9/Prover9Test.scala
@@ -22,15 +22,11 @@ import org.specs2.runner.JUnitRunner
 class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
   def parse(str:String) : FOLFormula = (new StringReader(str) with SimpleFOLParser getTerm).asInstanceOf[FOLFormula]
 
-  val box = List()
-  def checkForProver9OrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
-
   implicit def fo2occ(f:FOLFormula) = factory.createFormulaOccurrence(f, Nil)
 
+  args (skipAll = !Prover9.isInstalled ())
   "The Prover9 interface" should {
     "not refute { :- P; Q :- }" in {
-      //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
 
       val s1 = FSequent(Nil, List(parse("P")))
       val t1 = FSequent(List(parse("Q")),Nil)
@@ -44,8 +40,6 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
     }
 
     "prove { :- (All x) x = x   }" in {
-      //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
 
       val p = new Prover9Prover()
 
@@ -61,8 +55,6 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
     }
 
     "prove { A or B :- -(-A and -B)  }" in {
-      //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
 
       val p = new Prover9Prover()
       val s = FSequent(List(Or(parse("A"), parse("B"))), List(Neg(And(Neg(parse("A")), Neg(parse("B"))))))
@@ -75,8 +67,6 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
     }
 
     "handle quantified antecedents" in {
-      //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box) must not(throwA[IOException]).orSkip
 
       val g1 = parse("Forall x Forall y =(+(s(x), y), s(+(x, y)))")
       val g2 = parse("Forall z =(+(o, z), z)")
@@ -91,18 +81,17 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
 
   }
 
-
   "The Prover9 interface" should {
     "successfully load the goat puzzle PUZ047+1.out" in {
         // if the execution of prooftrans does not work: skip test
-        Prover9.parse_prover9(tempCopyOfClasspathFile("PUZ047+1.out")) must not(throwA[IOException]).orSkip
+        Prover9.parse_prover9(tempCopyOfClasspathFile("PUZ047+1.out"))
 
         "success" must beEqualTo("success")
     }
 
     "successfully load the expansion proof paper example cade13example.out" in {
         // if the execution of prooftrans does not work: skip test
-        Prover9.parse_prover9(tempCopyOfClasspathFile("cade13example.out")) must not(throwA[IOException]).orSkip
+        Prover9.parse_prover9(tempCopyOfClasspathFile("cade13example.out"))
 
         "success" must beEqualTo("success")
     }


### PR DESCRIPTION
Commit c4fd96e6b1ef8bf3e132482c51b26cc63cfbb467 add again a requirement on external binary and broke continuous test if prooftrans is not installed.

Objective for this pull request is to simplify Prover9Test to avoid other issues when external binaries are not found.
To simplify Prover9 is now considered installed if tptp_to_ladr is also installed and all tests are skipped if one binary is missing.
This seem a reasonable requirement for Prover9Test to have all binaries installed.
