### PR TITLE
Fix interface to Vampire prover

### DIFF
--- a/src/main/scala/at/logic/provers/vampire/vampire.scala
+++ b/src/main/scala/at/logic/provers/vampire/vampire.scala
@@ -1,7 +1,5 @@
 /**
- * Interface to the Prover9 first-order theorem prover.
- * Needs the command-line tools prover9 and tptp_to_ladr
- * to work.
+ * Interface to the Vampire first-order theorem prover.
  */
 
 package at.logic.provers.vampire
@@ -11,16 +9,15 @@ import at.logic.parsing.language.tptp.TPTPFOLExporter
 
 import java.io._
 import scala.io.Source
+import java.nio.file.{ Paths, Files }
 
 class VampireException( msg: String ) extends Exception( msg )
 
-object Vampire {
+object Vampire extends at.logic.utils.logging.Logger {
 
   def writeProblem( named_sequents: List[Tuple2[String, FSequent]], file_name: String ) =
     {
-
       val tptp = TPTPFOLExporter.tptp_problem_named( named_sequents )
-      //println("created tptp input: " + tptp)
       val writer = new FileWriter( file_name )
       writer.write( tptp )
       writer.flush
@@ -29,26 +26,20 @@ object Vampire {
   // TODO: this does not really belong here, refactor?
   // executes "prog" and feeds the contents of the file at
   // path "in" to its standard input.
-  private def exec( prog_alternatives: List[String], in: String ): ( Int, String ) =
-    {
-      for ( prog <- prog_alternatives ) {
-        try {
-          val p = Runtime.getRuntime.exec( prog )
+  private def exec( in: String ): ( Int, String ) = {
+    if ( !vampireBinaryName.isDefined )
+      throw new VampireException( "Unable to determine vampire's binary name for your OS!" )
+    val prog = vampireBinaryName.get
+    val p = Runtime.getRuntime.exec( prog )
 
-          val out = new OutputStreamWriter( p.getOutputStream )
-          out.write( Source.fromInputStream( new FileInputStream( in ) ).mkString )
-          out.close
+    val out = new OutputStreamWriter( p.getOutputStream )
+    out.write( Source.fromInputStream( new FileInputStream( in ) ).mkString )
+    out.close
 
-          val str = Source.fromInputStream( p.getInputStream ).mkString
-          p.waitFor
-          ( p.exitValue, str )
-        } catch {
-          case e: IOException => println( "could not find binary " + prog + " in path!" );
-        }
-      }
-
-      throw new VampireException( "Could not execute vampire binary!" )
-    }
+    val str = Source.fromInputStream( p.getInputStream ).mkString
+    p.waitFor
+    ( p.exitValue, str )
+  }
 
   def writeToFile( str: String, file: String ) = {
     val out = new FileWriter( file )
@@ -56,11 +47,10 @@ object Vampire {
     out.close
   }
 
-  def refute( input_file: String, output_file: String ): Int = {
-    //TODO: find correct binary (lin32, lin64, mac)
-    val ret = exec( List( "vampire_lin64", "vampire_lin32", "vampire_macosx" ), input_file )
+  def refute( input_file: String, output_file: String ): ( Int, String ) = {
+    val ret = exec( input_file )
     writeToFile( ret._2, output_file )
-    ret._1
+    ret
   }
 
   def refuteNamed( named_sequents: List[Tuple2[String, FSequent]], input_file: String, output_file: String ): Boolean =
@@ -68,9 +58,10 @@ object Vampire {
       writeProblem( named_sequents, input_file )
 
       val ret = refute( input_file, output_file )
-      ret match {
-        case 0 => true
-        case _ => throw new VampireException( "The set was satisfiable or there was a problem executing vampire!" )
+      ret._1 match {
+        case 0 if ret._2.startsWith( "Refutation found" ) => true
+        case 0 if ret._2.startsWith( "Satisfiable" ) => false
+        case _ => throw new VampireException( "There was a problem executing vampire!" )
       }
     }
 
@@ -79,11 +70,34 @@ object Vampire {
 
   def refute( sequents: List[FSequent] ): Boolean = {
     val in_file = File.createTempFile( "gapt-vampire", ".tptp", null )
-    val out_file = File.createTempFile( "gapt-vampire", "prover9", null )
+    val out_file = File.createTempFile( "gapt-vampire", "vampire", null )
     val ret = refute( sequents, in_file.getAbsolutePath, out_file.getAbsolutePath )
     in_file.delete
     out_file.delete
     ret
+  }
+
+  val vampireBinaryName: Option[String] = {
+    val osName = System.getProperty( "os.name" ).toLowerCase()
+    val osArch = System.getProperty( "os.arch" )
+    osName match {
+      case osName if osName.contains( "mac" ) => Some( "vampire_mac" )
+      case osName if osName.contains( "linux" ) && osArch.contains( "64" ) => Some( "vampire_lin64" )
+      case osName if osName.contains( "linux" ) && osArch.contains( "32" ) => Some( "vampire_lin32" )
+      case _ => None
+    }
+  }
+
+  def isInstalled(): Boolean = {
+    val box = List()
+    try {
+      Vampire.refute( box )
+    } catch {
+      case e: Throwable =>
+        warn( e.getMessage )
+        return false
+    }
+    return true
   }
 
 }

--- a/src/test/scala/at/logic/provers/vampire/vampireTest.scala
+++ b/src/test/scala/at/logic/provers/vampire/vampireTest.scala
@@ -14,14 +14,10 @@ import at.logic.calculi.lk.base.FSequent
 @RunWith(classOf[JUnitRunner])
 class VampireTest extends SpecificationWithJUnit {
 
-  val box = List()
-  def checkForVampireOrSkip = Vampire.refute(box) must not(throwA[VampireException]).orSkip
+  args (skipAll = !Vampire.isInstalled ())
 
   "The Vampire interface" should {
     "refute { :- P; P :- }" in {
-      //checks, if the execution of vampire works, o.w. skip test
-      Vampire.refute(box ) must not(throwA[VampireException]).orSkip
-
       val p = Atom("P", Nil)
       val s1 = FSequent(Nil, p::Nil)
       val s2 = FSequent(p::Nil, Nil)
@@ -32,9 +28,6 @@ class VampireTest extends SpecificationWithJUnit {
 
   "The Vampire interface" should {
     "prove SKKx = Ix : { :- f(a,x) = x; :- f(f(f(b,x),y),z) = f(f(x,z), f(y,z)); :- f(f(c,x),y) = x; f(f(f(b,c),c),x) = f(a,x) :- }" in {
-      //checks, if the execution of vampire works, o.w. skip test
-      Vampire.refute(box ) must not(throwA[VampireException]).orSkip
-
       val x = FOLVar("x")
       val y = FOLVar("y")
       val z = FOLVar("z")
@@ -68,9 +61,6 @@ class VampireTest extends SpecificationWithJUnit {
 
   "The Vampire interface" should {
     "not refute { :- P; Q :- }" in {
-      //checks, if the execution of vampire works, o.w. skip test
-      Vampire.refute(box ) must not(throwA[VampireException]).orSkip
-
       val s1 = FSequent(Nil, List(Atom("P", Nil)))
       val t1 = FSequent(List(Atom("Q", Nil)),Nil)
       val result : Boolean = Vampire.refute( List(s1,t1) )


### PR DESCRIPTION
Interface to Vampire prover was in very bad shape.
could not find binary vampire_lin64 in path!
could not find binary vampire_lin64 in path!
could not find binary vampire_lin64 in path!
could not find binary vampire_lin32 in path!
could not find binary vampire_lin32 in path!
could not find binary vampire_lin32 in path!
could not find binary vampire_macosx in path!
could not find binary vampire_macosx in path!
could not find binary vampire_macosx in path!
[info] Total for specification VampireTest
[info] Finished in 155 ms
[info] 3 examples, 0 failure, 0 error, 3 skipped

This pull request try to improve the situation.