### PR TITLE
Attempt to fix code-coverage with a real token

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
-import CoverallsPlugin.CoverallsKeys._
 
 lazy val commonSettings = Seq(
   organization := "at.logic.gapt",
@@ -13,8 +12,7 @@ lazy val commonSettings = Seq(
   testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "junitxml", "console"),
   libraryDependencies ++= testDependencies map(_ % Test),
 
-  sourcesInBase := false, // people like to keep scripts lying around
-  coverallsToken := "token"
+  sourcesInBase := false // people like to keep scripts lying around
 )
 
 lazy val root = (project in file(".")).


### PR DESCRIPTION
A real token will be exported during the build and should fix our issue with code coverage.
This is not required with an ordinary project so if this attempt work, that mean that this is mandatory if the project is in an organization.
(As far as I know this is not documented. Note also that the export of the token will make it public in the travis log)