### PR TITLE
Format also test files

### DIFF
--- a/scalariform.sbt
+++ b/scalariform.sbt
@@ -1,5 +1,7 @@
 import scalariform.formatter.preferences._
 
+addCommandAlias("format", "; scalariformFormat ; test:scalariformFormat")
+
 defaultScalariformSettings
 
 ScalariformKeys.preferences := FormattingPreferences()

--- a/src/test/scala/VeriTParsingTest.scala
+++ b/src/test/scala/VeriTParsingTest.scala
@@ -5,39 +5,39 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.mutable.SpecificationWithJUnit
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class VeriTParsingTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
   "The veriT parser" should {
     "parse correctly the simplest proof of the database" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("test0.verit"))
-      formulas.get.antecedent must haveSize(2)
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "test0.verit" ) )
+      formulas.get.antecedent must haveSize( 2 )
     }
 
     "parse correctly a more complicated example" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("test1.verit"))
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "test1.verit" ) )
       // Only 3 expansion trees: input, eq_transitive (with a million
       // instances!) and eq_symmetry (with hundreds of instances)
-      formulas.get.antecedent must haveSize(3)
+      formulas.get.antecedent must haveSize( 3 )
     }
 
     "parse correctly an even more complicated example" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("test2.verit"))
-      formulas.get.antecedent must haveSize(4)
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "test2.verit" ) )
+      formulas.get.antecedent must haveSize( 4 )
     }
-    
+
     "parse correctly an example from QG-classification" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("test3.verit"))
-      formulas.get.antecedent must haveSize(9)
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "test3.verit" ) )
+      formulas.get.antecedent must haveSize( 9 )
     }
     "parse correctly a different eq_congruent 1" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("iso_icl439.smt2.proof_flat"))
-      formulas.get.antecedent must haveSize(15)
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "iso_icl439.smt2.proof_flat" ) )
+      formulas.get.antecedent must haveSize( 15 )
     }
     // If the test above is commented out. This one fails with stackoverflow o.O
     "parse correctly a different eq_congruent 2" in {
-      val formulas = VeriTParser.getExpansionProof(tempCopyOfClasspathFile("test4.verit"))
-      formulas.get.antecedent must haveSize(11)
+      val formulas = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( "test4.verit" ) )
+      formulas.get.antecedent must haveSize( 11 )
     }
   }
 }

--- a/src/test/scala/VeriTProverTest.scala
+++ b/src/test/scala/VeriTProverTest.scala
@@ -11,27 +11,27 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class VeriTProverTest extends SpecificationWithJUnit {
 
   val veriT = new VeriTProver()
 
-  args(skipAll = !veriT.isInstalled())
+  args( skipAll = !veriT.isInstalled() )
 
   "VeriT" should {
     "prove a v not a" in {
       //skipped("--proof-version in isValid is only supported on Giselle's machine")
-      val a = Atom("a", Nil)
-      val f = Or(a, Neg(a))
+      val a = Atom( "a", Nil )
+      val f = Or( a, Neg( a ) )
 
-      veriT.isValid(f) must beEqualTo(true)
+      veriT.isValid( f ) must beEqualTo( true )
     }
 
     "parse the proof of a |- a" in {
-      val a = Atom("a")
-      val s = FSequent(List(a), List(a))
+      val a = Atom( "a" )
+      val s = FSequent( List( a ), List( a ) )
 
-      veriT.getExpansionSequent(s) must not be None
+      veriT.getExpansionSequent( s ) must not be None
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/cutIntroduction/ForgetfulResolutionTest.scala
+++ b/src/test/scala/at/logic/algorithms/cutIntroduction/ForgetfulResolutionTest.scala
@@ -12,54 +12,54 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.fol._
 import MinimizeSolution._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ForgetfulResolutionTest extends SpecificationWithJUnit {
 
   "Forgetful Paramodulation Should" should {
 
     "successfully paramodulate a=b into f(a,a)" in {
-      val a = FOLConst("a")
-      val b = FOLConst("b")
+      val a = FOLConst( "a" )
+      val b = FOLConst( "b" )
       val fs = "f"
-      val faa = Function(fs, a::a::Nil)
+      val faa = Function( fs, a :: a :: Nil )
 
-      val realab = Set( Function( fs, a::a::Nil ), Function( fs, a::b::Nil ), Function( fs, b::a::Nil ), Function( fs, b::b::Nil ) )
-      val realba = Set( Function( fs, a::a::Nil ) )
-     
-      val parasab = Paramodulants(a, b, faa)
-      val parasba = Paramodulants(b, a, faa)
+      val realab = Set( Function( fs, a :: a :: Nil ), Function( fs, a :: b :: Nil ), Function( fs, b :: a :: Nil ), Function( fs, b :: b :: Nil ) )
+      val realba = Set( Function( fs, a :: a :: Nil ) )
 
-      parasab must beEqualTo(realab)
-      parasba must beEqualTo(realba)
+      val parasab = Paramodulants( a, b, faa )
+      val parasba = Paramodulants( b, a, faa )
+
+      parasab must beEqualTo( realab )
+      parasba must beEqualTo( realba )
     }
 
     "successfully apply forgetful paramodulation to { :- a = b; :- P(a, a); :- Q } " in {
-      val a = FOLConst("a")
-      val b = FOLConst("b")
+      val a = FOLConst( "a" )
+      val b = FOLConst( "b" )
       val ps = "P"
-      val paa = Atom(ps, a::a::Nil)
-      val pab = Atom(ps, a::b::Nil)
-      val pba = Atom(ps, b::a::Nil)
-      val pbb = Atom(ps, b::b::Nil)
-      val q = Atom("Q", Nil )
-      val cq = new MyFClause( Nil, q::Nil )
-      val cpaa = new MyFClause( Nil, paa::Nil )
-      val cpab = new MyFClause( Nil, pab::Nil )
-      val cpba = new MyFClause( Nil, pba::Nil )
-      val cpbb = new MyFClause( Nil, pbb::Nil )
+      val paa = Atom( ps, a :: a :: Nil )
+      val pab = Atom( ps, a :: b :: Nil )
+      val pba = Atom( ps, b :: a :: Nil )
+      val pbb = Atom( ps, b :: b :: Nil )
+      val q = Atom( "Q", Nil )
+      val cq = new MyFClause( Nil, q :: Nil )
+      val cpaa = new MyFClause( Nil, paa :: Nil )
+      val cpab = new MyFClause( Nil, pab :: Nil )
+      val cpba = new MyFClause( Nil, pba :: Nil )
+      val cpbb = new MyFClause( Nil, pbb :: Nil )
 
-      val r1 = Set(cpab, cq)
-      val r2 = Set(cpba, cq)
-      val r3 = Set(cpbb, cq)
-      val real = Set(r1, r2, r3)
+      val r1 = Set( cpab, cq )
+      val r2 = Set( cpba, cq )
+      val r3 = Set( cpbb, cq )
+      val real = Set( r1, r2, r3 )
 
-      val res = ForgetfulParamodulateCNF( And( Equation( a, b)::paa::q::Nil ) )
+      val res = ForgetfulParamodulateCNF( And( Equation( a, b ) :: paa :: q :: Nil ) )
 
       val setres = res.map( cnf => cnf.toSet ).toSet
 
-      setres must beEqualTo(real)
+      setres must beEqualTo( real )
     }
-/*
+    /*
     "improve the solution correctly" in {
       val p = at.logic.testing.LinearExampleProof(8)
       val ts = new FlatTermSet(TermsExtraction(p))
@@ -79,23 +79,23 @@ class ForgetfulResolutionTest extends SpecificationWithJUnit {
   "Forgetful Resolution Should" should {
 
     "compute a single resolvent successfully" in {
-      val a = Atom("A")
-      val b = Atom("B")
-      val c = Atom("C")
-      val d = Atom("D")
-      val e = Atom("E")
+      val a = Atom( "A" )
+      val b = Atom( "B" )
+      val c = Atom( "C" )
+      val d = Atom( "D" )
+      val e = Atom( "E" )
 
-      val f = And(And(Or(a,Or(b,c)), Or(Neg(b), d)), e)
+      val f = And( And( Or( a, Or( b, c ) ), Or( Neg( b ), d ) ), e )
 
-      val res = ForgetfulResolve(f)
+      val res = ForgetfulResolve( f )
 
       //println("Formula (in CNF): " + f)
       //println("Resolvent: " + res)
 
-      res.size must beEqualTo(1)
+      res.size must beEqualTo( 1 )
     }
 
-/*
+    /*
     "improve the solution correctly" in {
       val p = at.logic.testing.LinearExampleProof(8)
       val ts = new FlatTermSet(TermsExtraction(p))

--- a/src/test/scala/at/logic/algorithms/cutIntroduction/GrammarTest.scala
+++ b/src/test/scala/at/logic/algorithms/cutIntroduction/GrammarTest.scala
@@ -15,76 +15,76 @@ import ComputeGrammars._
 import Deltas._
 import types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class GrammarTest extends SpecificationWithJUnit {
 
-// On the comments of the examples below, consider A as α
+  // On the comments of the examples below, consider A as α
 
   "The decomposition" should {
 
     "compute the bounded multi-variable delta-vector correctly" in {
       "trivial decomposition" in {
 
-        val deltaG = new ManyVariableDelta(1)
+        val deltaG = new ManyVariableDelta( 1 )
 
         val f = "f"
         val g = "g"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
 
-        val f1 = Function(f, a::Nil)
-        val g1 = Function(g, b::Nil)
+        val f1 = Function( f, a :: Nil )
+        val g1 = Function( g, b :: Nil )
 
-        val dec = deltaG.computeDelta(f1::g1::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: g1 :: Nil, "α" )
 
-        val alpha = FOLVar("α_0")
+        val alpha = FOLVar( "α_0" )
 
-        val s = Set(((f1::g1::Nil)::Nil).transpose: _*)
+        val s = Set( ( ( f1 :: g1 :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((alpha, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( alpha, s ) ) )
       }
 
-        "example #1" in {
-            val deltaG = new ManyVariableDelta(2)
+      "example #1" in {
+        val deltaG = new ManyVariableDelta( 2 )
 
-            val f = "f"
-            val a = FOLConst("a")
-            val b = FOLConst("b")
+        val f = "f"
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
 
-            val f1 = Function(f, a::b::Nil)
-            val f2 = Function(f, b::a::Nil)
+        val f1 = Function( f, a :: b :: Nil )
+        val f2 = Function( f, b :: a :: Nil )
 
-            val dec = deltaG.computeDelta(f1::f2::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: Nil, "α" )
 
-            val alpha = FOLVar("α_0")
-            val alpha_2 = FOLVar("α_1")
-            val f_alpha = Function(f, alpha::alpha_2::Nil)
+        val alpha = FOLVar( "α_0" )
+        val alpha_2 = FOLVar( "α_1" )
+        val f_alpha = Function( f, alpha :: alpha_2 :: Nil )
 
-            val s1 = Set(((f1::f2::Nil)::Nil).transpose: _*)
-            val s2 = Set(((a::b::Nil)::(b::a::Nil)::Nil).transpose: _*)
+        val s1 = Set( ( ( f1 :: f2 :: Nil ) :: Nil ).transpose: _* )
+        val s2 = Set( ( ( a :: b :: Nil ) :: ( b :: a :: Nil ) :: Nil ).transpose: _* )
 
-            (dec) must beEqualTo (Set[Decomposition]((alpha, s1), (f_alpha, s2.asInstanceOf[types.S])))
-        }
+        ( dec ) must beEqualTo( Set[Decomposition]( ( alpha, s1 ), ( f_alpha, s2.asInstanceOf[types.S] ) ) )
+      }
 
-        "example with a unary function symbol" in {
-            val deltaG = new ManyVariableDelta(2)
+      "example with a unary function symbol" in {
+        val deltaG = new ManyVariableDelta( 2 )
 
-            val f = "f"
-            val a = FOLConst("a")
-            val b = FOLConst("b")
+        val f = "f"
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
 
-            val f1 = Function(f, a::Nil)
-            val f2 = Function(f, b::Nil)
+        val f1 = Function( f, a :: Nil )
+        val f2 = Function( f, b :: Nil )
 
-            val dec = deltaG.computeDelta(f1::f2::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: Nil, "α" )
 
-            val alpha = FOLVar("α_0")
-            val f_alpha = Function(f, alpha::Nil)
+        val alpha = FOLVar( "α_0" )
+        val f_alpha = Function( f, alpha :: Nil )
 
-            val s = Set(((a::b::Nil)::Nil).transpose: _*)
+        val s = Set( ( ( a :: b :: Nil ) :: Nil ).transpose: _* )
 
-            (dec) must beEqualTo (Set[Decomposition]((f_alpha, s.asInstanceOf[types.S])))
-        }
+        ( dec ) must beEqualTo( Set[Decomposition]( ( f_alpha, s.asInstanceOf[types.S] ) ) )
+      }
     }
 
     "compute the multi-variable delta-vector DeltaG correctly" in {
@@ -94,19 +94,19 @@ class GrammarTest extends SpecificationWithJUnit {
 
         val f = "f"
         val g = "g"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
 
-        val f1 = Function(f, a::Nil)
-        val g1 = Function(g, b::Nil)
+        val f1 = Function( f, a :: Nil )
+        val g1 = Function( g, b :: Nil )
 
-        val dec = deltaG.computeDelta(f1::g1::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: g1 :: Nil, "α" )
 
-        val alpha = FOLVar("α_0")
+        val alpha = FOLVar( "α_0" )
 
-        val s = Set(((f1::g1::Nil)::Nil).transpose: _*)
+        val s = Set( ( ( f1 :: g1 :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((alpha, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( alpha, s ) ) )
       }
 
       "example #1 without duplicates" in {
@@ -115,26 +115,26 @@ class GrammarTest extends SpecificationWithJUnit {
 
         val f = "f"
         val g = "g"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val d = FOLConst("d")
-        val e = FOLConst("e")
-        val fc = FOLConst("f")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val c = FOLConst( "c" )
+        val d = FOLConst( "d" )
+        val e = FOLConst( "e" )
+        val fc = FOLConst( "f" )
 
-        val f1 = Function(f, a::Function(g, c::d::Nil)::Nil)
-        val f2 = Function(f, b::Function(g, e::fc::Nil)::Nil)
+        val f1 = Function( f, a :: Function( g, c :: d :: Nil ) :: Nil )
+        val f2 = Function( f, b :: Function( g, e :: fc :: Nil ) :: Nil )
 
-        val dec = deltaG.computeDelta(f1::f2::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: Nil, "α" )
 
-        val alpha0 = FOLVar("α_0")
-        val alpha1 = FOLVar("α_1")
-        val alpha2 = FOLVar("α_2")
+        val alpha0 = FOLVar( "α_0" )
+        val alpha1 = FOLVar( "α_1" )
+        val alpha2 = FOLVar( "α_2" )
 
-        val uTarget = Function(f, alpha0::Function(g, alpha1::alpha2::Nil)::Nil)
-        val s = Set(((a::b::Nil)::(c::e::Nil)::(d::fc::Nil)::Nil).transpose: _*)
+        val uTarget = Function( f, alpha0 :: Function( g, alpha1 :: alpha2 :: Nil ) :: Nil )
+        val s = Set( ( ( a :: b :: Nil ) :: ( c :: e :: Nil ) :: ( d :: fc :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((uTarget, s.asInstanceOf[types.S])))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( uTarget, s.asInstanceOf[types.S] ) ) )
       }
 
       "example #2 with duplicates" in {
@@ -143,23 +143,23 @@ class GrammarTest extends SpecificationWithJUnit {
 
         val f = "f"
         val g = "g"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val d = FOLConst("d")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val c = FOLConst( "c" )
+        val d = FOLConst( "d" )
 
-        val f1 = Function(f, a::Function(g, c::c::Nil)::Nil)
-        val f2 = Function(f, b::Function(g, d::d::Nil)::Nil)
+        val f1 = Function( f, a :: Function( g, c :: c :: Nil ) :: Nil )
+        val f2 = Function( f, b :: Function( g, d :: d :: Nil ) :: Nil )
 
-        val dec = deltaG.computeDelta(f1::f2::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: Nil, "α" )
 
-        val alpha0 = FOLVar("α_0")
-        val alpha1 = FOLVar("α_1")
+        val alpha0 = FOLVar( "α_0" )
+        val alpha1 = FOLVar( "α_1" )
 
-        val uTarget = Function(f, alpha0::Function(g, alpha1::alpha1::Nil)::Nil)
-        val s = Set(((a::b::Nil)::(c::d::Nil)::Nil).transpose: _*)
+        val uTarget = Function( f, alpha0 :: Function( g, alpha1 :: alpha1 :: Nil ) :: Nil )
+        val s = Set( ( ( a :: b :: Nil ) :: ( c :: d :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((uTarget, s.asInstanceOf[types.S])))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( uTarget, s.asInstanceOf[types.S] ) ) )
       }
 
       "example #3 with alpha-elimination" in {
@@ -168,22 +168,22 @@ class GrammarTest extends SpecificationWithJUnit {
 
         val f = "f"
         val g = "g"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val d = FOLConst("d")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val c = FOLConst( "c" )
+        val d = FOLConst( "d" )
 
-        val f1 = Function(f, a::Function(g, c::d::Nil)::Nil)
-        val f2 = Function(f, b::Function(g, c::d::Nil)::Nil)
+        val f1 = Function( f, a :: Function( g, c :: d :: Nil ) :: Nil )
+        val f2 = Function( f, b :: Function( g, c :: d :: Nil ) :: Nil )
 
-        val dec = deltaG.computeDelta(f1::f2::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: Nil, "α" )
 
-        val alpha0 = FOLVar("α_0")
+        val alpha0 = FOLVar( "α_0" )
 
-        val uTarget = Function(f, alpha0::Function(g, c::d::Nil)::Nil)
-        val s = Set(((a::b::Nil)::Nil).transpose: _*)
+        val uTarget = Function( f, alpha0 :: Function( g, c :: d :: Nil ) :: Nil )
+        val s = Set( ( ( a :: b :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((uTarget, s.asInstanceOf[types.S])))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( uTarget, s.asInstanceOf[types.S] ) ) )
       }
 
       "example #4 with duplicates and alpha-elimination" in {
@@ -193,23 +193,23 @@ class GrammarTest extends SpecificationWithJUnit {
         val f = "f"
         val g = "g"
         val h = "h"
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val d = FOLConst("d")
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val c = FOLConst( "c" )
+        val d = FOLConst( "d" )
 
-        val f1 = Function(f, Function(h, a::Nil)::Function(g, c::a::Nil)::Nil)
-        val f2 = Function(f, Function(h, b::Nil)::Function(g, c::b::Nil)::Nil)
-        val f3 = Function(f, Function(h, b::Nil)::Function(g, c::b::Nil)::Nil)
+        val f1 = Function( f, Function( h, a :: Nil ) :: Function( g, c :: a :: Nil ) :: Nil )
+        val f2 = Function( f, Function( h, b :: Nil ) :: Function( g, c :: b :: Nil ) :: Nil )
+        val f3 = Function( f, Function( h, b :: Nil ) :: Function( g, c :: b :: Nil ) :: Nil )
 
-        val dec = deltaG.computeDelta(f1::f2::f3::Nil, "α")
+        val dec = deltaG.computeDelta( f1 :: f2 :: f3 :: Nil, "α" )
 
-        val alpha0 = FOLVar("α_0")
+        val alpha0 = FOLVar( "α_0" )
 
-        val uTarget = Function(f, Function(h, alpha0::Nil)::Function(g, c::alpha0::Nil)::Nil)
-        val s = Set(((a::b::b::Nil)::Nil).transpose: _*)
+        val uTarget = Function( f, Function( h, alpha0 :: Nil ) :: Function( g, c :: alpha0 :: Nil ) :: Nil )
+        val s = Set( ( ( a :: b :: b :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((uTarget, s.asInstanceOf[types.S])))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( uTarget, s.asInstanceOf[types.S] ) ) )
       }
     }
 
@@ -221,25 +221,25 @@ class GrammarTest extends SpecificationWithJUnit {
         val f = "f"
         val h = "h"
         val g = "g"
-        val c = FOLConst("c")
+        val c = FOLConst( "c" )
 
-        val gc = Function(g, c::Nil)
-        val ggc = Function( g, (Function(g, c::Nil))::Nil )
-        val hgc = Function( h, (Function(g, c::Nil))::Nil )
-        val hggc = Function(h, (Function(g, (Function(g, c::Nil))::Nil))::Nil)
+        val gc = Function( g, c :: Nil )
+        val ggc = Function( g, ( Function( g, c :: Nil ) ) :: Nil )
+        val hgc = Function( h, ( Function( g, c :: Nil ) ) :: Nil )
+        val hggc = Function( h, ( Function( g, ( Function( g, c :: Nil ) ) :: Nil ) ) :: Nil )
 
-        val f1 = Function(f, hggc::ggc::Nil)
-        val f2 = Function(f, hgc::gc::Nil)
+        val f1 = Function( f, hggc :: ggc :: Nil )
+        val f2 = Function( f, hgc :: gc :: Nil )
 
-        val alpha = FOLVar("α_0")
-        val galpha = Function(g, alpha::Nil)
-        val hgalpha = Function(h, galpha::Nil)
-        val common = Function(f, hgalpha::galpha::Nil)
+        val alpha = FOLVar( "α_0" )
+        val galpha = Function( g, alpha :: Nil )
+        val hgalpha = Function( h, galpha :: Nil )
+        val common = Function( f, hgalpha :: galpha :: Nil )
 
-        val dec = delta.computeDelta(f1::f2::Nil, "α")
-        val s = Set(((gc::c::Nil)::Nil).transpose: _*)
+        val dec = delta.computeDelta( f1 :: f2 :: Nil, "α" )
+        val s = Set( ( ( gc :: c :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((common, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( common, s ) ) )
       }
 
       "trivial decomposition" in {
@@ -249,24 +249,24 @@ class GrammarTest extends SpecificationWithJUnit {
         val f = "f"
         val h = "h"
         val g = "g"
-        val c = FOLConst("c")
-        val b = FOLConst("b")
-        val a = FOLConst("a")
+        val c = FOLConst( "c" )
+        val b = FOLConst( "b" )
+        val a = FOLConst( "a" )
 
-        val gb = Function(g, b::Nil)
-        val gga = Function( g, (Function(g, a::Nil))::Nil )
-        val hgc = Function( h, (Function(g, c::Nil))::Nil )
-        val hggc = Function(h, (Function(g, (Function(g, c::Nil))::Nil))::Nil)
+        val gb = Function( g, b :: Nil )
+        val gga = Function( g, ( Function( g, a :: Nil ) ) :: Nil )
+        val hgc = Function( h, ( Function( g, c :: Nil ) ) :: Nil )
+        val hggc = Function( h, ( Function( g, ( Function( g, c :: Nil ) ) :: Nil ) ) :: Nil )
 
-        val f1 = Function(f, hggc::gga::Nil)
-        val f2 = Function(f, hgc::gb::Nil)
+        val f1 = Function( f, hggc :: gga :: Nil )
+        val f2 = Function( f, hgc :: gb :: Nil )
 
-        val alpha = FOLVar("α_0")
+        val alpha = FOLVar( "α_0" )
 
-        val dec = delta.computeDelta(f1::f2::Nil, "α")
-        val s = Set(((f1::f2::Nil)::Nil).transpose: _*)
+        val dec = delta.computeDelta( f1 :: f2 :: Nil, "α" )
+        val s = Set( ( ( f1 :: f2 :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((alpha, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( alpha, s ) ) )
 
       }
 
@@ -277,26 +277,26 @@ class GrammarTest extends SpecificationWithJUnit {
         val f = "f"
         val h = "h"
         val g = "g"
-        val c = FOLConst("c")
-        val a = FOLConst("a")
+        val c = FOLConst( "c" )
+        val a = FOLConst( "a" )
 
-        val ga = Function(g, a::Nil)
-        val gc = Function(g, c::Nil)
-        val hgc = Function( h, (Function(g, c::Nil))::Nil )
-        val hggc = Function(h, (Function(g, (Function(g, c::Nil))::Nil))::Nil)
+        val ga = Function( g, a :: Nil )
+        val gc = Function( g, c :: Nil )
+        val hgc = Function( h, ( Function( g, c :: Nil ) ) :: Nil )
+        val hggc = Function( h, ( Function( g, ( Function( g, c :: Nil ) ) :: Nil ) ) :: Nil )
 
-        val f1 = Function(f, hggc::ga::Nil)
-        val f2 = Function(f, hgc::ga::Nil)
+        val f1 = Function( f, hggc :: ga :: Nil )
+        val f2 = Function( f, hgc :: ga :: Nil )
 
-        val alpha = FOLVar("α_0")
-        val galpha = Function(g, alpha::Nil)
-        val hgalpha = Function(h, galpha::Nil)
-        val common = Function(f, hgalpha::ga::Nil)
+        val alpha = FOLVar( "α_0" )
+        val galpha = Function( g, alpha :: Nil )
+        val hgalpha = Function( h, galpha :: Nil )
+        val common = Function( f, hgalpha :: ga :: Nil )
 
-        val dec = delta.computeDelta(f1::f2::Nil, "α")
-        val s = Set(((gc::c::Nil)::Nil).transpose: _*)
+        val dec = delta.computeDelta( f1 :: f2 :: Nil, "α" )
+        val s = Set( ( ( gc :: c :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((common, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( common, s ) ) )
 
       }
 
@@ -305,19 +305,19 @@ class GrammarTest extends SpecificationWithJUnit {
         val delta = new OneVariableDelta()
 
         val f = "f"
-        val a = FOLConst("a")
+        val a = FOLConst( "a" )
 
-        val fa = Function(f, a::Nil)
-        val f2a = Function(f, (Function(f, a::Nil))::Nil)
-        val f3a = Function(f, (Function(f, (Function(f, a::Nil))::Nil))::Nil)
+        val fa = Function( f, a :: Nil )
+        val f2a = Function( f, ( Function( f, a :: Nil ) ) :: Nil )
+        val f3a = Function( f, ( Function( f, ( Function( f, a :: Nil ) ) :: Nil ) ) :: Nil )
 
-        val alpha = FOLVar("α_0")
-        val falpha = Function(f, alpha::Nil)
+        val alpha = FOLVar( "α_0" )
+        val falpha = Function( f, alpha :: Nil )
 
-        val dec = delta.computeDelta(fa::f2a::f3a::Nil, "α")
-        val s = Set(((a::fa::f2a::Nil)::Nil).transpose: _*)
+        val dec = delta.computeDelta( fa :: f2a :: f3a :: Nil, "α" )
+        val s = Set( ( ( a :: fa :: f2a :: Nil ) :: Nil ).transpose: _* )
 
-        (dec) must beEqualTo (Set[Decomposition]((falpha, s)))
+        ( dec ) must beEqualTo( Set[Decomposition]( ( falpha, s ) ) )
       }
     }
 

--- a/src/test/scala/at/logic/algorithms/cutIntroduction/TreeGrammarDecompositionTest.scala
+++ b/src/test/scala/at/logic/algorithms/cutIntroduction/TreeGrammarDecompositionTest.scala
@@ -1,12 +1,11 @@
 package at.logic.algorithms.cutIntroduction
 
-import at.logic.language.fol.{FOLVar, Function, FOLConst, FOLTerm}
+import at.logic.language.fol.{ FOLVar, Function, FOLConst, FOLTerm }
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
 
   /**
@@ -16,9 +15,9 @@ class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
    * @param t base case term (default: FOLConst("0"))
    * @return
    */
-  def s(n:Int, t: FOLTerm=FOLConst("0")) : FOLTerm = n match {
+  def s( n: Int, t: FOLTerm = FOLConst( "0" ) ): FOLTerm = n match {
     case 0 => t
-    case i => Function("s", List(s(i-1, t)))
+    case i => Function( "s", List( s( i - 1, t ) ) )
   }
 
   /**
@@ -27,31 +26,31 @@ class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
    * with basecase t
    *
    */
-  def testln(n: Int, t: FOLTerm= FOLConst("0")) : List[FOLTerm] = {
-    List.range(0, n).map(x => s(x, t))
+  def testln( n: Int, t: FOLTerm = FOLConst( "0" ) ): List[FOLTerm] = {
+    List.range( 0, n ).map( x => s( x, t ) )
   }
 
-  val alpha1 = FOLVar("α_1")
-  val alpha2 = FOLVar("α_2")
+  val alpha1 = FOLVar( "α_1" )
+  val alpha2 = FOLVar( "α_2" )
 
   "TreeGrammarDecompositionPWM" should {
 
     "compute correctly the sufficient set of keys of testln(8) where n=1" in {
-      val decomp = new TreeGrammarDecompositionPWM(testln(8), 1)
+      val decomp = new TreeGrammarDecompositionPWM( testln( 8 ), 1 )
       decomp.suffKeys()
 
-      val expected = testln(7, alpha1)
+      val expected = testln( 7, alpha1 )
 
-      decomp.keyList.toSet should beEqualTo(expected.toSet)
+      decomp.keyList.toSet should beEqualTo( expected.toSet )
     }
 
     "compute correctly the sufficient set of keys of testln(8) where n=2" in {
-      val decomp = new TreeGrammarDecompositionPWM(testln(8), 2)
+      val decomp = new TreeGrammarDecompositionPWM( testln( 8 ), 2 )
       decomp.suffKeys()
 
-      val expected = testln(7, alpha1) ++ testln(6, alpha2)
+      val expected = testln( 7, alpha1 ) ++ testln( 6, alpha2 )
 
-      decomp.keyList.toSet should beEqualTo(expected.toSet)
+      decomp.keyList.toSet should beEqualTo( expected.toSet )
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/diophantine/lankfordTest.scala
+++ b/src/test/scala/at/logic/algorithms/diophantine/lankfordTest.scala
@@ -4,91 +4,91 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LankfordSolverTest extends SpecificationWithJUnit {
   "The Lankford Diophantine solver" should {
     "handle vectors correctly" in {
-      val v1: Vector = Vector(-1, 0, 1, 0, 0, 2)
-      val v2: Vector = Vector(1, 1, 1, 2, 1, 0)
-      val v3: Vector = Vector(0, 0, 0, 0, 0, 0)
-      val v4: Vector = Vector(0, 1, 2, 2, 1, 2)
-      val v5: Vector = Vector(0, 0, 0, 0, 0, 1)
-      val v6: Vector = Vector(0, 0, 0, 0, 1, 0)
+      val v1: Vector = Vector( -1, 0, 1, 0, 0, 2 )
+      val v2: Vector = Vector( 1, 1, 1, 2, 1, 0 )
+      val v3: Vector = Vector( 0, 0, 0, 0, 0, 0 )
+      val v4: Vector = Vector( 0, 1, 2, 2, 1, 2 )
+      val v5: Vector = Vector( 0, 0, 0, 0, 0, 1 )
+      val v6: Vector = Vector( 0, 0, 0, 0, 1, 0 )
 
       //        println (v1-v1)
       //        println (v1+v2)
       //        println (v1+v3)
       //        println (v1-v3)
 
-      (v1 - v1) must beEqualTo(v3)
-      (v1 + v2) must beEqualTo(v4)
-      (v1 + v3) must beEqualTo(v1)
-      (v1 - v3) must beEqualTo(v1)
+      ( v1 - v1 ) must beEqualTo( v3 )
+      ( v1 + v2 ) must beEqualTo( v4 )
+      ( v1 + v3 ) must beEqualTo( v1 )
+      ( v1 - v3 ) must beEqualTo( v1 )
     }
 
     "new solve the equation x_1 + x_2 = y_1 + y_2" in {
-      val lhs = Vector(1, 1)
-      val rhs = Vector(1, 1)
+      val lhs = Vector( 1, 1 )
+      val rhs = Vector( 1, 1 )
 
       val expected_result = List(
-        Vector(1, 0, 1, 0),
-        Vector(1, 0, 0, 1),
-        Vector(0, 1, 1, 0),
-        Vector(0, 1, 0, 1))
+        Vector( 1, 0, 1, 0 ),
+        Vector( 1, 0, 0, 1 ),
+        Vector( 0, 1, 1, 0 ),
+        Vector( 0, 1, 0, 1 ) )
 
-      val r = LankfordSolver solve (lhs, rhs)
+      val r = LankfordSolver solve ( lhs, rhs )
 
-      (r) must contain (exactly (expected_result:_*)) 
+      ( r ) must contain( exactly( expected_result: _* ) )
     }
 
     "new solve the equation x_1 + x_2 = y_1 + y_2 + y_3" in {
-      val lhs = Vector(1, 1)
-      val rhs = Vector(1, 1, 1)
+      val lhs = Vector( 1, 1 )
+      val rhs = Vector( 1, 1, 1 )
 
       val expected_result = List(
-        Vector(1, 0, 1, 0, 0),
-        Vector(1, 0, 0, 1, 0),
-        Vector(1, 0, 0, 0, 1),
-        Vector(0, 1, 1, 0, 0),
-        Vector(0, 1, 0, 1, 0),
-        Vector(0, 1, 0, 0, 1))
+        Vector( 1, 0, 1, 0, 0 ),
+        Vector( 1, 0, 0, 1, 0 ),
+        Vector( 1, 0, 0, 0, 1 ),
+        Vector( 0, 1, 1, 0, 0 ),
+        Vector( 0, 1, 0, 1, 0 ),
+        Vector( 0, 1, 0, 0, 1 ) )
 
-      val r = LankfordSolver solve (lhs, rhs)
-      (r) must contain (exactly (expected_result:_*))
+      val r = LankfordSolver solve ( lhs, rhs )
+      ( r ) must contain( exactly( expected_result: _* ) )
     }
 
     "new solve the equation 2x_1 + x_2 +x_3= 2y_1 + y_2" in {
-      val lhs = Vector(2, 1, 1)
-      val rhs = Vector(2, 1)
+      val lhs = Vector( 2, 1, 1 )
+      val rhs = Vector( 2, 1 )
 
       val expected_result = List(
-        Vector(1, 0, 0, 1, 0),
-        Vector(0, 1, 0, 0, 1),
-        Vector(0, 0, 1, 0, 1),
-        Vector(1, 0, 0, 0, 2),
-        Vector(0, 2, 0, 1, 0),
-        Vector(0, 1, 1, 1, 0),
-        Vector(0, 0, 2, 1, 0))
+        Vector( 1, 0, 0, 1, 0 ),
+        Vector( 0, 1, 0, 0, 1 ),
+        Vector( 0, 0, 1, 0, 1 ),
+        Vector( 1, 0, 0, 0, 2 ),
+        Vector( 0, 2, 0, 1, 0 ),
+        Vector( 0, 1, 1, 1, 0 ),
+        Vector( 0, 0, 2, 1, 0 ) )
 
-      val r = LankfordSolver solve (lhs, rhs)
+      val r = LankfordSolver solve ( lhs, rhs )
       //      println("===")
       //      println(r)
       //      println("===")
       //      println(expected_result)
 
-      (r) must contain (exactly (expected_result:_*))
+      ( r ) must contain( exactly( expected_result: _* ) )
     }
 
     "new solve the equation x_1 = y_1 + y_2" in {
-      val lhs = Vector(1)
-      val rhs = Vector(1, 1)
+      val lhs = Vector( 1 )
+      val rhs = Vector( 1, 1 )
 
       val expected_result = List(
-        Vector(1, 1, 0),
-        Vector(1, 0, 1))
+        Vector( 1, 1, 0 ),
+        Vector( 1, 0, 1 ) )
 
-      val r = LankfordSolver solve (lhs, rhs)
-      (r) must contain (exactly (expected_result:_*))    
+      val r = LankfordSolver solve ( lhs, rhs )
+      ( r ) must contain( exactly( expected_result: _* ) )
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/expansionTrees/compressTest.scala
+++ b/src/test/scala/at/logic/algorithms/expansionTrees/compressTest.scala
@@ -1,7 +1,7 @@
 package at.logic.algorithms.expansionTrees
 
-import at.logic.language.hol.{Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _}
-import at.logic.language.lambda.types.{Ti => i, To => o, ->}
+import at.logic.language.hol.{ Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _ }
+import at.logic.language.lambda.types.{ Ti => i, To => o, -> }
 import at.logic.calculi.expansionTrees._
 import at.logic.calculi.lk.base.FSequent
 import at.logic.algorithms.expansionTrees._
@@ -10,34 +10,29 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class compressTest extends SpecificationWithJUnit {
 
-  val x = HOLVar(("x" ), i)
-  val c = HOLConst(("c" ), i)
-  val d = HOLConst(("d" ), i)
-  val P = HOLConst("P", i -> o)
-  
+  val x = HOLVar( ( "x" ), i )
+  val c = HOLConst( ( "c" ), i )
+  val d = HOLConst( ( "d" ), i )
+  val P = HOLConst( "P", i -> o )
+
   val et1: ExpansionTree = merge(
     WeakQuantifier(
-      AllVar(x, AtomHOL(P,x::Nil)),
-      List((Atom(AtomHOL(P,c::Nil)),c),(Atom(AtomHOL(P,d::Nil)),d))
-      )
-  )
+      AllVar( x, AtomHOL( P, x :: Nil ) ),
+      List( ( Atom( AtomHOL( P, c :: Nil ) ), c ), ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) )
 
   val et2: ExpansionTree = merge(
     WeakQuantifier(
-      ExVar(x, AtomHOL(P, x::Nil)),
-      List((Atom(AtomHOL(P, c::Nil)),c),(Atom(AtomHOL(P,d::Nil)),d))
-     )
-  )
-  
-  val eSeq = ExpansionSequent(List(et1), List(et2))
+      ExVar( x, AtomHOL( P, x :: Nil ) ),
+      List( ( Atom( AtomHOL( P, c :: Nil ) ), c ), ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) )
 
-  val meSeq = compressQuantifiers(eSeq)
-  val eSeq2 = decompressQuantifiers(meSeq)
-  
+  val eSeq = ExpansionSequent( List( et1 ), List( et2 ) )
+
+  val meSeq = compressQuantifiers( eSeq )
+  val eSeq2 = decompressQuantifiers( meSeq )
+
   "Expansion tree compression and decompression" should {
     "be computed correctly" in {
       eSeq2 mustEqual eSeq

--- a/src/test/scala/at/logic/algorithms/expansionTrees/minimalTest.scala
+++ b/src/test/scala/at/logic/algorithms/expansionTrees/minimalTest.scala
@@ -1,7 +1,7 @@
 package at.logic.algorithms.expansionTrees
 
-import at.logic.language.hol.{Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _}
-import at.logic.language.lambda.types.{Ti => i, To => o, ->}
+import at.logic.language.hol.{ Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _ }
+import at.logic.language.lambda.types.{ Ti => i, To => o, -> }
 import at.logic.calculi.expansionTrees._
 import at.logic.calculi.lk.base.FSequent
 import at.logic.algorithms.expansionTrees._
@@ -10,60 +10,47 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class minimalExpansionSequentTest extends SpecificationWithJUnit {
 
-  val x = HOLVar(("x" ), i)
-  val c = HOLConst(("c" ), i)
-  val d = HOLConst(("d" ), i)
-  val P = HOLConst("P", i -> o)
-  
+  val x = HOLVar( ( "x" ), i )
+  val c = HOLConst( ( "c" ), i )
+  val d = HOLConst( ( "d" ), i )
+  val P = HOLConst( "P", i -> o )
+
   val et1: ExpansionTree = merge(
     WeakQuantifier(
-      AllVar(x, AtomHOL(P,x::Nil)),
-      List((Atom(AtomHOL(P,c::Nil)),c),(Atom(AtomHOL(P,d::Nil)),d))
-      )
-  )
+      AllVar( x, AtomHOL( P, x :: Nil ) ),
+      List( ( Atom( AtomHOL( P, c :: Nil ) ), c ), ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) )
 
   val et2: ExpansionTree = merge(
     WeakQuantifier(
-      ExVar(x, AtomHOL(P, x::Nil)),
-      List((Atom(AtomHOL(P, c::Nil)),c),(Atom(AtomHOL(P,d::Nil)),d))
-     )
-  )
-  
-  val eSeq = compressQuantifiers(ExpansionSequent(List(et1), List(et2)))
-  
+      ExVar( x, AtomHOL( P, x :: Nil ) ),
+      List( ( Atom( AtomHOL( P, c :: Nil ) ), c ), ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) )
+
+  val eSeq = compressQuantifiers( ExpansionSequent( List( et1 ), List( et2 ) ) )
+
   val minESeq = List(
-    ExpansionSequent(List(merge(
-    WeakQuantifier(
-      AllVar(x, AtomHOL(P,x::Nil)),
-      List((Atom(AtomHOL(P,c::Nil)),c))
-    )
-  )), List(merge(
-    WeakQuantifier(
-      ExVar(x, AtomHOL(P, x::Nil)),
-      List((Atom(AtomHOL(P, c::Nil)),c))
-    )
-  ))),
-    ExpansionSequent(List(merge(
-    WeakQuantifier(
-      AllVar(x, AtomHOL(P,x::Nil)),
-      List((Atom(AtomHOL(P,d::Nil)),d))
-    )
-  )), List(merge(
-    WeakQuantifier(
-      ExVar(x, AtomHOL(P, x::Nil)),
-      List((Atom(AtomHOL(P, d::Nil)),d))
-    )
-  )))
-  ).map(compressQuantifiers.apply)
-  
-  args(skipAll = !(new MiniSATProver).isInstalled())
+    ExpansionSequent( List( merge(
+      WeakQuantifier(
+        AllVar( x, AtomHOL( P, x :: Nil ) ),
+        List( ( Atom( AtomHOL( P, c :: Nil ) ), c ) ) ) ) ), List( merge(
+      WeakQuantifier(
+        ExVar( x, AtomHOL( P, x :: Nil ) ),
+        List( ( Atom( AtomHOL( P, c :: Nil ) ), c ) ) ) ) ) ),
+    ExpansionSequent( List( merge(
+      WeakQuantifier(
+        AllVar( x, AtomHOL( P, x :: Nil ) ),
+        List( ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) ) ), List( merge(
+      WeakQuantifier(
+        ExVar( x, AtomHOL( P, x :: Nil ) ),
+        List( ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) ) ) ) ).map( compressQuantifiers.apply )
+
+  args( skipAll = !( new MiniSATProver ).isInstalled() )
 
   "Minimal expansion trees" should {
     "be computed correctly by the smart algorithm" in {
-      minESeq mustEqual minimalExpansionSequents(eSeq, new MiniSATProver)
+      minESeq mustEqual minimalExpansionSequents( eSeq, new MiniSATProver )
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/fol/fol2holTest.scala
+++ b/src/test/scala/at/logic/algorithms/fol/fol2holTest.scala
@@ -6,39 +6,38 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.fol
 import at.logic.language.hol
-import at.logic.language.lambda.types.{To, Ti}
-import at.logic.language.hol.{HOLConst, HOLFactory}
+import at.logic.language.lambda.types.{ To, Ti }
+import at.logic.language.hol.{ HOLConst, HOLFactory }
 
 /**
  * Created by marty on 3/10/14.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class fol2holTest extends SpecificationWithJUnit {
   "Conversion from fol to hol" should {
     "work for some simple terms" in {
-      val fterm = fol.Function("f", List(
-                    fol.FOLConst("q1"),
-                    fol.FOLVar("x")))
-      val hterm = fol2hol(fterm)
-      hterm must beEqualTo(fterm)
-      hterm.factory must beEqualTo(hol.HOLFactory)
+      val fterm = fol.Function( "f", List(
+        fol.FOLConst( "q1" ),
+        fol.FOLVar( "x" ) ) )
+      val hterm = fol2hol( fterm )
+      hterm must beEqualTo( fterm )
+      hterm.factory must beEqualTo( hol.HOLFactory )
 
-      val rterm = recreateWithFactory(fterm, hol.HOLFactory)
-      rterm must beEqualTo(fterm)
-      rterm.factory must beEqualTo(hol.HOLFactory)
+      val rterm = recreateWithFactory( fterm, hol.HOLFactory )
+      rterm must beEqualTo( fterm )
+      rterm.factory must beEqualTo( hol.HOLFactory )
     }
 
     "allow substitution of a fol term into a hol term" in {
-      val p = hol.HOLConst("P", Ti -> ((Ti -> Ti) -> To))
-      val x = hol.HOLVar("x", Ti)
-      val y = hol.HOLVar("y", Ti)
+      val p = hol.HOLConst( "P", Ti -> ( ( Ti -> Ti ) -> To ) )
+      val x = hol.HOLVar( "x", Ti )
+      val y = hol.HOLVar( "y", Ti )
 
-      val hterm = hol.Atom(HOLConst("P", Ti -> ((Ti -> Ti) -> To)),List(y, hol.HOLAbs(x,x)))
+      val hterm = hol.Atom( HOLConst( "P", Ti -> ( ( Ti -> Ti ) -> To ) ), List( y, hol.HOLAbs( x, x ) ) )
 
-      val fterm = fol.FOLConst("c")
+      val fterm = fol.FOLConst( "c" )
 
-      val fsub = hol.Substitution(fol.FOLVar("y"), fterm)
-
+      val fsub = hol.Substitution( fol.FOLVar( "y" ), fterm )
 
       /*TODO: Martin expected this to fail, but it doesn't (app takes the factory of the first parameter, which is fol
         after the substitution, so the lambda x.x should be created by the fol factory and fail).

--- a/src/test/scala/at/logic/algorithms/fol/hol2folTest.scala
+++ b/src/test/scala/at/logic/algorithms/fol/hol2folTest.scala
@@ -10,7 +10,7 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.fol
 import at.logic.language.fol._
-import at.logic.language.hol.{Neg => HOLNeg, And => HOLAnd, Or => HOLOr, Imp => HOLImp, Function => HOLFunction, Atom => HOLAtom, ExVar => HOLExVar, AllVar => HOLAllVar, HOLApp, HOLVar, HOLConst, HOLExpression}
+import at.logic.language.hol.{ Neg => HOLNeg, And => HOLAnd, Or => HOLOr, Imp => HOLImp, Function => HOLFunction, Atom => HOLAtom, ExVar => HOLExVar, AllVar => HOLAllVar, HOLApp, HOLVar, HOLConst, HOLExpression }
 import at.logic.language.lambda.types._
 
 import scala.collection.mutable
@@ -19,97 +19,97 @@ import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.language.hol.logicSymbols.ImpSymbol
 import at.logic.algorithms.fol.fol2hol
 import at.logic.language.lambda.LambdaExpression
-import at.logic.parsing.language.simple.{SimpleFOLParser, SimpleHOLParser}
+import at.logic.parsing.language.simple.{ SimpleFOLParser, SimpleHOLParser }
 import at.logic.parsing.readers.StringReader
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class hol2folTest extends SpecificationWithJUnit {
   def imap = Map[HOLExpression, StringSymbol]() // the scope for most tests is just the term itself
-  def iid = new {var idd = 0; def nextId = {idd = idd+1; idd}}
+  def iid = new { var idd = 0; def nextId = { idd = idd + 1; idd } }
 
-  private class MyParserHOL(input: String) extends StringReader(input) with SimpleHOLParser
-  private class MyParserFOL(input: String) extends StringReader(input) with SimpleFOLParser
+  private class MyParserHOL( input: String ) extends StringReader( input ) with SimpleHOLParser
+  private class MyParserFOL( input: String ) extends StringReader( input ) with SimpleFOLParser
 
   "HOL terms" should {
-    val hx = HOLVar("x", Ti -> Ti)
-    val ha = HOLConst("a", To -> Ti)
-    val hb = HOLConst("b", To -> Ti)
-    val fx = FOLVar("x")
-    val fa = FOLConst("a")
-    val fb = FOLConst("b")
+    val hx = HOLVar( "x", Ti -> Ti )
+    val ha = HOLConst( "a", To -> Ti )
+    val hb = HOLConst( "b", To -> Ti )
+    val fx = FOLVar( "x" )
+    val fa = FOLConst( "a" )
+    val fb = FOLConst( "b" )
     //TODO: fix the tests
     "be correctly reduced into FOL terms for" in {
       "Atom - A(x:(i->i), a:o->i)" in {
-        val hol = HOLAtom(HOLConst("A", (Ti -> Ti) -> ((To -> Ti) -> To)), hx::ha::Nil)
-        val fol = Atom("A", fx::fa::Nil)
-        reduceHolToFol(hol) must beEqualTo (fol)
-        convertHolToFol(new MyParserHOL("A(x:i, a:i)").getTerm()) must beEqualTo (new MyParserFOL("A(x, a)").getTerm())
+        val hol = HOLAtom( HOLConst( "A", ( Ti -> Ti ) -> ( ( To -> Ti ) -> To ) ), hx :: ha :: Nil )
+        val fol = Atom( "A", fx :: fa :: Nil )
+        reduceHolToFol( hol ) must beEqualTo( fol )
+        convertHolToFol( new MyParserHOL( "A(x:i, a:i)" ).getTerm() ) must beEqualTo( new MyParserFOL( "A(x, a)" ).getTerm() )
       }
       "Function - f(x:(i->i), a:(o->i)):(o->o)" in {
-        val hol = HOLFunction(HOLConst("f", (Ti -> Ti) -> ((To -> Ti) -> (To -> To))), hx::ha::Nil)
-        val fol = Function("f", fx::fa::Nil)
-        reduceHolToFol(hol) must beEqualTo (fol)
-        convertHolToFol.convertTerm(new MyParserHOL("f(x:i, a:i):i").getTerm()) must beEqualTo (new MyParserFOL("f(x, a)").getTerm())
+        val hol = HOLFunction( HOLConst( "f", ( Ti -> Ti ) -> ( ( To -> Ti ) -> ( To -> To ) ) ), hx :: ha :: Nil )
+        val fol = Function( "f", fx :: fa :: Nil )
+        reduceHolToFol( hol ) must beEqualTo( fol )
+        convertHolToFol.convertTerm( new MyParserHOL( "f(x:i, a:i):i" ).getTerm() ) must beEqualTo( new MyParserFOL( "f(x, a)" ).getTerm() )
       }
       "Connective - And A(x:(i->i), a:(o->i)) B(x:(i->i), b:(o->i))" in {
-        val hA = HOLAtom(HOLConst("A", (Ti -> Ti) -> ((To -> Ti) -> To)), hx::ha::Nil)
-        val hB = HOLAtom(HOLConst("B", (Ti -> Ti) -> ((To -> Ti) -> To)), hx::hb::Nil)
-        val hol = HOLAnd(hA, hB)
-        val fA = Atom("A", fx::fa::Nil)
-        val fB = Atom("B", fx::fb::Nil)
-        val fol = And(fA, fB)
-        reduceHolToFol(hol) must beEqualTo (fol)
-        convertHolToFol(new MyParserHOL("And A(x:i, a:i) B(x:i, b:i)").getTerm()) must beEqualTo (new MyParserFOL("And A(x, a) B(x, b)").getTerm())
+        val hA = HOLAtom( HOLConst( "A", ( Ti -> Ti ) -> ( ( To -> Ti ) -> To ) ), hx :: ha :: Nil )
+        val hB = HOLAtom( HOLConst( "B", ( Ti -> Ti ) -> ( ( To -> Ti ) -> To ) ), hx :: hb :: Nil )
+        val hol = HOLAnd( hA, hB )
+        val fA = Atom( "A", fx :: fa :: Nil )
+        val fB = Atom( "B", fx :: fb :: Nil )
+        val fol = And( fA, fB )
+        reduceHolToFol( hol ) must beEqualTo( fol )
+        convertHolToFol( new MyParserHOL( "And A(x:i, a:i) B(x:i, b:i)" ).getTerm() ) must beEqualTo( new MyParserFOL( "And A(x, a) B(x, b)" ).getTerm() )
       }
       "Abstraction - f(Abs x:(i->i) A(x:(i->i), a:(o->i))):(o->o)" in {
-        val holf = new MyParserHOL("f(Abs x:(i->i) A(x:(i->i), a:(o->i))):(o->o)").getTerm()
-        val folf = new MyParserFOL("f(q_{1})").getTerm()
-        reduceHolToFol(holf) must beEqualTo (folf)
+        val holf = new MyParserHOL( "f(Abs x:(i->i) A(x:(i->i), a:(o->i))):(o->o)" ).getTerm()
+        val folf = new MyParserFOL( "f(q_{1})" ).getTerm()
+        reduceHolToFol( holf ) must beEqualTo( folf )
       }
       "Abstraction - f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o)" in {
-        val red = reduceHolToFol(new MyParserHOL("f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o)").getTerm())
-        val fol = (new MyParserFOL("f(q_{1}(y))").getTerm())
-        red must beEqualTo (fol)
+        val red = reduceHolToFol( new MyParserHOL( "f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o)" ).getTerm() )
+        val fol = ( new MyParserFOL( "f(q_{1}(y))" ).getTerm() )
+        red must beEqualTo( fol )
       }
 
       //TODO: check if this test case is really what we want
       "Two terms - f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o) and g(Abs x:(i->i) A(x:(i->i), z:(o->i))):(o->o)" in {
         var id = iid // create new id function
-        val (f1,scope1) = reduceHolToFol(new MyParserHOL("f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o)").getTerm(),imap,id)
-        val (f2,scope2) = reduceHolToFol(new MyParserHOL("g(Abs x:(i->i) A(x:(i->i), z:(o->i))):(o->o)").getTerm(),scope1,id)
+        val ( f1, scope1 ) = reduceHolToFol( new MyParserHOL( "f(Abs x:(i->i) A(x:(i->i), y:(o->i))):(o->o)" ).getTerm(), imap, id )
+        val ( f2, scope2 ) = reduceHolToFol( new MyParserHOL( "g(Abs x:(i->i) A(x:(i->i), z:(o->i))):(o->o)" ).getTerm(), scope1, id )
 
-        List(f1,f2) must beEqualTo(
-        List(new MyParserFOL("f(q_{1}(y))").getTerm(), new MyParserFOL("g(q_{1}(z))").getTerm()))
+        List( f1, f2 ) must beEqualTo(
+          List( new MyParserFOL( "f(q_{1}(y))" ).getTerm(), new MyParserFOL( "g(q_{1}(z))" ).getTerm() ) )
       }
 
       "Correctly convert from type o to i on the termlevel" in {
-        val List(sp,sq) = List("P","Q")
-        val List(x,y) = List("x","y").map(x => HOLAtom(HOLVar(x,To), List()))
-        val f1 = HOLAtom(HOLConst(sp, To -> To),List(HOLImp(x,y)))
-        val f2 = fol.Atom(sp, List(fol.Function(ImpSymbol.toString,
-          List(fol.FOLVar("x"),
-               fol.FOLVar("y")))))
+        val List( sp, sq ) = List( "P", "Q" )
+        val List( x, y ) = List( "x", "y" ).map( x => HOLAtom( HOLVar( x, To ), List() ) )
+        val f1 = HOLAtom( HOLConst( sp, To -> To ), List( HOLImp( x, y ) ) )
+        val f2 = fol.Atom( sp, List( fol.Function( ImpSymbol.toString,
+          List( fol.FOLVar( "x" ),
+            fol.FOLVar( "y" ) ) ) ) )
 
-        val red = reduceHolToFol(f1)
-        red must beEqualTo(f2)
+        val red = reduceHolToFol( f1 )
+        red must beEqualTo( f2 )
       }
     }
   }
 
   "Type replacement" should {
     "work for simple terms" in {
-      skipped("TODO: fix this!")
-      val fterm1 = fol.Function("f", List(
-        fol.FOLConst("q_1"),
-        fol.FOLConst("c")))
+      skipped( "TODO: fix this!" )
+      val fterm1 = fol.Function( "f", List(
+        fol.FOLConst( "q_1" ),
+        fol.FOLConst( "c" ) ) )
 
-      val fterm2 = fol.AllVar(fol.FOLVar("x"),
-                              fol.Atom("P",
-                                       List(fol.FOLVar("q_1"),
-                                            fol.FOLConst("q_1")) ))
+      val fterm2 = fol.AllVar( fol.FOLVar( "x" ),
+        fol.Atom( "P",
+          List( fol.FOLVar( "q_1" ),
+            fol.FOLConst( "q_1" ) ) ) )
 
-      val hterm1 = changeTypeIn(fol2hol(fterm1), Map[String, TA](("q_1", Ti->Ti) ))
-      val hterm2 = changeTypeIn(fol2hol(fterm2), Map[String, TA](("q_1", Ti->Ti) ))
+      val hterm1 = changeTypeIn( fol2hol( fterm1 ), Map[String, TA]( ( "q_1", Ti -> Ti ) ) )
+      val hterm2 = changeTypeIn( fol2hol( fterm2 ), Map[String, TA]( ( "q_1", Ti -> Ti ) ) )
       ok
     }
   }

--- a/src/test/scala/at/logic/algorithms/hlk/HOLParserHLKTest.scala
+++ b/src/test/scala/at/logic/algorithms/hlk/HOLParserHLKTest.scala
@@ -8,8 +8,8 @@ import org.specs2.execute.Success
 /**
  * Test files for the hol parser
  */
-@RunWith(classOf[JUnitRunner])
-class HOLParserTest  extends SpecificationWithJUnit {
+@RunWith( classOf[JUnitRunner] )
+class HOLParserTest extends SpecificationWithJUnit {
   "HLK HOL Parser" should {
     "Parse atoms" in {
       /*

--- a/src/test/scala/at/logic/algorithms/hlk/HybridLatexParserTest.scala
+++ b/src/test/scala/at/logic/algorithms/hlk/HybridLatexParserTest.scala
@@ -5,16 +5,15 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.execute.Success
-import at.logic.parsing.language.hlk.{HOLASTParser, HLKHOLParser, ast}
+import at.logic.parsing.language.hlk.{ HOLASTParser, HLKHOLParser, ast }
 import at.logic.parsing.language.hlk.ast.LambdaAST
 import java.io.File.separator
-import at.logic.language.lambda.types.{To, Ti, TA}
+import at.logic.language.lambda.types.{ To, Ti, TA }
 import at.logic.language.hol._
 import at.logic.calculi.lk.base.FSequent
 import at.logic.language.lambda.types.Ti
 import at.logic.language.lambda.types.To
 import at.logic.language.lambda.App
-
 
 /**
  * Created with IntelliJ IDEA.
@@ -23,7 +22,7 @@ import at.logic.language.lambda.App
  * Time: 3:02 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class HybridLatexParserTest extends SpecificationWithJUnit with ClasspathFileCopier {
   val p1 =
     """\AX{T,MON(h_1,\alpha)}{MON(h_1,\alpha) }
@@ -40,149 +39,146 @@ class HybridLatexParserTest extends SpecificationWithJUnit with ClasspathFileCop
       |\CONTINUEWITH{\rho(\sigma)}
       |""".stripMargin
 
-  def checkformula(f:String) = {
-    HybridLatexParser.parseAll(HybridLatexParser.formula,f) match {
-      case HybridLatexParser.Success(r,_) =>
-        ok(r.toString)
-      case HybridLatexParser.NoSuccess(msg, input) =>
-        ko("Error at "+input.pos+": "+msg)
+  def checkformula( f: String ) = {
+    HybridLatexParser.parseAll( HybridLatexParser.formula, f ) match {
+      case HybridLatexParser.Success( r, _ ) =>
+        ok( r.toString )
+      case HybridLatexParser.NoSuccess( msg, input ) =>
+        ko( "Error at " + input.pos + ": " + msg )
     }
   }
 
-
   "Hybrid Latex-GAPT" should {
     "correctly handle latex macros in formulas (1)" in {
-      checkformula("\\benc{j_1<n+1}")
+      checkformula( "\\benc{j_1<n+1}" )
       ok
     }
 
     "correctly handle latex macros in formulas (2)" in {
-      checkformula("\\ite{\\benc{j_1<n+1}}{h'(j_1)}{\\alpha}")
+      checkformula( "\\ite{\\benc{j_1<n+1}}{h'(j_1)}{\\alpha}" )
       ok
     }
 
     "correctly handle latex macros in formulas (3)" in {
-      checkformula("\\ite{\\ienc{j_1<n+1}}{h'(j_1)}{\\alpha}")
+      checkformula( "\\ite{\\ienc{j_1<n+1}}{h'(j_1)}{\\alpha}" )
       ok
     }
 
     "correctly handle latex macros in formulas (4)" in {
-      checkformula("\\ite{\\benc{j_1<n+1}}{h'(j_1)}{\\alpha} = 0")
+      checkformula( "\\ite{\\benc{j_1<n+1}}{h'(j_1)}{\\alpha} = 0" )
       ok
     }
 
     "accept the proof outline" in {
       //println(p1)
-      HybridLatexParser.parseAll(HybridLatexParser.rules, p1) match {
-        case HybridLatexParser.Success(r : List[Token] , _) =>
+      HybridLatexParser.parseAll( HybridLatexParser.rules, p1 ) match {
+        case HybridLatexParser.Success( r: List[Token], _ ) =>
           //println(r)
-          val lterms : List[LambdaAST] = r.flatMap(_ match {
-            case RToken(_,_,a, s,_) => a++s
-            case TToken(_,_,_) => Nil
-            case AToken(_,_,a,s) => a++s
-          })
-
+          val lterms: List[LambdaAST] = r.flatMap( _ match {
+            case RToken( _, _, a, s, _ ) => a ++ s
+            case TToken( _, _, _ )       => Nil
+            case AToken( _, _, a, s )    => a ++ s
+          } )
 
           //println(lterms.flatMap(_.varnames).toSet)
 
-          ok("successfully parsed "+r)
-        case HybridLatexParser.NoSuccess(msg, input) =>
-          ko("parsing error at "+input.pos +": "+msg)
+          ok( "successfully parsed " + r )
+        case HybridLatexParser.NoSuccess( msg, input ) =>
+          ko( "parsing error at " + input.pos + ": " + msg )
       }
       ok
     }
 
     "accept the proof outline with the parse interface" in {
-        val r = HybridLatexParser.parse(p1)
-        ok
+      val r = HybridLatexParser.parse( p1 )
+      ok
     }
 
     "correctly infer replacement terms in equalities" in {
-      import at.logic.calculi.lk.EquationVerifier.{Equal, Different, EqualModuloEquality, checkReplacement}
-      val List(a) = List("a") map (x => HOLConst(x, Ti))
-      val List(f,g) = List("f","g") map (x => HOLConst(x, Ti -> Ti))
-      val List(p) = List("p") map (x => HOLConst(x, Ti -> (Ti -> (Ti -> To)) ))
-      val t1 = App(p, List(App(f,a), App(f,App(g,App(f,a))), a  ))
-      val t2 = App(p, List(App(f,a), App(f,App(g,App(g,a))), a  ))
-      val fa = App(f,a)
-      val ga = App(g,a)
+      import at.logic.calculi.lk.EquationVerifier.{ Equal, Different, EqualModuloEquality, checkReplacement }
+      val List( a ) = List( "a" ) map ( x => HOLConst( x, Ti ) )
+      val List( f, g ) = List( "f", "g" ) map ( x => HOLConst( x, Ti -> Ti ) )
+      val List( p ) = List( "p" ) map ( x => HOLConst( x, Ti -> ( Ti -> ( Ti -> To ) ) ) )
+      val t1 = App( p, List( App( f, a ), App( f, App( g, App( f, a ) ) ), a ) )
+      val t2 = App( p, List( App( f, a ), App( f, App( g, App( g, a ) ) ), a ) )
+      val fa = App( f, a )
+      val ga = App( g, a )
 
-      checkReplacement(fa,ga,t1,t2) match {
-        case Equal => ko("Terms "+t1+" and "+t2+" considered as equal, but they differ!")
-        case Different => ko("Terms "+t1+" and t2 considered as (completely) different, but they differ only modulo one replacement!")
-        case EqualModuloEquality(path) =>
+      checkReplacement( fa, ga, t1, t2 ) match {
+        case Equal     => ko( "Terms " + t1 + " and " + t2 + " considered as equal, but they differ!" )
+        case Different => ko( "Terms " + t1 + " and t2 considered as (completely) different, but they differ only modulo one replacement!" )
+        case EqualModuloEquality( path ) =>
           //println("Path:"+path)
           ok
       }
 
-      checkReplacement(fa,ga,t1,t1) match {
-        case Equal => ok
-        case Different => ko("Terms "+t1+" and t2 considered as (completely) different, but they are equal!")
-        case EqualModuloEquality(path) => ko("Found an equality modulo "+Equation(fa.asInstanceOf[HOLExpression],ga.asInstanceOf[HOLExpression])+" but should be equal!")
+      checkReplacement( fa, ga, t1, t1 ) match {
+        case Equal                       => ok
+        case Different                   => ko( "Terms " + t1 + " and t2 considered as (completely) different, but they are equal!" )
+        case EqualModuloEquality( path ) => ko( "Found an equality modulo " + Equation( fa.asInstanceOf[HOLExpression], ga.asInstanceOf[HOLExpression] ) + " but should be equal!" )
       }
       ok
     }
 
-
     "load the simple example from file and parse it" in {
-        val r = HybridLatexParser.parseFile(tempCopyOfClasspathFile("simple.llk"))
-        val p = HybridLatexParser.createLKProof(r)
-        //println(p)
+      val r = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "simple.llk" ) )
+      val p = HybridLatexParser.createLKProof( r )
+      //println(p)
 
-        ok
+      ok
     }
 
-
     "load the commutativity of + proof from file and parse it" in {
-        val r = HybridLatexParser.parseFile(tempCopyOfClasspathFile("komm.llk"))
-        val p = HybridLatexParser.createLKProof(r)
-        (p.proof("THEPROOF")) must not throwAn() //exception
+      val r = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "komm.llk" ) )
+      val p = HybridLatexParser.createLKProof( r )
+      ( p.proof( "THEPROOF" ) ) must not throwAn () //exception
 
-        ok
+      ok
     }
 
     "load the 3-2 pigeon hole example from file and parse it" in {
-        val r = HybridLatexParser.parseFile(tempCopyOfClasspathFile("pigeon32.llk"))
-        val p = HybridLatexParser.createLKProof(r)
-        (p.proof("PROOF")) must not throwAn() //exception
+      val r = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "pigeon32.llk" ) )
+      val p = HybridLatexParser.createLKProof( r )
+      ( p.proof( "PROOF" ) ) must not throwAn () //exception
 
-        ok
+      ok
     }
 
     "load the tape3 proof from file" in {
-        val r = HybridLatexParser.parseFile(tempCopyOfClasspathFile("tape3.llk"))
-        val p = HybridLatexParser.createLKProof(r)
-        p.proofs.length must be_>(0)
-        p.Definitions.toList.length must be_>(0)
-        p.axioms.length must be_>(0)
-        ok
+      val r = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "tape3.llk" ) )
+      val p = HybridLatexParser.createLKProof( r )
+      p.proofs.length must be_>( 0 )
+      p.Definitions.toList.length must be_>( 0 )
+      p.axioms.length must be_>( 0 )
+      ok
     }
-
 
   }
 
   "Tactics" should {
     "correctly prove the instance of an axiom" in {
-      val vmap = Map[String,TA]( "x" -> Ti, "y" -> Ti, "z" -> Ti)
-      val cmap = Map[String,TA]( "a" -> Ti, "1" -> Ti, "+" -> (Ti->(Ti->Ti)))
-      val naming : String => HOLExpression = x => { if (vmap contains x) HOLVar(x,vmap(x)) else
-                                                                       HOLConst(x,cmap(x)) }
-      val axiom =  HLKHOLParser.ASTtoHOL( naming, HybridLatexParser.parseFormula("(all x all y all z (x+(y+z)=(x+y)+z))"))
-      val instance = HLKHOLParser.ASTtoHOL( naming, HybridLatexParser.parseFormula("a+((1+x)+y)=(a+(1+x))+y"))
-      val t1 = Function(HOLConst("+",Ti -> (Ti -> Ti)),List(
-                          HOLConst("1", Ti),
-                          HOLVar("x",Ti)))
-      val t2 = HOLConst("a", Ti)
-      val x = HOLVar("x",Ti)
-      val y = HOLVar("y",Ti)
-      val z = HOLVar("z",Ti)
-      val sub = Substitution( List((x,t2), (y,t1), (z,y)) )
-      val p = HybridLatexParser.proveInstance(axiom.asInstanceOf[HOLFormula],instance.asInstanceOf[HOLFormula], sub)
-      p.root.occurrences must haveSize(2)
-      p.root.antecedent must haveSize(1)
-      p.root.succedent must haveSize(1)
-      p.root.antecedent(0).formula mustEqual(axiom)
-      p.root.succedent(0).formula mustEqual(instance)
+      val vmap = Map[String, TA]( "x" -> Ti, "y" -> Ti, "z" -> Ti )
+      val cmap = Map[String, TA]( "a" -> Ti, "1" -> Ti, "+" -> ( Ti -> ( Ti -> Ti ) ) )
+      val naming: String => HOLExpression = x => {
+        if ( vmap contains x ) HOLVar( x, vmap( x ) ) else
+          HOLConst( x, cmap( x ) )
+      }
+      val axiom = HLKHOLParser.ASTtoHOL( naming, HybridLatexParser.parseFormula( "(all x all y all z (x+(y+z)=(x+y)+z))" ) )
+      val instance = HLKHOLParser.ASTtoHOL( naming, HybridLatexParser.parseFormula( "a+((1+x)+y)=(a+(1+x))+y" ) )
+      val t1 = Function( HOLConst( "+", Ti -> ( Ti -> Ti ) ), List(
+        HOLConst( "1", Ti ),
+        HOLVar( "x", Ti ) ) )
+      val t2 = HOLConst( "a", Ti )
+      val x = HOLVar( "x", Ti )
+      val y = HOLVar( "y", Ti )
+      val z = HOLVar( "z", Ti )
+      val sub = Substitution( List( ( x, t2 ), ( y, t1 ), ( z, y ) ) )
+      val p = HybridLatexParser.proveInstance( axiom.asInstanceOf[HOLFormula], instance.asInstanceOf[HOLFormula], sub )
+      p.root.occurrences must haveSize( 2 )
+      p.root.antecedent must haveSize( 1 )
+      p.root.succedent must haveSize( 1 )
+      p.root.antecedent( 0 ).formula mustEqual ( axiom )
+      p.root.succedent( 0 ).formula mustEqual ( instance )
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/interpolation/interpolationTest.scala
+++ b/src/test/scala/at/logic/algorithms/interpolation/interpolationTest.scala
@@ -12,69 +12,69 @@ import at.logic.calculi.occurrences._
 import at.logic.calculi.lk.base._
 import at.logic.calculi.lk._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class interpolationTest extends SpecificationWithJUnit {
   "interpolation" should {
 
     "correctly interpolate an axiom with top" in {
-      val p = Atom(HOLConst("p", To))
-      val ax = Axiom( p::Nil, p::Nil )
+      val p = Atom( HOLConst( "p", To ) )
+      val ax = Axiom( p :: Nil, p :: Nil )
       val npart = Set[FormulaOccurrence]()
-      val ppart = Set( ax.root.antecedent(0), ax.root.succedent(0) )
+      val ppart = Set( ax.root.antecedent( 0 ), ax.root.succedent( 0 ) )
       val ( nproof, pproof, ipl ) = Interpolate( ax, npart, ppart )
 
       ipl must beEqualTo( TopC )
     }
 
     "correctly create an interpolating proof" in {
-      val p = Atom(HOLConst("p", To))
-      val ax = Axiom( p::Nil, p::Nil )
-      val npart = Set( ax.root.antecedent(0), ax.root.succedent(0) )
+      val p = Atom( HOLConst( "p", To ) )
+      val ax = Axiom( p :: Nil, p :: Nil )
+      val npart = Set( ax.root.antecedent( 0 ), ax.root.succedent( 0 ) )
       val ppart = Set[FormulaOccurrence]()
       val ( nproof, pproof, ipl ) = Interpolate( ax, npart, ppart )
 
       ipl must beEqualTo( BottomC )
-      nproof.root.toFSequent must beEqualTo ( FSequent( p::Nil, p::BottomC::Nil ) )
-      pproof.root.toFSequent must beEqualTo ( FSequent( BottomC::Nil, Nil ) )
+      nproof.root.toFSequent must beEqualTo( FSequent( p :: Nil, p :: BottomC :: Nil ) )
+      pproof.root.toFSequent must beEqualTo( FSequent( BottomC :: Nil, Nil ) )
     }
 
     "correctly interpolate a single unary inference with not p" in {
-      val p = Atom(HOLConst("p", To))
-      val q = Atom(HOLConst("q", To))
-      val ax = Axiom( p::Nil, p::Nil )
+      val p = Atom( HOLConst( "p", To ) )
+      val q = Atom( HOLConst( "q", To ) )
+      val ax = Axiom( p :: Nil, p :: Nil )
       val pr = OrRight1Rule( ax, p, q )
       val npart = Set( pr.root.succedent( 0 ) )
       val ppart = Set( pr.root.antecedent( 0 ) )
       val ( nproof, pproof, ipl ) = Interpolate( pr, npart, ppart )
 
       ipl must beEqualTo( Neg( p ) )
-      nproof.root.toFSequent must beEqualTo ( FSequent( Nil, Neg( p )::Or( p, q )::Nil ) )
-      pproof.root.toFSequent must beEqualTo ( FSequent( p::Neg( p )::Nil, Nil ) )
+      nproof.root.toFSequent must beEqualTo( FSequent( Nil, Neg( p ) :: Or( p, q ) :: Nil ) )
+      pproof.root.toFSequent must beEqualTo( FSequent( p :: Neg( p ) :: Nil, Nil ) )
     }
 
     "correctly interpolate a single binary inference with bot or q" in {
-      val p = Atom(HOLConst("p", To))
-      val q = Atom(HOLConst("q", To))
-      val axp = Axiom( p::Nil, p::Nil )
-      val axq = Axiom( q::Nil, q::Nil )
+      val p = Atom( HOLConst( "p", To ) )
+      val q = Atom( HOLConst( "q", To ) )
+      val axp = Axiom( p :: Nil, p :: Nil )
+      val axq = Axiom( q :: Nil, q :: Nil )
       val pr = OrLeftRule( axp, axq, p, q )
       val npart = Set( pr.root.antecedent( 0 ), pr.root.succedent( 0 ) )
       val ppart = Set( pr.root.succedent( 1 ) )
       val ( nproof, pproof, ipl ) = Interpolate( pr, npart, ppart )
 
       ipl must beEqualTo( Or( BottomC, q ) )
-      nproof.root.toFSequent must beEqualTo ( FSequent( Or( p, q )::Nil, p::Or( BottomC, q )::Nil ) )
-      pproof.root.toFSequent must beEqualTo ( FSequent( Or( BottomC, q )::Nil, q::Nil ) )
+      nproof.root.toFSequent must beEqualTo( FSequent( Or( p, q ) :: Nil, p :: Or( BottomC, q ) :: Nil ) )
+      pproof.root.toFSequent must beEqualTo( FSequent( Or( BottomC, q ) :: Nil, q :: Nil ) )
     }
 
     "correctly interpolate a small proof of 4 inference rules" in {
-      val p = Atom(HOLConst("p", To))
-      val q = Atom(HOLConst("q", To))
-      val r = Atom(HOLConst("r", To))
+      val p = Atom( HOLConst( "p", To ) )
+      val q = Atom( HOLConst( "q", To ) )
+      val r = Atom( HOLConst( "r", To ) )
 
-      val axp = Axiom( p::Nil, p::Nil )
-      val axq = Axiom( q::Nil, q::Nil )
-      val axr = Axiom( r::Nil, r::Nil )
+      val axp = Axiom( p :: Nil, p :: Nil )
+      val axq = Axiom( q :: Nil, q :: Nil )
+      val axr = Axiom( r :: Nil, r :: Nil )
       val p1 = NegLeftRule( axq, q )
       val p2 = OrLeftRule( p1, axr, q, r )
       val p3 = ImpRightRule( p2, Neg( q ), r )
@@ -85,10 +85,9 @@ class interpolationTest extends SpecificationWithJUnit {
       val ( nproof, pproof, ipl ) = Interpolate( p4, npart, ppart )
 
       ipl must beEqualTo( Or( BottomC, Or( q, r ) ) )
-      nproof.root.toFSequent must beEqualTo ( FSequent( p::Imp( p, Or( q, r ))::Nil, Or( BottomC, Or( q, r ) )::Nil ) )
-      pproof.root.toFSequent must beEqualTo ( FSequent( Or( BottomC, Or( q, r ) )::Nil, Imp( Neg( q ), r )::Nil ) )
+      nproof.root.toFSequent must beEqualTo( FSequent( p :: Imp( p, Or( q, r ) ) :: Nil, Or( BottomC, Or( q, r ) ) :: Nil ) )
+      pproof.root.toFSequent must beEqualTo( FSequent( Or( BottomC, Or( q, r ) ) :: Nil, Imp( Neg( q ), r ) :: Nil ) )
     }
-
 
   }
 }

--- a/src/test/scala/at/logic/algorithms/lk/CloneLKProofTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/CloneLKProofTest.scala
@@ -6,23 +6,22 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class CloneLKProofTest extends SpecificationWithJUnit {
   "withMap" should {
-    val List(a,b) = List("a","b") map (FOLConst(_))
-    val List(x,y) = List("x","y") map (FOLVar(_))
+    val List( a, b ) = List( "a", "b" ) map ( FOLConst( _ ) )
+    val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )
     val p = "P"
-    val pay = Atom(p, List(a,y))
-    val allxpax = ExVar(x,Atom(p, List(a,x)))
-    val ax = Axiom(List(pay), List(pay))
-    val i1 = ExistsRightRule(ax, ax.root.succedent(0), allxpax, y)
-    val i2 = ExistsLeftRule(i1, i1.root.antecedent(0), allxpax, y)
+    val pay = Atom( p, List( a, y ) )
+    val allxpax = ExVar( x, Atom( p, List( a, x ) ) )
+    val ax = Axiom( List( pay ), List( pay ) )
+    val i1 = ExistsRightRule( ax, ax.root.succedent( 0 ), allxpax, y )
+    val i2 = ExistsLeftRule( i1, i1.root.antecedent( 0 ), allxpax, y )
 
     "formula occurrences must fit together" in {
-      val (_, m) = CloneLKProof.withMap(i2)
+      val ( _, m ) = CloneLKProof.withMap( i2 )
 
-      m.forall(p => p._1 =^= p._2) must beTrue
+      m.forall( p => p._1 =^= p._2 ) must beTrue
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/lk/CutFormulaExtractionTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/CutFormulaExtractionTest.scala
@@ -6,40 +6,40 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
-import at.logic.calculi.lk.base.{BinaryLKProof, LKProof, Sequent}
-import at.logic.calculi.lk.{Axiom, CutRule}
+import at.logic.calculi.lk.base.{ BinaryLKProof, LKProof, Sequent }
+import at.logic.calculi.lk.{ Axiom, CutRule }
 import at.logic.calculi.occurrences.FormulaOccurrence
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class CutFormulaExtractionTest extends SpecificationWithJUnit {
   "Substitutions" should {
-    val x = HOLVar("x", Ti)
-    val P = HOLConst("P", Ti -> To)
-    val px = Atom(P, List(x))
-    val ax1 = Axiom( List(px), List(px) )
-    val ax2 = Axiom( List(px), List(px) )
+    val x = HOLVar( "x", Ti )
+    val P = HOLConst( "P", Ti -> To )
+    val px = Atom( P, List( x ) )
+    val ax1 = Axiom( List( px ), List( px ) )
+    val ax2 = Axiom( List( px ), List( px ) )
     val proof = CutRule( ax1, ax2, ax1.root.succedent.toList.head, ax2.root.antecedent.toList.head )
 
-    val ax1_ = Axiom( List(px), List(px) )
-    val ax2_ = Axiom( List(px), List(px) )
+    val ax1_ = Axiom( List( px ), List( px ) )
+    val ax2_ = Axiom( List( px ), List( px ) )
     val proof_ = CutRule( ax1_, ax2_, ax1_.root.succedent.toList.head, ax2_.root.antecedent.toList.head )
 
-    def toSequent(aux:FormulaOccurrence) = Sequent(Nil, List(aux))
+    def toSequent( aux: FormulaOccurrence ) = Sequent( Nil, List( aux ) )
 
     "apply correctly to a proof with one cut" in {
-      val cutproofs = getCutsAsProofs(proof)
-      val cutformulas = cutformulaExtraction(proof)
-      cutproofs must beEqualTo (List(proof))
+      val cutproofs = getCutsAsProofs( proof )
+      val cutformulas = cutformulaExtraction( proof )
+      cutproofs must beEqualTo( List( proof ) )
     }
 
     "apply correctly to a proof with three cuts" in {
-      val proof2 = CutRule(proof, proof_ , proof.root.succedent.head,  proof_.root.antecedent.head )
-      val prooflist : List[BinaryLKProof] = List(proof, proof_, proof2)
+      val proof2 = CutRule( proof, proof_, proof.root.succedent.head, proof_.root.antecedent.head )
+      val prooflist: List[BinaryLKProof] = List( proof, proof_, proof2 )
 
-      val cutproofs = getCutsAsProofs(proof2)
-      val cutformulas = cutformulaExtraction(proof2)
+      val cutproofs = getCutsAsProofs( proof2 )
+      val cutformulas = cutformulaExtraction( proof2 )
 
-      cutproofs must beEqualTo (prooflist)
+      cutproofs must beEqualTo( prooflist )
     }
 
   }

--- a/src/test/scala/at/logic/algorithms/lk/RegularizationTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/RegularizationTest.scala
@@ -7,19 +7,19 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
-import at.logic.calculi.lk.base.{Sequent, FSequent}
+import at.logic.calculi.lk.base.{ Sequent, FSequent }
 import at.logic.calculi.lk._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class RegularizationTest extends SpecificationWithJUnit {
   "Regularization" should {
     "apply correctly to a simple proof (1)" in {
-      val x = HOLVar("x", Ti)
-      val P = HOLConst("P", Ti -> To)
-      val px = Atom(P, x::Nil )
-      val s = FSequent( px::Nil, px::Nil )
-      val ax1 = Axiom( px::Nil, px::Nil )
-      val ax2 = Axiom( px::Nil, px::Nil )
+      val x = HOLVar( "x", Ti )
+      val P = HOLConst( "P", Ti -> To )
+      val px = Atom( P, x :: Nil )
+      val s = FSequent( px :: Nil, px :: Nil )
+      val ax1 = Axiom( px :: Nil, px :: Nil )
+      val ax2 = Axiom( px :: Nil, px :: Nil )
       val proof = CutRule( ax1, ax2, ax1.root.succedent.head, ax2.root.antecedent.head )
       val p_s = regularize( proof )
       val s2 = p_s.root.toFSequent
@@ -27,82 +27,82 @@ class RegularizationTest extends SpecificationWithJUnit {
     }
 
     "apply to a simple proof (2)" in {
-      skipped("Fix me. Should not depend so much on the names and the kind of renaming used")
-      val List(a,b,x,y) = List("a","b","x","y") map ((x:String) => HOLVar(x, Ti))
-      val List(k,l) = List("k","l") map ((x:String) => HOLConst(x, Ti))
-      val P = HOLConst("P", Ti -> (Ti -> (Ti -> To)))
-      val Pabk = Atom(P, List(a,b,k))
-      val exPayk = ExVar(y, Atom(P, List(a,y,k)))
-      val Q = HOLConst("Q", Ti -> (Ti -> (Ti -> (Ti -> To))))
-      val Pxyk = Atom(Q, List(x,y,k,l))
+      skipped( "Fix me. Should not depend so much on the names and the kind of renaming used" )
+      val List( a, b, x, y ) = List( "a", "b", "x", "y" ) map ( ( x: String ) => HOLVar( x, Ti ) )
+      val List( k, l ) = List( "k", "l" ) map ( ( x: String ) => HOLConst( x, Ti ) )
+      val P = HOLConst( "P", Ti -> ( Ti -> ( Ti -> To ) ) )
+      val Pabk = Atom( P, List( a, b, k ) )
+      val exPayk = ExVar( y, Atom( P, List( a, y, k ) ) )
+      val Q = HOLConst( "Q", Ti -> ( Ti -> ( Ti -> ( Ti -> To ) ) ) )
+      val Pxyk = Atom( Q, List( x, y, k, l ) )
 
-      val l1 = Axiom( Pabk::Nil, Pabk::Nil )
-      val l2 = ExistsRightRule(l1, l1.root.succedent(0), exPayk, b)
-      val l3 = ExistsLeftRule(l2, l2.root.antecedent(0), exPayk, b)
-      val l4 = WeakeningRightRule(l3, Pxyk)
+      val l1 = Axiom( Pabk :: Nil, Pabk :: Nil )
+      val l2 = ExistsRightRule( l1, l1.root.succedent( 0 ), exPayk, b )
+      val l3 = ExistsLeftRule( l2, l2.root.antecedent( 0 ), exPayk, b )
+      val l4 = WeakeningRightRule( l3, Pxyk )
 
-      val r1 = Axiom( Pabk::Nil, Pabk::Nil )
-      val r2 = ExistsRightRule(r1, r1.root.succedent(0), exPayk, b)
-      val r3 = ExistsLeftRule(r2, r2.root.antecedent(0), exPayk, b)
-      val r4 = WeakeningLeftRule(r3, Pxyk)
+      val r1 = Axiom( Pabk :: Nil, Pabk :: Nil )
+      val r2 = ExistsRightRule( r1, r1.root.succedent( 0 ), exPayk, b )
+      val r3 = ExistsLeftRule( r2, r2.root.antecedent( 0 ), exPayk, b )
+      val r4 = WeakeningLeftRule( r3, Pxyk )
 
-      val proof = CutRule(l4,r4,l4.root.succedent(1), r4.root.antecedent(1))
-      val (rproof, blacklist, _) = regularize.recApply(proof)
-      
+      val proof = CutRule( l4, r4, l4.root.succedent( 1 ), r4.root.antecedent( 1 ) )
+      val ( rproof, blacklist, _ ) = regularize.recApply( proof )
+
       //val names = List("a","b","x","y","k","l","P","Q")
-      val names = List(a, b, x, y, k, l, P, Q)
-      for (name <- names)
-        blacklist must contain (name)
+      val names = List( a, b, x, y, k, l, P, Q )
+      for ( name <- names )
+        blacklist must contain( name )
 
-      val regvars = regularize.variables(rproof)
+      val regvars = regularize.variables( rproof )
 
       //our implementation always appends a number, so b will be removed from the original proof
-      regvars must beEqualTo (blacklist  filterNot(_ == b))
+      regvars must beEqualTo( blacklist filterNot ( _ == b ) )
 
       //the remaining symbols should be b_1,B_2 and the existential quantifier -- but since
       // the naming scheme may change, we only chek the size
-      (blacklist.diff(names)).size must beEqualTo (3)
+      ( blacklist.diff( names ) ).size must beEqualTo( 3 )
 
     }
 
     "apply to a simple proof (3)" in {
-      skipped("Fix me. Should not depend so much on the names and the kind of renaming used")
+      skipped( "Fix me. Should not depend so much on the names and the kind of renaming used" )
       //this is similar to (2) but checks the universal quantifier and if there are no collisions between newly
       // generated vars and already existing ones
-      val List(a,b,x,y) = List("a_1","a_2","x","y") map ((x:String) => HOLVar(x, Ti))
-      val List(k,l) = List("k","l") map ((x:String) => HOLConst(x, Ti))
-      val P = HOLConst("P", Ti -> (Ti -> (Ti -> To)))
-      val Pabk = Atom(P, List(a,b,k))
-      val exPayk = AllVar(y, Atom(P, List(a,y,k)))
-      val Q = HOLConst("Q", Ti -> (Ti -> (Ti -> (Ti -> To))))
-      val Pxyk = Atom(Q, List(x,y,k,l))
+      val List( a, b, x, y ) = List( "a_1", "a_2", "x", "y" ) map ( ( x: String ) => HOLVar( x, Ti ) )
+      val List( k, l ) = List( "k", "l" ) map ( ( x: String ) => HOLConst( x, Ti ) )
+      val P = HOLConst( "P", Ti -> ( Ti -> ( Ti -> To ) ) )
+      val Pabk = Atom( P, List( a, b, k ) )
+      val exPayk = AllVar( y, Atom( P, List( a, y, k ) ) )
+      val Q = HOLConst( "Q", Ti -> ( Ti -> ( Ti -> ( Ti -> To ) ) ) )
+      val Pxyk = Atom( Q, List( x, y, k, l ) )
 
-      val l1 = Axiom( Pabk::Nil, Pabk::Nil )
-      val l2 = ForallLeftRule(l1, l1.root.antecedent(0), exPayk, b)
-      val l3 = ForallRightRule(l2, l2.root.succedent(0), exPayk, b)
-      val l4 = WeakeningRightRule(l3, Pxyk)
+      val l1 = Axiom( Pabk :: Nil, Pabk :: Nil )
+      val l2 = ForallLeftRule( l1, l1.root.antecedent( 0 ), exPayk, b )
+      val l3 = ForallRightRule( l2, l2.root.succedent( 0 ), exPayk, b )
+      val l4 = WeakeningRightRule( l3, Pxyk )
 
-      val r1 = Axiom( Pabk::Nil, Pabk::Nil )
-      val r2 = ForallLeftRule(r1, r1.root.antecedent(0), exPayk, b)
-      val r3 = ForallRightRule(r2, r2.root.succedent(0), exPayk, b)
-      val r4 = WeakeningLeftRule(r3, Pxyk)
+      val r1 = Axiom( Pabk :: Nil, Pabk :: Nil )
+      val r2 = ForallLeftRule( r1, r1.root.antecedent( 0 ), exPayk, b )
+      val r3 = ForallRightRule( r2, r2.root.succedent( 0 ), exPayk, b )
+      val r4 = WeakeningLeftRule( r3, Pxyk )
 
-      val proof = CutRule(l4,r4,l4.root.succedent(1), r4.root.antecedent(1))
-      val (rproof, blacklist, _) = regularize.recApply(proof)
+      val proof = CutRule( l4, r4, l4.root.succedent( 1 ), r4.root.antecedent( 1 ) )
+      val ( rproof, blacklist, _ ) = regularize.recApply( proof )
 
       //val names = List("a_1","a_2","x","y","k","l","P","Q")
-      val names = List(a, b, x, y, k, l, P, Q)
-      for (name <- names)
-        blacklist must contain (name)
+      val names = List( a, b, x, y, k, l, P, Q )
+      for ( name <- names )
+        blacklist must contain( name )
 
-      val regvars = regularize.variables(rproof)
+      val regvars = regularize.variables( rproof )
 
       //here a_1 will be taken, so the replacements of a_2 will be a_3 and a_4
-      regvars must beEqualTo (blacklist filterNot (_ == b))
+      regvars must beEqualTo( blacklist filterNot ( _ == b ) )
 
       //the remaining symbols should be b_1,B_2 and the existential quantifier -- but since
       // the naming scheme may change, we only chek the size
-      (blacklist.diff(names)).size must beEqualTo (3)
+      ( blacklist.diff( names ) ).size must beEqualTo( 3 )
     }
 
   }

--- a/src/test/scala/at/logic/algorithms/lk/SimplificationTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/SimplificationTest.scala
@@ -5,96 +5,96 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-import at.logic.language.fol.{FOLFormula, FOLExpression}
+import at.logic.language.fol.{ FOLFormula, FOLExpression }
 import at.logic.language.hol._
-import at.logic.language.fol.{Function => FOLFunction, Atom => FOLAtom, FOLVar, FOLConst}
+import at.logic.language.fol.{ Function => FOLFunction, Atom => FOLAtom, FOLVar, FOLConst }
 import at.logic.language.lambda.types._
 import at.logic.calculi.lk.base.FSequent
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimplificationTest extends SpecificationWithJUnit {
   "Simplifications" should {
-      val a = Atom(HOLVar("a", To))
-      val b = Atom(HOLVar("b", To))
-      val s1 = FSequent( a::Nil, a::Nil )
-      val s2 = FSequent( b::a::b::Nil, b::b::b::a::b::Nil )
-      val s3 = FSequent( a::Nil, b::Nil )
-      val s4 = FSequent( b::Nil, a::Nil )
+    val a = Atom( HOLVar( "a", To ) )
+    val b = Atom( HOLVar( "b", To ) )
+    val s1 = FSequent( a :: Nil, a :: Nil )
+    val s2 = FSequent( b :: a :: b :: Nil, b :: b :: b :: a :: b :: Nil )
+    val s3 = FSequent( a :: Nil, b :: Nil )
+    val s4 = FSequent( b :: Nil, a :: Nil )
 
-      val P = HOLConst("P", (Ti ->Ti) -> To)
-      val Q = HOLConst("Q", (Ti -> Ti)-> To)
-      val z = HOLVar("z", Ti -> Ti)
-      val z2 = HOLVar("z2", Ti -> Ti)
-      val b1 = HOLConst("b", Ti -> Ti)
-      val Pz = Atom(P, z::Nil)
-      val Pz2 = Atom(P, z2::Nil)
-      val Qb1 = Atom(Q, b1::Nil)
+    val P = HOLConst( "P", ( Ti -> Ti ) -> To )
+    val Q = HOLConst( "Q", ( Ti -> Ti ) -> To )
+    val z = HOLVar( "z", Ti -> Ti )
+    val z2 = HOLVar( "z2", Ti -> Ti )
+    val b1 = HOLConst( "b", Ti -> Ti )
+    val Pz = Atom( P, z :: Nil )
+    val Pz2 = Atom( P, z2 :: Nil )
+    val Qb1 = Atom( Q, b1 :: Nil )
 
-      val f1a = And(Pz, Qb1)
-      val f1b = And(Pz2, Qb1)
-      
-      val P1 = HOLConst("P", Ti -> To)
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val ai = HOLConst("a", Ti)
-      val b2 = HOLConst("b", Ti)
-      val f = HOLConst("f", Ti -> (Ti -> Ti))
-      val fxy = Function(f, x::y::Nil)
-      val fba = Function(f, b2::ai::Nil)
+    val f1a = And( Pz, Qb1 )
+    val f1b = And( Pz2, Qb1 )
 
-      val a1 = Atom(P1, x::Nil)
-      val a2 = Atom(P1, fxy::Nil)
-      val a3 = Atom(P1, ai::Nil)
-      val a4 = Atom(P1, b2::Nil)
-      val a5 = Atom(P1, fba::Nil)
+    val P1 = HOLConst( "P", Ti -> To )
+    val x = HOLVar( "x", Ti )
+    val y = HOLVar( "y", Ti )
+    val ai = HOLConst( "a", Ti )
+    val b2 = HOLConst( "b", Ti )
+    val f = HOLConst( "f", Ti -> ( Ti -> Ti ) )
+    val fxy = Function( f, x :: y :: Nil )
+    val fba = Function( f, b2 :: ai :: Nil )
 
-      val s9 = FSequent(Nil, a1::a2::Nil)
-      val s10 = FSequent(f1a::f1b::Nil, a3::a4::a5::Nil)
+    val a1 = Atom( P1, x :: Nil )
+    val a2 = Atom( P1, fxy :: Nil )
+    val a3 = Atom( P1, ai :: Nil )
+    val a4 = Atom( P1, b2 :: Nil )
+    val a5 = Atom( P1, fba :: Nil )
+
+    val s9 = FSequent( Nil, a1 :: a2 :: Nil )
+    val s10 = FSequent( f1a :: f1b :: Nil, a3 :: a4 :: a5 :: Nil )
 
     "correctly delete tautologous sequents" in {
-      val list = s1::s2::s3::s4::s1::Nil
+      val list = s1 :: s2 :: s3 :: s4 :: s1 :: Nil
       val dlist = deleteTautologies( list )
       dlist.size must beEqualTo( 2 )
     }
 
     "correctly set-normalize a list of Sequents" in {
-      val list = s1::s2::s2::s1::s2::s3::s1::s2::s4::s3::s2::s1::s2::s3::Nil
+      val list = s1 :: s2 :: s2 :: s1 :: s2 :: s3 :: s1 :: s2 :: s4 :: s3 :: s2 :: s1 :: s2 :: s3 :: Nil
       val set = setNormalize( list )
       set.size must beEqualTo( 4 )
     }
 
     "correctly remove subsumed sequents from a set of Sequents" in {
-      val a = FOLConst("a")
-      val x = FOLVar("x")
-      val px = FOLFunction("p", x::Nil)
-      val s = FOLConst("s")
+      val a = FOLConst( "a" )
+      val x = FOLVar( "x" )
+      val px = FOLFunction( "p", x :: Nil )
+      val s = FOLConst( "s" )
 
-      val f1 = FOLAtom("<", a::px::Nil)
-      val f2 = FOLAtom("=", x::s::Nil)
-      val f3 = FOLAtom("=", a::a::Nil)
-      val f4 = FOLAtom("=", x::x::Nil)
-      val f5 = FOLAtom("=", x::a::Nil)
+      val f1 = FOLAtom( "<", a :: px :: Nil )
+      val f2 = FOLAtom( "=", x :: s :: Nil )
+      val f3 = FOLAtom( "=", a :: a :: Nil )
+      val f4 = FOLAtom( "=", x :: x :: Nil )
+      val f5 = FOLAtom( "=", x :: a :: Nil )
 
-      val seq1f = FSequent(Nil, f1::Nil)
-      val seq2f = FSequent(f2::Nil, f1::Nil)
-      val seq3f = FSequent(Nil, f3::Nil)
-      val seq4f = FSequent(Nil, f4::f5::Nil)
+      val seq1f = FSequent( Nil, f1 :: Nil )
+      val seq2f = FSequent( f2 :: Nil, f1 :: Nil )
+      val seq3f = FSequent( Nil, f3 :: Nil )
+      val seq4f = FSequent( Nil, f4 :: f5 :: Nil )
 
       "FOL" in {
-        val ls = List(seq1f,seq2f,seq3f,seq4f)
+        val ls = List( seq1f, seq2f, seq3f, seq4f )
         val ret = subsumedClausesRemoval( ls )
-        ret.toSet must beEqualTo( Set(seq1f,seq4f) )
+        ret.toSet must beEqualTo( Set( seq1f, seq4f ) )
       }
       "HOL" in {
-       "1" in {
-          val ls = List(s9,s10)
+        "1" in {
+          val ls = List( s9, s10 )
           val ret = subsumedClausesRemovalHOL( ls )
           ret.size must beEqualTo( 1 )
         }
         "2" in {
-          val ls = List(seq1f,seq2f,seq3f,seq4f)
+          val ls = List( seq1f, seq2f, seq3f, seq4f )
           val ret = subsumedClausesRemovalHOL( ls )
-          ret.toSet must beEqualTo( Set(seq1f,seq4f) )
+          ret.toSet must beEqualTo( Set( seq1f, seq4f ) )
         }
       }
     }

--- a/src/test/scala/at/logic/algorithms/lk/SolveTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/SolveTest.scala
@@ -1,117 +1,117 @@
 package at.logic.algorithms.lk
 
-import at.logic.calculi.lk.base.{LKUnaryRuleCreationException, LKProof, FSequent, beSyntacticFSequentEqual}
-import at.logic.calculi.lk.{Axiom, NegLeftRule}
-import at.logic.calculi.occurrences.{FormulaOccurrence, defaultFormulaOccurrenceFactory}
+import at.logic.calculi.lk.base.{ LKUnaryRuleCreationException, LKProof, FSequent, beSyntacticFSequentEqual }
+import at.logic.calculi.lk.{ Axiom, NegLeftRule }
+import at.logic.calculi.occurrences.{ FormulaOccurrence, defaultFormulaOccurrenceFactory }
 import at.logic.language.hol._
-import at.logic.language.hol.logicSymbols.{LogicalSymbolA}
+import at.logic.language.hol.logicSymbols.{ LogicalSymbolA }
 import at.logic.language.lambda.symbols.StringSymbol
-import at.logic.language.schema.{IntVar, Succ, IndexedPredicate, IntZero, Or => OrS, SchemaFormula, BigAnd, BigOr}
+import at.logic.language.schema.{ IntVar, Succ, IndexedPredicate, IntZero, Or => OrS, SchemaFormula, BigAnd, BigOr }
 import java.io.File.separator
 import scala.io._
 import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.execute.Success
-import at.logic.language.lambda.types.{To, Ti}
+import at.logic.language.lambda.types.{ To, Ti }
 import at.logic.algorithms.lk.statistics._
-import at.logic.calculi.expansionTrees.{ExpansionTree, ExpansionSequent, Atom => AtomET, Neg => NegET, Or => OrET, WeakQuantifier => WeakQuantifierET, StrongQuantifier => StrongQuantifierET, toFSequent}
+import at.logic.calculi.expansionTrees.{ ExpansionTree, ExpansionSequent, Atom => AtomET, Neg => NegET, Or => OrET, WeakQuantifier => WeakQuantifierET, StrongQuantifier => StrongQuantifierET, toFSequent }
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SolveTest extends SpecificationWithJUnit {
   implicit val factory = defaultFormulaOccurrenceFactory
   "SolveTest" should {
     "solve the sequents" in {
-      val k = IntVar("k")
-      val real_n = IntVar("n")
+      val k = IntVar( "k" )
+      val real_n = IntVar( "n" )
       val n = k
-      val n1 = Succ(k); val n2 = Succ(n1); val n3 = Succ(n2)
-      val k1 = Succ(k); val k2 = Succ(n1); val k3 = Succ(n2)
+      val n1 = Succ( k ); val n2 = Succ( n1 ); val n3 = Succ( n2 )
+      val k1 = Succ( k ); val k2 = Succ( n1 ); val k3 = Succ( n2 )
       val s = Set[FormulaOccurrence]()
 
-      val i = IntVar("i")
-      val A = IndexedPredicate("A", i)
-      val B = IndexedPredicate("B", i)
-      val C = IndexedPredicate("C", i)
-      val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-      val four = Succ(three);val five = Succ(four); val six = Succ(Succ(four));val seven = Succ(Succ(five))
-      val A0 = IndexedPredicate("A", IntZero())
-      val A1 = IndexedPredicate("A", one)
-      val A2 = IndexedPredicate("A", two)
-      val A3 = IndexedPredicate("A", three)
+      val i = IntVar( "i" )
+      val A = IndexedPredicate( "A", i )
+      val B = IndexedPredicate( "B", i )
+      val C = IndexedPredicate( "C", i )
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val four = Succ( three ); val five = Succ( four ); val six = Succ( Succ( four ) ); val seven = Succ( Succ( five ) )
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val A1 = IndexedPredicate( "A", one )
+      val A2 = IndexedPredicate( "A", two )
+      val A3 = IndexedPredicate( "A", three )
 
-      val B0 = IndexedPredicate("B", IntZero())
+      val B0 = IndexedPredicate( "B", IntZero() )
 
-      val Ak = IndexedPredicate("A", k)
-      val Ai = IndexedPredicate("A", i)
-      val Ai1 = IndexedPredicate("A", Succ(i))
-      val orneg = OrS(at.logic.language.schema.Neg(Ai).asInstanceOf[SchemaFormula], Ai1.asInstanceOf[SchemaFormula]).asInstanceOf[SchemaFormula]
+      val Ak = IndexedPredicate( "A", k )
+      val Ai = IndexedPredicate( "A", i )
+      val Ai1 = IndexedPredicate( "A", Succ( i ) )
+      val orneg = OrS( at.logic.language.schema.Neg( Ai ).asInstanceOf[SchemaFormula], Ai1.asInstanceOf[SchemaFormula] ).asInstanceOf[SchemaFormula]
 
-      val Ak1 = IndexedPredicate("A", Succ(k))
-      val An = IndexedPredicate("A", k)
-      val An1 = IndexedPredicate("A", n1)
-      val An2 = IndexedPredicate("A", n2)
-      val An3 = IndexedPredicate("A", n3)
+      val Ak1 = IndexedPredicate( "A", Succ( k ) )
+      val An = IndexedPredicate( "A", k )
+      val An1 = IndexedPredicate( "A", n1 )
+      val An2 = IndexedPredicate( "A", n2 )
+      val An3 = IndexedPredicate( "A", n3 )
 
-      val biga = BigAnd(i, A, zero, one)
-      val bigo = BigOr(i, A, zero, one)
-      val biga2 = BigAnd(i, A, zero, two)
-      val bigo2 = BigOr(i, A, zero, two)
+      val biga = BigAnd( i, A, zero, one )
+      val bigo = BigOr( i, A, zero, one )
+      val biga2 = BigAnd( i, A, zero, two )
+      val bigo2 = BigOr( i, A, zero, two )
 
-      val fseq = FSequent(A0 :: A1 :: Nil, bigo :: Nil)
+      val fseq = FSequent( A0 :: A1 :: Nil, bigo :: Nil )
 
-      val p = solve.solvePropositional(fseq)
+      val p = solve.solvePropositional( fseq )
 
       // TODO: something with these...
-      solve.solvePropositional(FSequent(Neg(And(Neg(A), Neg(B))) :: Nil, Or(A , B) :: Nil))
-      solve.solvePropositional(FSequent(Or(Or(A, B), C) :: Nil, A :: B :: C :: Nil))
-      solve.solvePropositional(FSequent(And(A , B) :: Nil, Neg(Or(Neg(A), Neg(B))) :: Nil))
-      solve.solvePropositional(FSequent(A0 :: A1 :: A2 :: Nil, biga2 :: Nil))
-      solve.solvePropositional(FSequent(A :: B :: C :: Nil, And(And(A, B), C) :: Nil))
-      solve.solvePropositional(FSequent(bigo2 :: Nil, A0 :: A1 :: A2 :: Nil))
-      
-      val c2 = HOLConst(new StringSymbol("c"), Ti)
-      val d2 = HOLConst(new StringSymbol("d"), Ti)
-      val e2 = HOLConst(new StringSymbol("e"), Ti)
-        
-      val P = HOLConst(new StringSymbol("P"), Ti -> To)      
+      solve.solvePropositional( FSequent( Neg( And( Neg( A ), Neg( B ) ) ) :: Nil, Or( A, B ) :: Nil ) )
+      solve.solvePropositional( FSequent( Or( Or( A, B ), C ) :: Nil, A :: B :: C :: Nil ) )
+      solve.solvePropositional( FSequent( And( A, B ) :: Nil, Neg( Or( Neg( A ), Neg( B ) ) ) :: Nil ) )
+      solve.solvePropositional( FSequent( A0 :: A1 :: A2 :: Nil, biga2 :: Nil ) )
+      solve.solvePropositional( FSequent( A :: B :: C :: Nil, And( And( A, B ), C ) :: Nil ) )
+      solve.solvePropositional( FSequent( bigo2 :: Nil, A0 :: A1 :: A2 :: Nil ) )
 
-      val Pc2 = Atom(P, c2::Nil)
-      val Pd2 = Atom(P, d2::Nil)
-      val Pe2 = Atom(P, e2::Nil)
-      val andPc2Pd2 = And(Pc2, Pd2)
-      val impPc2Pd2 = Imp(Pc2, Pd2)
-      val imp_andPc2Pd2_Pe2 = Imp(andPc2Pd2, Pe2)
-      val orPc2Pd2 = Or(Pc2, Pd2)
-      val seq11 = FSequent(Pc2::Nil, Pc2::Nil)
-      val seq12 = FSequent(andPc2Pd2::Nil, Pc2::Nil)
-      val seq13 = FSequent(Pc2::Nil, orPc2Pd2::Nil)
-      val seq14 = FSequent(andPc2Pd2::Nil, orPc2Pd2::Nil)
-      val seq15 = FSequent(Pc2::impPc2Pd2::imp_andPc2Pd2_Pe2::Nil, Pe2::Nil)
-      val seq16 = FSequent(Pc2::Nil, Pd2::Nil)
+      val c2 = HOLConst( new StringSymbol( "c" ), Ti )
+      val d2 = HOLConst( new StringSymbol( "d" ), Ti )
+      val e2 = HOLConst( new StringSymbol( "e" ), Ti )
 
-      solve.solvePropositional(seq16) must beEqualTo (None)
+      val P = HOLConst( new StringSymbol( "P" ), Ti -> To )
+
+      val Pc2 = Atom( P, c2 :: Nil )
+      val Pd2 = Atom( P, d2 :: Nil )
+      val Pe2 = Atom( P, e2 :: Nil )
+      val andPc2Pd2 = And( Pc2, Pd2 )
+      val impPc2Pd2 = Imp( Pc2, Pd2 )
+      val imp_andPc2Pd2_Pe2 = Imp( andPc2Pd2, Pe2 )
+      val orPc2Pd2 = Or( Pc2, Pd2 )
+      val seq11 = FSequent( Pc2 :: Nil, Pc2 :: Nil )
+      val seq12 = FSequent( andPc2Pd2 :: Nil, Pc2 :: Nil )
+      val seq13 = FSequent( Pc2 :: Nil, orPc2Pd2 :: Nil )
+      val seq14 = FSequent( andPc2Pd2 :: Nil, orPc2Pd2 :: Nil )
+      val seq15 = FSequent( Pc2 :: impPc2Pd2 :: imp_andPc2Pd2_Pe2 :: Nil, Pe2 :: Nil )
+      val seq16 = FSequent( Pc2 :: Nil, Pd2 :: Nil )
+
+      solve.solvePropositional( seq16 ) must beEqualTo( None )
     }
 
     "prove non-atomic axioms (1)" in {
       import at.logic.language.hol._
-      val List(x,y,z)    = List("x","y","z") map (x => HOLVar(StringSymbol(x), Ti))
-      val List(u,v,w) = List("u","v","w") map (x => HOLVar(StringSymbol(x), Ti -> Ti))
-      val List(a,b,c, zero)    = List("a","b","c","0") map (x => HOLConst(StringSymbol(x), Ti))
-      val List(f,g,h,s)    = List("f","g","h","s") map (x => HOLConst(StringSymbol(x), Ti -> Ti))
-      val List(p,q)      = List("P","Q") map (x => HOLConst(StringSymbol(x), Ti -> Ti))
-      val List(_Xsym,_Ysym)    = List("X","Y") map (x => StringSymbol(x))
-      val List(_X,_Y)    = List(_Xsym,_Ysym) map (x => HOLVar(x, Ti -> To))
+      val List( x, y, z ) = List( "x", "y", "z" ) map ( x => HOLVar( StringSymbol( x ), Ti ) )
+      val List( u, v, w ) = List( "u", "v", "w" ) map ( x => HOLVar( StringSymbol( x ), Ti -> Ti ) )
+      val List( a, b, c, zero ) = List( "a", "b", "c", "0" ) map ( x => HOLConst( StringSymbol( x ), Ti ) )
+      val List( f, g, h, s ) = List( "f", "g", "h", "s" ) map ( x => HOLConst( StringSymbol( x ), Ti -> Ti ) )
+      val List( p, q ) = List( "P", "Q" ) map ( x => HOLConst( StringSymbol( x ), Ti -> Ti ) )
+      val List( _Xsym, _Ysym ) = List( "X", "Y" ) map ( x => StringSymbol( x ) )
+      val List( _X, _Y ) = List( _Xsym, _Ysym ) map ( x => HOLVar( x, Ti -> To ) )
 
-      val xzero = Atom(_X,List(zero))
-      val xx = Atom(_X,List(x))
-      val xsx = Atom(_X,List(Function(s,List(x))))
+      val xzero = Atom( _X, List( zero ) )
+      val xx = Atom( _X, List( x ) )
+      val xsx = Atom( _X, List( Function( s, List( x ) ) ) )
 
-      val ind = AllVar(_X, Imp(And(xzero, AllVar(x, Imp(xx,xsx) )), AllVar(x, xx) ))
-      val fs = FSequent(ind::Nil,ind::Nil)
-      val proof = AtomicExpansion(fs)
+      val ind = AllVar( _X, Imp( And( xzero, AllVar( x, Imp( xx, xsx ) ) ), AllVar( x, xx ) ) )
+      val fs = FSequent( ind :: Nil, ind :: Nil )
+      val proof = AtomicExpansion( fs )
       //check if the derived end-sequent is correct
-      proof.root.toFSequent must beSyntacticFSequentEqual (fs)
+      proof.root.toFSequent must beSyntacticFSequentEqual( fs )
 
       //check if three different eigenvariables were introduced and nothing more
       /* FIXME: replace toFormula.symbols call with call to getVars from utils
@@ -125,23 +125,23 @@ class SolveTest extends SpecificationWithJUnit {
 
     "prove non-atomic axioms (2)" in {
       import at.logic.language.hol._
-      val List(x,y,z)    = List("x","y","z") map (x => HOLVar(StringSymbol(x), Ti))
-      val List(u,v,w) = List("u","v","w") map (x => HOLVar(StringSymbol(x), Ti -> Ti))
-      val List(a,b,c, zero)    = List("a","b","c","0") map (x => HOLConst(StringSymbol(x), Ti))
-      val List(f,g,h,s)    = List("f","g","h","s") map (x => HOLConst(StringSymbol(x), Ti -> Ti))
-      val List(psym,qsym)      = List("P","Q") map (x => StringSymbol(x))
-      val List(_Xsym,_Ysym)    = List("X","Y") map (x => StringSymbol(x))
-      val List(_X,_Y)    = List(_Xsym,_Ysym) map (x => HOLVar(x, Ti -> To))
+      val List( x, y, z ) = List( "x", "y", "z" ) map ( x => HOLVar( StringSymbol( x ), Ti ) )
+      val List( u, v, w ) = List( "u", "v", "w" ) map ( x => HOLVar( StringSymbol( x ), Ti -> Ti ) )
+      val List( a, b, c, zero ) = List( "a", "b", "c", "0" ) map ( x => HOLConst( StringSymbol( x ), Ti ) )
+      val List( f, g, h, s ) = List( "f", "g", "h", "s" ) map ( x => HOLConst( StringSymbol( x ), Ti -> Ti ) )
+      val List( psym, qsym ) = List( "P", "Q" ) map ( x => StringSymbol( x ) )
+      val List( _Xsym, _Ysym ) = List( "X", "Y" ) map ( x => StringSymbol( x ) )
+      val List( _X, _Y ) = List( _Xsym, _Ysym ) map ( x => HOLVar( x, Ti -> To ) )
 
-      val Q = HOLConst(qsym, Ti -> (Ti -> To) )
-      val P = HOLConst(qsym, Ti -> To)
-      val xzero = Atom(Q,List(y, Function(s,List(x))))
+      val Q = HOLConst( qsym, Ti -> ( Ti -> To ) )
+      val P = HOLConst( qsym, Ti -> To )
+      val xzero = Atom( Q, List( y, Function( s, List( x ) ) ) )
 
-      val formula = AllVar(x, Neg(ExVar(y, xzero)))
-      val fs = FSequent(List(Atom(P,x::Nil), formula),List(formula, Atom(P,y::Nil)))
-      val proof = AtomicExpansion(fs)
+      val formula = AllVar( x, Neg( ExVar( y, xzero ) ) )
+      val fs = FSequent( List( Atom( P, x :: Nil ), formula ), List( formula, Atom( P, y :: Nil ) ) )
+      val proof = AtomicExpansion( fs )
       //check if the derived end-sequent is correct
-      proof.root.toFSequent must beSyntacticFSequentEqual (fs)
+      proof.root.toFSequent must beSyntacticFSequentEqual( fs )
 
       //check if two different eigenvariables were introduced and nothing more
       /* FIXME: replace toFormula.symbols call with call to getVars from utils
@@ -155,28 +155,27 @@ class SolveTest extends SpecificationWithJUnit {
 
     "prove sequent where quantifier order matters" in {
       // example from Chaudhuri et.al.: A multi-focused proof system ...
-      val List(x,y,u,v)    = List("x","y","u","v") map (x => HOLVar(StringSymbol(x), Ti))
-      val c = HOLConst(StringSymbol("c"), Ti)
-      val d = HOLConst(StringSymbol("d"), Ti -> To)
+      val List( x, y, u, v ) = List( "x", "y", "u", "v" ) map ( x => HOLVar( StringSymbol( x ), Ti ) )
+      val c = HOLConst( StringSymbol( "c" ), Ti )
+      val d = HOLConst( StringSymbol( "d" ), Ti -> To )
 
-
-      val formula = ExVar(x, Or( Neg( Atom(d, x::Nil) ), AllVar(y, Atom(d, y::Nil)))) // exists x (-d(x) or forall y d(y))
+      val formula = ExVar( x, Or( Neg( Atom( d, x :: Nil ) ), AllVar( y, Atom( d, y :: Nil ) ) ) ) // exists x (-d(x) or forall y d(y))
 
       val inst1 = OrET(
-        NegET( AtomET( Atom(d, u::Nil))), // -d(u)
-        StrongQuantifierET( AllVar(y, Atom(d, y::Nil)), v, AtomET(Atom(d, v::Nil))) // forall y d(y) +^v d(v)
-      )
+        NegET( AtomET( Atom( d, u :: Nil ) ) ), // -d(u)
+        StrongQuantifierET( AllVar( y, Atom( d, y :: Nil ) ), v, AtomET( Atom( d, v :: Nil ) ) ) // forall y d(y) +^v d(v)
+        )
 
       val inst2 = OrET(
-        NegET( AtomET( Atom(d, c::Nil))), // -d(c)
-        StrongQuantifierET( AllVar(y, Atom(d, y::Nil)), u, AtomET(Atom(d, u::Nil))) // forall y d(y) +^u d(u)
-      )
+        NegET( AtomET( Atom( d, c :: Nil ) ) ), // -d(c)
+        StrongQuantifierET( AllVar( y, Atom( d, y :: Nil ) ), u, AtomET( Atom( d, u :: Nil ) ) ) // forall y d(y) +^u d(u)
+        )
 
       // here, the second tree, containing c, must be expanded before u, as u is used as eigenvar in the c branch
-      val et = WeakQuantifierET.applyWithoutMerge(formula, List( (inst1, u), (inst2, c)))
-      val etSeq = new ExpansionSequent(Nil, et::Nil)
+      val et = WeakQuantifierET.applyWithoutMerge( formula, List( ( inst1, u ), ( inst2, c ) ) )
+      val etSeq = new ExpansionSequent( Nil, et :: Nil )
 
-      val lkProof = solve.expansionProofToLKProof(toFSequent(etSeq), etSeq)
+      val lkProof = solve.expansionProofToLKProof( toFSequent( etSeq ), etSeq )
       lkProof.isDefined must beTrue
     }
 

--- a/src/test/scala/at/logic/algorithms/lk/SubstitutionTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/SubstitutionTest.scala
@@ -10,51 +10,51 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SubstitutionTest extends SpecificationWithJUnit {
   "Substitutions" should {
     object proof1 {
       val x = HOLVar( "x", Ti )
-      val p = HOLConst("P", Ti -> To)
-      val px = Atom(p, x::Nil )
-      val ax1 = Axiom( px::Nil, px::Nil )
-      val ax2 = Axiom( px::Nil, px::Nil )
+      val p = HOLConst( "P", Ti -> To )
+      val px = Atom( p, x :: Nil )
+      val ax1 = Axiom( px :: Nil, px :: Nil )
+      val ax2 = Axiom( px :: Nil, px :: Nil )
       val proof = CutRule( ax1, ax2, ax1.root.succedent.toList.head, ax2.root.antecedent.toList.head )
-      val a = HOLConst("a", Ti)
-      val f = HOLConst("f", Ti -> Ti)
-      val fa = HOLApp(f, a)
+      val a = HOLConst( "a", Ti )
+      val f = HOLConst( "f", Ti -> Ti )
+      val fa = HOLApp( f, a )
       val subst = Substitution( x, fa )
     }
 
     object proof2 {
       val x = HOLVar( "x", Ti )
       val y = HOLVar( "y", Ti )
-      val p = HOLConst("P", Ti -> (Ti -> To))
-      val pxy = Atom(p, List(x,y))
-      val allxpx = AllVar(x,pxy)
-      val ax1 = Axiom( pxy::Nil, pxy::Nil )
-      val r1 = ForallLeftRule(ax1, ax1.root.antecedent(0), allxpx, x )
-      val proof = ForallRightRule(r1, r1.root.succedent(0), allxpx, x)
+      val p = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val pxy = Atom( p, List( x, y ) )
+      val allxpx = AllVar( x, pxy )
+      val ax1 = Axiom( pxy :: Nil, pxy :: Nil )
+      val r1 = ForallLeftRule( ax1, ax1.root.antecedent( 0 ), allxpx, x )
+      val proof = ForallRightRule( r1, r1.root.succedent( 0 ), allxpx, x )
 
-      val a = HOLConst("a", Ti)
-      val f = HOLConst("f", Ti -> Ti)
-      val fa = HOLApp(f, a)
+      val a = HOLConst( "a", Ti )
+      val f = HOLConst( "f", Ti -> Ti )
+      val fa = HOLApp( f, a )
       val subst = Substitution( y, fa )
       val subst2 = Substitution( y, x ) //test for overbinding
     }
 
     "apply correctly to a simple proof" in {
       val p_s = applySubstitution( proof1.proof, proof1.subst )
-      val pfa = Atom(proof1.p, proof1.fa::Nil )
-      val new_seq = FSequent( pfa::Nil, pfa::Nil )
+      val pfa = Atom( proof1.p, proof1.fa :: Nil )
+      val new_seq = FSequent( pfa :: Nil, pfa :: Nil )
       val seq = p_s._1.root.toFSequent
       seq must beEqualTo( new_seq )
     }
 
     "apply correctly to a proof with quantifiers" in {
       val p_s = applySubstitution( proof2.proof, proof2.subst )
-      val pfa = AllVar(proof2.x, Atom(proof2.p, List(proof2.x, proof2.fa) ))
-      val new_seq = FSequent( pfa::Nil, pfa::Nil )
+      val pfa = AllVar( proof2.x, Atom( proof2.p, List( proof2.x, proof2.fa ) ) )
+      val new_seq = FSequent( pfa :: Nil, pfa :: Nil )
       val seq = p_s._1.root.toFSequent
       seq must beEqualTo( new_seq )
     }

--- a/src/test/scala/at/logic/algorithms/lk/mapTest.scala
+++ b/src/test/scala/at/logic/algorithms/lk/mapTest.scala
@@ -11,62 +11,61 @@ import at.logic.calculi.lk.base._
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
 
-
 /**
  * Created by marty on 10/17/14.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class mapTest extends SpecificationWithJUnit {
   "map" should {
-    val List(u,x,y,z) = List("u","x","y","z") map (HOLVar(_, Ti))
-    val List(a,b,c) = List("a","b","c") map (HOLConst(_, Ti))
-    val List(p) = List("p") map (HOLConst(_, Ti -> (Ti -> To)))
-    val List(q) = List("q") map (HOLConst(_, Ti -> To))
-    val pxy = Atom(p, List(x,y))
-    val qz = Atom(q, List(z))
+    val List( u, x, y, z ) = List( "u", "x", "y", "z" ) map ( HOLVar( _, Ti ) )
+    val List( a, b, c ) = List( "a", "b", "c" ) map ( HOLConst( _, Ti ) )
+    val List( p ) = List( "p" ) map ( HOLConst( _, Ti -> ( Ti -> To ) ) )
+    val List( q ) = List( "q" ) map ( HOLConst( _, Ti -> To ) )
+    val pxy = Atom( p, List( x, y ) )
+    val qz = Atom( q, List( z ) )
 
-    val deMorgan1 = Imp( Neg(And(pxy, qz  )),
-      Or(Neg(pxy), Neg(qz)))
-    val deMorgan2 = Imp( Or(Neg(pxy), Neg(qz)),
-      Neg(And(pxy, qz  )))
+    val deMorgan1 = Imp( Neg( And( pxy, qz ) ),
+      Or( Neg( pxy ), Neg( qz ) ) )
+    val deMorgan2 = Imp( Or( Neg( pxy ), Neg( qz ) ),
+      Neg( And( pxy, qz ) ) )
 
-    val deMorgan = And(deMorgan1, deMorgan2)
-    val Some(p1) = solve.solvePropositional(FSequent(Nil,List(deMorgan)), true, true)
+    val deMorgan = And( deMorgan1, deMorgan2 )
+    val Some( p1 ) = solve.solvePropositional( FSequent( Nil, List( deMorgan ) ), true, true )
 
     "be able to convert a hol proof to a fol proof" in {
-      val (proof, _) = map_proof(p1, convertHolToFol.apply )
-      for (f <- proof.root.toFSequent.formulas) {
-        val r = if (f.isInstanceOf[FOLFormula]) "" else (f.toString+" is not a fol formula")
-        "" must_== (r)
+      val ( proof, _ ) = map_proof( p1, convertHolToFol.apply )
+      for ( f <- proof.root.toFSequent.formulas ) {
+        val r = if ( f.isInstanceOf[FOLFormula] ) "" else ( f.toString + " is not a fol formula" )
+        "" must_== ( r )
       }
 
       ok
     }
 
     "be able to convert a proof with a quantified cut" in {
-      val sub = Substitution(z,a)
-      val sub2 = Substitution(z,u)
-      val zdeMorgan = AllVar(u, sub2(deMorgan))
-      val zdeMorgan1 = AllVar(u, sub2(deMorgan1))
-      val Some(proof) = solve.solvePropositional(FSequent(List(deMorgan), List(deMorgan1)))
+      val sub = Substitution( z, a )
+      val sub2 = Substitution( z, u )
+      val zdeMorgan = AllVar( u, sub2( deMorgan ) )
+      val zdeMorgan1 = AllVar( u, sub2( deMorgan1 ) )
+      val Some( proof ) = solve.solvePropositional( FSequent( List( deMorgan ), List( deMorgan1 ) ) )
 
-      val i1 = ForallLeftRule(proof, proof.root.antecedent(0), zdeMorgan, z)
-      val i1a = ForallRightRule(i1, i1.root.succedent(0), zdeMorgan1, z)
+      val i1 = ForallLeftRule( proof, proof.root.antecedent( 0 ), zdeMorgan, z )
+      val i1a = ForallRightRule( i1, i1.root.succedent( 0 ), zdeMorgan1, z )
 
-      val Some(proof2) = solve.solvePropositional(FSequent(sub(deMorgan1)::Nil, sub(deMorgan1)::Nil))
-      val i2 = ForallLeftRule(proof2, proof2.root.antecedent(0), zdeMorgan1, a)
+      val Some( proof2 ) = solve.solvePropositional( FSequent( sub( deMorgan1 ) :: Nil, sub( deMorgan1 ) :: Nil ) )
+      val i2 = ForallLeftRule( proof2, proof2.root.antecedent( 0 ), zdeMorgan1, a )
 
-      val cut = CutRule(i1a, i2, i1a.root.succedent(0), i2.root.antecedent(0))
+      val cut = CutRule( i1a, i2, i1a.root.succedent( 0 ), i2.root.antecedent( 0 ) )
 
-      def fun(e:HOLExpression) : HOLExpression = e match {
-        case f : HOLFormula => convertHolToFol.convertFormula(f)
-        case _ => convertHolToFol.convertTerm(e)
+      def fun( e: HOLExpression ): HOLExpression = e match {
+        case f: HOLFormula => convertHolToFol.convertFormula( f )
+        case _             => convertHolToFol.convertTerm( e )
       }
 
-      val (cutproof, _) = map_proof(cut, fun )
-      for (f <- cutproof.root.toFSequent.formulas) {
-        val r = if (f.isInstanceOf[FOLFormula]) "" else (f.toString+" is not a fol formula")
-        "" must_== (r)
+      val ( cutproof, _ ) = map_proof( cut, fun )
+      for ( f <- cutproof.root.toFSequent.formulas ) {
+        val r = if ( f.isInstanceOf[FOLFormula] ) "" else ( f.toString + " is not a fol formula" )
+        "" must_== ( r )
       }
       ok
     }

--- a/src/test/scala/at/logic/algorithms/lksk/SubstitutionTest.scala
+++ b/src/test/scala/at/logic/algorithms/lksk/SubstitutionTest.scala
@@ -6,56 +6,56 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.hol._
 import at.logic.language.hol.logicSymbols._
-import at.logic.calculi.lk.base.{Sequent, FSequent}
+import at.logic.calculi.lk.base.{ Sequent, FSequent }
 import at.logic.calculi.lksk._
 import at.logic.calculi.lksk.TypeSynonyms._
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SubstitutionTest extends SpecificationWithJUnit {
   "Substitutions" should {
-    val f = HOLConst("f", Ti -> Ti)
-    val y = HOLVar("y", Ti)
-    val x = HOLVar("x", Ti)
-    val a = HOLVar("a", Ti)
-    val fa = HOLApp(f, a)
-    val R = HOLConst("R", Ti -> (Ti -> To))
-    val Rafa = Atom(R, a::fa::Nil)
-    val exyRay = ExVar(y, Atom(R, a::y::Nil ))
-    val allxexy = AllVar(x, ExVar( y, Atom(R, x::y::Nil ) ) )
+    val f = HOLConst( "f", Ti -> Ti )
+    val y = HOLVar( "y", Ti )
+    val x = HOLVar( "x", Ti )
+    val a = HOLVar( "a", Ti )
+    val fa = HOLApp( f, a )
+    val R = HOLConst( "R", Ti -> ( Ti -> To ) )
+    val Rafa = Atom( R, a :: fa :: Nil )
+    val exyRay = ExVar( y, Atom( R, a :: y :: Nil ) )
+    val allxexy = AllVar( x, ExVar( y, Atom( R, x :: y :: Nil ) ) )
 
-    val ax = Axiom.createDefault(new FSequent(Rafa::Nil, Rafa::Nil), Tuple2( (EmptyLabel() + a)::Nil , EmptyLabel()::Nil ) )
-    val r1 = ExistsSkLeftRule(ax._1, ax._2._1.head, exyRay, fa)
-    val r2 = ForallSkLeftRule(r1, r1.prin.head, allxexy, a, true)
-    r2.root.antecedent.toList.head must beLike {case o: LabelledFormulaOccurrence => ok}
-    r2.root.succedent.toList.head must beLike {case o: LabelledFormulaOccurrence => ok}
+    val ax = Axiom.createDefault( new FSequent( Rafa :: Nil, Rafa :: Nil ), Tuple2( ( EmptyLabel() + a ) :: Nil, EmptyLabel() :: Nil ) )
+    val r1 = ExistsSkLeftRule( ax._1, ax._2._1.head, exyRay, fa )
+    val r2 = ForallSkLeftRule( r1, r1.prin.head, allxexy, a, true )
+    r2.root.antecedent.toList.head must beLike { case o: LabelledFormulaOccurrence => ok }
+    r2.root.succedent.toList.head must beLike { case o: LabelledFormulaOccurrence => ok }
 
     "work for an axiom" in {
-      val P = HOLConst("P", Ti -> To)
-      val Px = Atom(P, x::Nil)
-      val c : HOLExpression = HOLConst("c", Ti)
-      val Pc = Atom(P, c::Nil)
+      val P = HOLConst( "P", Ti -> To )
+      val Px = Atom( P, x :: Nil )
+      val c: HOLExpression = HOLConst( "c", Ti )
+      val Pc = Atom( P, c :: Nil )
 
-      val a = Axiom.createDefault(new FSequent( Px::Nil, Px::Nil ), Tuple2( (EmptyLabel() + x)::Nil, (EmptyLabel() + y)::Nil ) )
-      val subst = Substitution(x, c)
-      val r = applySubstitution(a._1, subst)
-      r._1.root.succedent.toList.head must beLike {case o : LabelledFormulaOccurrence => o.skolem_label == (EmptyLabel() + y) && o.formula == Pc must_== true }
-      r._1.root.antecedent.toList.head must beLike {case o : LabelledFormulaOccurrence => o.skolem_label == (EmptyLabel() + c) && o.formula == Pc must_== true }
+      val a = Axiom.createDefault( new FSequent( Px :: Nil, Px :: Nil ), Tuple2( ( EmptyLabel() + x ) :: Nil, ( EmptyLabel() + y ) :: Nil ) )
+      val subst = Substitution( x, c )
+      val r = applySubstitution( a._1, subst )
+      r._1.root.succedent.toList.head must beLike { case o: LabelledFormulaOccurrence => o.skolem_label == ( EmptyLabel() + y ) && o.formula == Pc must_== true }
+      r._1.root.antecedent.toList.head must beLike { case o: LabelledFormulaOccurrence => o.skolem_label == ( EmptyLabel() + c ) && o.formula == Pc must_== true }
     }
 
     "apply correctly to a simple proof" in {
-      val c = HOLConst("c", Ti)
-      val g = HOLConst("g", Ti -> Ti)
-      val gc = HOLApp(g, c)
-      val fgc = HOLApp(f, gc)
-      val R = HOLConst("R", Ti -> (Ti -> To))
-      val Rgcfgc = Atom(R, gc::fgc::Nil )
-      val exyRgcy = ExVar(y, Atom(R, gc::y::Nil ) )
+      val c = HOLConst( "c", Ti )
+      val g = HOLConst( "g", Ti -> Ti )
+      val gc = HOLApp( g, c )
+      val fgc = HOLApp( f, gc )
+      val R = HOLConst( "R", Ti -> ( Ti -> To ) )
+      val Rgcfgc = Atom( R, gc :: fgc :: Nil )
+      val exyRgcy = ExVar( y, Atom( R, gc :: y :: Nil ) )
       val subst = Substitution( a, gc ) // a <- g(c)
 
       val p_s = applySubstitution( r2, subst )
-      p_s._1.root.antecedent.toList.head must beLike{ case o : LabelledFormulaOccurrence => o.skolem_label == EmptyLabel() && o.formula == allxexy must_== true }
-      p_s._1.root.succedent.toList.head must beLike{ case o : LabelledFormulaOccurrence => o.skolem_label == EmptyLabel() && o.formula == Rgcfgc must_== true }
+      p_s._1.root.antecedent.toList.head must beLike { case o: LabelledFormulaOccurrence => o.skolem_label == EmptyLabel() && o.formula == allxexy must_== true }
+      p_s._1.root.succedent.toList.head must beLike { case o: LabelledFormulaOccurrence => o.skolem_label == EmptyLabel() && o.formula == Rgcfgc must_== true }
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/matching/FOLMatchingAlgorithmTest.scala
+++ b/src/test/scala/at/logic/algorithms/matching/FOLMatchingAlgorithmTest.scala
@@ -10,129 +10,126 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.language.fol._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class FOLMatchingAlgorithmTest extends SpecificationWithJUnit {
   "FOLMatchingAlgorithm" should {
-    val x = FOLVar("x")
-    val x1 = FOLVar("x1")
-    val x2 = FOLVar("x2")
-    val x3 = FOLVar("x3")
-    val a = FOLConst("a")
-    val b = FOLConst("b")
-    val c = FOLConst("c")
-    val d = FOLConst("d")
+    val x = FOLVar( "x" )
+    val x1 = FOLVar( "x1" )
+    val x2 = FOLVar( "x2" )
+    val x3 = FOLVar( "x3" )
+    val a = FOLConst( "a" )
+    val b = FOLConst( "b" )
+    val c = FOLConst( "c" )
+    val d = FOLConst( "d" )
 
     "match correctly the lambda expressions f(x, x) and f(a,b)" in {
-      val term = Function("f", x::x::Nil)
-      val posInstance = Function("f", a::b::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub must beEqualTo (sub)
+      val term = Function( "f", x :: x :: Nil )
+      val posInstance = Function( "f", a :: b :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub must beEqualTo( sub )
     }
-
 
     "match correctly the lambda expressions f(x1, x2, c) and f(a,b,c)" in {
-      val term = Function("f", x1::x2::c::Nil)
-      val posInstance = Function("f", a::b::c::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub.get(term) must beEqualTo (posInstance)
+      val term = Function( "f", x1 :: x2 :: c :: Nil )
+      val posInstance = Function( "f", a :: b :: c :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub.get( term ) must beEqualTo( posInstance )
     }
 
-
     "not match the lambda expressions f(x1, d, c) and f(a,b,c)" in {
-      val term = Function("f", x1::d::c::Nil)
-      val posInstance = Function("f", a::b::c::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub must beEqualTo (None)
+      val term = Function( "f", x1 :: d :: c :: Nil )
+      val posInstance = Function( "f", a :: b :: c :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub must beEqualTo( None )
     }
 
     "match the lambda expressions f(x1, x2, c) and f(x1,b,c)" in {
-      val term = Function("f", x1::x2::c::Nil)
-      val posInstance = Function("f", x1::b::c::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub.get(term) must beEqualTo (posInstance)
+      val term = Function( "f", x1 :: x2 :: c :: Nil )
+      val posInstance = Function( "f", x1 :: b :: c :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub.get( term ) must beEqualTo( posInstance )
     }
 
     "not match the lambda expressions f(x1, x2, c, d) and f(x1,b,c)" in {
-      val term = Function("f", x1::x2::c::d::Nil)
-      val posInstance = Function("f", x1::b::c::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub must beEqualTo (None)
+      val term = Function( "f", x1 :: x2 :: c :: d :: Nil )
+      val posInstance = Function( "f", x1 :: b :: c :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub must beEqualTo( None )
     }
 
     "match the lambda expressions f(x1, x2, c) and f(x3,b,c)" in {
-      val term = Function("f", x1::x2::c::Nil)
-      val posInstance = Function("f", x3::b::c::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub.get(term) must beEqualTo (posInstance)
+      val term = Function( "f", x1 :: x2 :: c :: Nil )
+      val posInstance = Function( "f", x3 :: b :: c :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub.get( term ) must beEqualTo( posInstance )
     }
 
     "match the lambda expressions f(x1, x2, x3) and f(x3,b,x3)" in {
-      val term = Function("f", x1::x2::x3::Nil)
-      val posInstance = Function("f", x3::b::x3::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub.get(term) must beEqualTo (posInstance)
+      val term = Function( "f", x1 :: x2 :: x3 :: Nil )
+      val posInstance = Function( "f", x3 :: b :: x3 :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub.get( term ) must beEqualTo( posInstance )
     }
 
     "match the lambda expressions f(x1, x1, x3) and f(x3,b,g(d))" in {
-      val term = Function("f", x1::x1::x3::Nil)
-      val gd = Function("g", d::Nil)
-      val posInstance = Function("f", x3::b::gd::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub must beEqualTo (None)
+      val term = Function( "f", x1 :: x1 :: x3 :: Nil )
+      val gd = Function( "g", d :: Nil )
+      val posInstance = Function( "f", x3 :: b :: gd :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub must beEqualTo( None )
     }
 
     "match the FOL formulas P(x1,f(x1, g(x1,x3), x3)) and P(c,f(x1, g(x1,a), x3))" in {
-      val gx1x3 = Function("g", x1::x3::Nil)
-      val gx1a = Function("g", x1::a::Nil)
-      val term1 = Function("f", x1::gx1x3::x3::Nil)
-      val term2 = Function("f", c::gx1a::x3::Nil)
-      val P1 = AllVar(x1, Atom("P", x1::term1::Nil))
-      val P2 = AllVar(x1, Atom("P", c::term2::Nil))
-      val sub1 = FOLMatchingAlgorithm.matchTerm(P1, P2, freeVariables(P2))
+      val gx1x3 = Function( "g", x1 :: x3 :: Nil )
+      val gx1a = Function( "g", x1 :: a :: Nil )
+      val term1 = Function( "f", x1 :: gx1x3 :: x3 :: Nil )
+      val term2 = Function( "f", c :: gx1a :: x3 :: Nil )
+      val P1 = AllVar( x1, Atom( "P", x1 :: term1 :: Nil ) )
+      val P2 = AllVar( x1, Atom( "P", c :: term2 :: Nil ) )
+      val sub1 = FOLMatchingAlgorithm.matchTerm( P1, P2, freeVariables( P2 ) )
       // ??
-      0 must beEqualTo (0)
+      0 must beEqualTo( 0 )
     }
 
     "match the FOL formulas And(P(x1,f(x1, g(x1,x3), x3)),Q(x1)) and And(P(c,f(c, g(x1,a), x3)),Q(c))" in {
-      val gx1x3 = Function("g", x1::x3::Nil)
-      val gx1a = Function("g", x1::a::Nil)
-      val term1 = Function("f", x1::gx1x3::x3::Nil)
-      val term2 = Function("f", c::gx1a::x3::Nil)
-      val P1 = And(Atom("P", x1::term1::Nil), Atom("Q", x1::Nil))
-      val P2 = And(Atom("P", c::term2::Nil), Atom("Q", c::Nil))
-      val sub1 = FOLMatchingAlgorithm.matchTerm(P1, P2, freeVariables(P2))
-      sub1 must beEqualTo (None)
+      val gx1x3 = Function( "g", x1 :: x3 :: Nil )
+      val gx1a = Function( "g", x1 :: a :: Nil )
+      val term1 = Function( "f", x1 :: gx1x3 :: x3 :: Nil )
+      val term2 = Function( "f", c :: gx1a :: x3 :: Nil )
+      val P1 = And( Atom( "P", x1 :: term1 :: Nil ), Atom( "Q", x1 :: Nil ) )
+      val P2 = And( Atom( "P", c :: term2 :: Nil ), Atom( "Q", c :: Nil ) )
+      val sub1 = FOLMatchingAlgorithm.matchTerm( P1, P2, freeVariables( P2 ) )
+      sub1 must beEqualTo( None )
     }
 
     "match the FOL formulas And(P(x2,f(x2, g(x1,x3), x3)),Q(c)) and And(P(c,f(c, g(x1,a), x1)),Q(c))" in {
-      val gx2x3 = Function("g", x2::x3::Nil)
-      val gax1 = Function("g", a::x1::Nil)
-      val term1 = Function("f", x2::gx2x3::x3::Nil)
-      val term2 = Function("f", c::gax1::x1::Nil)
-      val P1 = And(Atom("P", term1::Nil), Atom("Q", c::Nil))
-      val P2 = And(Atom("P", term2::Nil), Atom("Q", c::Nil))
-      val sub1 = FOLMatchingAlgorithm.matchTerm(P1, P2, freeVariables(P2))
-      sub1 must beEqualTo (None)
+      val gx2x3 = Function( "g", x2 :: x3 :: Nil )
+      val gax1 = Function( "g", a :: x1 :: Nil )
+      val term1 = Function( "f", x2 :: gx2x3 :: x3 :: Nil )
+      val term2 = Function( "f", c :: gax1 :: x1 :: Nil )
+      val P1 = And( Atom( "P", term1 :: Nil ), Atom( "Q", c :: Nil ) )
+      val P2 = And( Atom( "P", term2 :: Nil ), Atom( "Q", c :: Nil ) )
+      val sub1 = FOLMatchingAlgorithm.matchTerm( P1, P2, freeVariables( P2 ) )
+      sub1 must beEqualTo( None )
     }
-    
+
     "match the FOL formulas And(P(f(x2, g(x1,x3), x3)),Q(x2)) and And(P(f(c, g(a,x1), x2)),Q(c))" in {
-      val gx2x3 = Function("g", x2::x3::Nil)
-      val gcx1 = Function("g", c::x1::Nil)
-      val term1 = Function("f", x2::gx2x3::x3::Nil)
-      val term2 = Function("f", c::gcx1::x2::Nil)
-      val P1 = And(Atom("P", term1::Nil), Atom("Q", x2::Nil))
-      val P2 = And(Atom("P", term2::Nil), Atom("Q", c::Nil))
-      val sub1 = FOLMatchingAlgorithm.matchTerm(P1, P2, freeVariables(P2))
-      sub1 must beEqualTo (None)
+      val gx2x3 = Function( "g", x2 :: x3 :: Nil )
+      val gcx1 = Function( "g", c :: x1 :: Nil )
+      val term1 = Function( "f", x2 :: gx2x3 :: x3 :: Nil )
+      val term2 = Function( "f", c :: gcx1 :: x2 :: Nil )
+      val P1 = And( Atom( "P", term1 :: Nil ), Atom( "Q", x2 :: Nil ) )
+      val P2 = And( Atom( "P", term2 :: Nil ), Atom( "Q", c :: Nil ) )
+      val sub1 = FOLMatchingAlgorithm.matchTerm( P1, P2, freeVariables( P2 ) )
+      sub1 must beEqualTo( None )
     }
 
     "not match the lambda expressions f(x, b) and f(a,b)" in {
-      val term = Function("f", x::b::Nil)
-      val posInstance = Function("f", a::b::Nil)
-      val sub = FOLMatchingAlgorithm.matchTerm(term, posInstance, freeVariables(posInstance))
-      sub.get(term) must beEqualTo (posInstance)
+      val term = Function( "f", x :: b :: Nil )
+      val posInstance = Function( "f", a :: b :: Nil )
+      val sub = FOLMatchingAlgorithm.matchTerm( term, posInstance, freeVariables( posInstance ) )
+      sub.get( term ) must beEqualTo( posInstance )
     }
   }
 }
-
 

--- a/src/test/scala/at/logic/algorithms/matching/NaiveIncompleteMatchingAlgorithmTest.scala
+++ b/src/test/scala/at/logic/algorithms/matching/NaiveIncompleteMatchingAlgorithmTest.scala
@@ -12,80 +12,79 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class NaiveIncompleteMatchingAlgorithmTest extends SpecificationWithJUnit {
   "NaiveIncompleteMatchingAlgorithm " should {
     "match correctly the HOL expressions P(a,x) and P(a,f(b))" in {
-      val P = HOLConst("P", Ti->(Ti->To))
-      val a = HOLConst("a", Ti)
-      val b = HOLConst("b", Ti)
-      val Pa = HOLApp(P,a);
-      val x = HOLVar("x", Ti)
-      val Pax = HOLApp(Pa,x)
-      val f = HOLConst("f", Ti->Ti)
-      val fb= HOLApp(f,b)
-      val Pafb = HOLApp(Pa,fb)
-      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm(Pax,Pafb)
-      val subst1 = Substitution(x,fb)
-      subst must beEqualTo (Some(subst1))
+      val P = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val a = HOLConst( "a", Ti )
+      val b = HOLConst( "b", Ti )
+      val Pa = HOLApp( P, a );
+      val x = HOLVar( "x", Ti )
+      val Pax = HOLApp( Pa, x )
+      val f = HOLConst( "f", Ti -> Ti )
+      val fb = HOLApp( f, b )
+      val Pafb = HOLApp( Pa, fb )
+      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm( Pax, Pafb )
+      val subst1 = Substitution( x, fb )
+      subst must beEqualTo( Some( subst1 ) )
     }
 
     "match correctly the HOL expressions P(z,x) and P(f(b),f(b))" in {
-      val P = HOLConst("P", Ti->(Ti->To))
-      val b = HOLConst("b", Ti)
-      val x = HOLVar("x", Ti)
-      val z = HOLVar("z", Ti)
-      val Pz = HOLApp(P,z)
-     
-      val Pzx = HOLApp(Pz,x)
-      val f = HOLConst("f", Ti->Ti)
-      val fb= HOLApp(f,b)
-      val Pfb = HOLApp(P,fb)
-      val Pfbfb = HOLApp(Pfb,fb)
-      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm(Pzx,Pfbfb)
-      val subst1 = Substitution(Map((x, fb), (z, fb)))
-      subst must beEqualTo (Some(subst1))
+      val P = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val b = HOLConst( "b", Ti )
+      val x = HOLVar( "x", Ti )
+      val z = HOLVar( "z", Ti )
+      val Pz = HOLApp( P, z )
+
+      val Pzx = HOLApp( Pz, x )
+      val f = HOLConst( "f", Ti -> Ti )
+      val fb = HOLApp( f, b )
+      val Pfb = HOLApp( P, fb )
+      val Pfbfb = HOLApp( Pfb, fb )
+      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm( Pzx, Pfbfb )
+      val subst1 = Substitution( Map( ( x, fb ), ( z, fb ) ) )
+      subst must beEqualTo( Some( subst1 ) )
     }
 
     "NOT match correctly the HOL expressions P(z,x) and P(f(b),z)" in {
-      val P = HOLConst("P", Ti->(Ti->To))
-      val b = HOLConst("b", Ti)
-      val x = HOLVar("x", Ti)
-      val z = HOLVar("z", Ti)
-      val Pz = HOLApp(P,z)
-      val Pzx = HOLApp(Pz,x)
-      val f = HOLConst("f", Ti->Ti)
-      val fb= HOLApp(f,b)
-      val Pfb = HOLApp(P,fb)
-      val Pfbz = HOLApp(Pfb,z)
-      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm(Pzx,Pfbz)
-      val subst1 = Substitution( Map((z,fb), (x,z)) )
-      subst must beEqualTo (None)         // correct !!!
+      val P = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val b = HOLConst( "b", Ti )
+      val x = HOLVar( "x", Ti )
+      val z = HOLVar( "z", Ti )
+      val Pz = HOLApp( P, z )
+      val Pzx = HOLApp( Pz, x )
+      val f = HOLConst( "f", Ti -> Ti )
+      val fb = HOLApp( f, b )
+      val Pfb = HOLApp( P, fb )
+      val Pfbz = HOLApp( Pfb, z )
+      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm( Pzx, Pfbz )
+      val subst1 = Substitution( Map( ( z, fb ), ( x, z ) ) )
+      subst must beEqualTo( None ) // correct !!!
     }
 
     "match correctly the HOL expression a < p(x) with itself" in {
-      val lt = HOLConst("<", Ti->(Ti->To))
-      val a = HOLConst("a", Ti)
-      val p = HOLConst("p", Ti->Ti)
-      val x = HOLVar("x", Ti)
-      val px = Function(p, x::Nil)
-      val at = Function(lt, a::px::Nil)
-      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm(at, at)
-      subst must beEqualTo (Some(Substitution()))
+      val lt = HOLConst( "<", Ti -> ( Ti -> To ) )
+      val a = HOLConst( "a", Ti )
+      val p = HOLConst( "p", Ti -> Ti )
+      val x = HOLVar( "x", Ti )
+      val px = Function( p, x :: Nil )
+      val at = Function( lt, a :: px :: Nil )
+      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm( at, at )
+      subst must beEqualTo( Some( Substitution() ) )
     }
 
     "match correctly the HOL expression a < p(x) with another copy of itself" in {
-      val lt = HOLConst("<", Ti->(Ti->To))
-      val a = HOLConst("a", Ti)
-      val p = HOLConst("p", Ti->Ti)
-      val x = HOLVar("x", Ti)
-      val px = Function(p, x::Nil)
-      val at = Function(lt, a::px::Nil)
-      val at2 = Function(lt, a::px::Nil) // Is this a copy?
-      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm(at, at2)
-      subst must beEqualTo (Some(Substitution()))
+      val lt = HOLConst( "<", Ti -> ( Ti -> To ) )
+      val a = HOLConst( "a", Ti )
+      val p = HOLConst( "p", Ti -> Ti )
+      val x = HOLVar( "x", Ti )
+      val px = Function( p, x :: Nil )
+      val at = Function( lt, a :: px :: Nil )
+      val at2 = Function( lt, a :: px :: Nil ) // Is this a copy?
+      val subst = NaiveIncompleteMatchingAlgorithm.matchTerm( at, at2 )
+      subst must beEqualTo( Some( Substitution() ) )
     }
   }
 }
-
 

--- a/src/test/scala/at/logic/algorithms/resolution/CNFTest.scala
+++ b/src/test/scala/at/logic/algorithms/resolution/CNFTest.scala
@@ -3,54 +3,53 @@ package at.logic.algorithms.resolution
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
-import at.logic.language.hol.{Atom => HOLAtom, HOLConst}
+import at.logic.language.hol.{ Atom => HOLAtom, HOLConst }
 import at.logic.language.lambda.types.To
-import at.logic.language.fol.{And, Or, Neg, Atom, FOLConst, Imp}
+import at.logic.language.fol.{ And, Or, Neg, Atom, FOLConst, Imp }
 import at.logic.calculi.resolution.FClause
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class CNFTest extends SpecificationWithJUnit {
   "the computation of CNFp(f)" should {
     "be {|- Pa,Qa, Qa|-} for f = (Pa ∨ Qa) ∧ ¬Qa" in {
-      val Pa = Atom("P", FOLConst("a")::Nil)
-      val Qa = Atom("Q", FOLConst("a")::Nil)
-      val nQa = Neg(Qa)
-      val PavQa = Or(Pa,Qa)
-      val f = And(PavQa, nQa)
-      CNFp(f).toSet must beEqualTo(Set(FClause(List(),List(Pa,Qa)),FClause(List(Qa),List())))
+      val Pa = Atom( "P", FOLConst( "a" ) :: Nil )
+      val Qa = Atom( "Q", FOLConst( "a" ) :: Nil )
+      val nQa = Neg( Qa )
+      val PavQa = Or( Pa, Qa )
+      val f = And( PavQa, nQa )
+      CNFp( f ).toSet must beEqualTo( Set( FClause( List(), List( Pa, Qa ) ), FClause( List( Qa ), List() ) ) )
     }
   }
 
   "the computation of TseitinCNF(f)" should {
     "should be right, where f = ((P ∨ Q) ∧ R ) -> ¬S" in {
-      val p = Atom("P", Nil)
-      val q = Atom("Q", Nil)
-      val r = Atom("R", Nil)
-      val s = Atom("S", Nil)
+      val p = Atom( "P", Nil )
+      val q = Atom( "Q", Nil )
+      val r = Atom( "R", Nil )
+      val s = Atom( "S", Nil )
 
-      val f = Imp(And(Or(p, q), r), Neg(s))
+      val f = Imp( And( Or( p, q ), r ), Neg( s ) )
 
-      val x =  Atom("x", Nil)
-      val x0 = Atom("x0", Nil)
-      val x1 = Atom("x1", Nil)
-      val x2 = Atom("x2", Nil)
+      val x = Atom( "x", Nil )
+      val x0 = Atom( "x0", Nil )
+      val x1 = Atom( "x1", Nil )
+      val x2 = Atom( "x2", Nil )
 
-      val cnf = TseitinCNF(f)
+      val cnf = TseitinCNF( f )
       val expected = Set(
-        FClause(List(), List(x2)),
-        FClause(List(x1), List(x2)),
-        FClause(List(), List(x2, x0)),
-        FClause(List(), List(x1, s)),
-        FClause(List(x1, s), List()),
-        FClause(List(x0), List(r)),
-        FClause(List(x0), List(x)),
-        FClause(List(q), List(x)),
-        FClause(List(p), List(x)),
-        FClause(List(x2, x0), List(x1)),
-        FClause(List(x, r), List(x0)),
-        FClause(List(x), List(p, q))
-      )
-      cnf._1.toSet must beEqualTo(expected)
+        FClause( List(), List( x2 ) ),
+        FClause( List( x1 ), List( x2 ) ),
+        FClause( List(), List( x2, x0 ) ),
+        FClause( List(), List( x1, s ) ),
+        FClause( List( x1, s ), List() ),
+        FClause( List( x0 ), List( r ) ),
+        FClause( List( x0 ), List( x ) ),
+        FClause( List( q ), List( x ) ),
+        FClause( List( p ), List( x ) ),
+        FClause( List( x2, x0 ), List( x1 ) ),
+        FClause( List( x, r ), List( x0 ) ),
+        FClause( List( x ), List( p, q ) ) )
+      cnf._1.toSet must beEqualTo( expected )
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/resolution/PCNFTest.scala
+++ b/src/test/scala/at/logic/algorithms/resolution/PCNFTest.scala
@@ -9,85 +9,84 @@ import at.logic.calculi.resolution.FClause
 import at.logic.calculi.lk._
 import at.logic.calculi.lk.base.FSequent
 
-
 // we compare toStrings as proofs have only pointer equality. This needs to be changed by allowing syntaxEquals in graphs and vertices should
 // have syntaxEquals as well
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class projectionsTest extends SpecificationWithJUnit {
   "PCNF" should {
     "create the projection of" in {
-      val Pa = Atom("P", FOLConst("a")::Nil)
-      val Qa = Atom("Q", FOLConst("a")::Nil)
-      val nPa = Neg(Pa)
-      val cPa = FClause(List(), List(Pa))
+      val Pa = Atom( "P", FOLConst( "a" ) :: Nil )
+      val Qa = Atom( "Q", FOLConst( "a" ) :: Nil )
+      val nPa = Neg( Pa )
+      val cPa = FClause( List(), List( Pa ) )
       "an atom Pa in the CNF(-s) where s is the sequent" in {
-        val pPaPa = Axiom(List(Pa), List(Pa))
+        val pPaPa = Axiom( List( Pa ), List( Pa ) )
         "|- ¬Pa" in {
-          val lkProof = NegRightRule(pPaPa, Pa)
-          PCNF(FSequent(List(), List(nPa)), cPa).toString must beEqualTo (lkProof.toString)
+          val lkProof = NegRightRule( pPaPa, Pa )
+          PCNF( FSequent( List(), List( nPa ) ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "Pa |-" in {
           val lkProof = pPaPa
-          PCNF(FSequent(List(Pa), List()), cPa).toString must beEqualTo (lkProof.toString)
+          PCNF( FSequent( List( Pa ), List() ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "Pa ∨ Qa |- Qa" in {
-          val PavQa = Or(Pa,Qa)
-          val lkProof = OrLeftRule(Axiom(List(Pa),List(Pa)), Axiom(List(Qa),List(Qa)), Pa,Qa)
-          PCNF(FSequent(List(PavQa), List(Qa)), cPa).toString must beEqualTo (lkProof.toString)
-        }.pendingUntilFixed("not new : already silently broken with Scala 2.10")
+          val PavQa = Or( Pa, Qa )
+          val lkProof = OrLeftRule( Axiom( List( Pa ), List( Pa ) ), Axiom( List( Qa ), List( Qa ) ), Pa, Qa )
+          PCNF( FSequent( List( PavQa ), List( Qa ) ), cPa ).toString must beEqualTo( lkProof.toString )
+        }.pendingUntilFixed( "not new : already silently broken with Scala 2.10" )
         "|- ¬Pa ∨ Qa" in {
-          val nPavQa = Or(nPa,Qa)
-          val lkProof = OrRight1Rule(NegRightRule(Axiom(List(Pa),List(Pa)), Pa), nPa,Qa)
-          PCNF(FSequent(List(), List(nPavQa)), cPa).toString must beEqualTo (lkProof.toString)
+          val nPavQa = Or( nPa, Qa )
+          val lkProof = OrRight1Rule( NegRightRule( Axiom( List( Pa ), List( Pa ) ), Pa ), nPa, Qa )
+          PCNF( FSequent( List(), List( nPavQa ) ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "|- Qa ∨ ¬Pa" in {
-          val QavnPa = Or(Qa,nPa)
-          val lkProof = OrRight2Rule(NegRightRule(Axiom(List(Pa),List(Pa)), Pa), Qa, nPa)
-          PCNF(FSequent(List(), List(QavnPa)), cPa).toString must beEqualTo (lkProof.toString)
+          val QavnPa = Or( Qa, nPa )
+          val lkProof = OrRight2Rule( NegRightRule( Axiom( List( Pa ), List( Pa ) ), Pa ), Qa, nPa )
+          PCNF( FSequent( List(), List( QavnPa ) ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "Pa ∧ Qa |-" in {
-          val PawQa = And(Pa,Qa)
-          val lkProof = AndLeft1Rule(Axiom(List(Pa),List(Pa)), Pa, Qa)
-          PCNF(FSequent(List(PawQa), List()), cPa).toString must beEqualTo (lkProof.toString)
+          val PawQa = And( Pa, Qa )
+          val lkProof = AndLeft1Rule( Axiom( List( Pa ), List( Pa ) ), Pa, Qa )
+          PCNF( FSequent( List( PawQa ), List() ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "Qa ∧ Pa |-" in {
-          val QawPa = And(Qa,Pa)
-          val lkProof = AndLeft2Rule(Axiom(List(Pa),List(Pa)), Qa, Pa)
-          PCNF(FSequent(List(QawPa), List()), cPa).toString must beEqualTo (lkProof.toString)
+          val QawPa = And( Qa, Pa )
+          val lkProof = AndLeft2Rule( Axiom( List( Pa ), List( Pa ) ), Qa, Pa )
+          PCNF( FSequent( List( QawPa ), List() ), cPa ).toString must beEqualTo( lkProof.toString )
         }
         "Sa, Qa ∧ Pa |- Ra" in {
-          val Sa = Atom("S", FOLConst("a")::Nil)
-          val Ra = Atom("R", FOLConst("a")::Nil)
-          val QawPa = And(Qa,Pa)
-          val lkProof = WeakeningRightRule(WeakeningLeftRule(AndLeft2Rule(Axiom(List(Pa),List(Pa)), Qa, Pa),Sa),Ra)
-          PCNF(FSequent(List(Sa,QawPa), List(Ra)), cPa).toString must beEqualTo (lkProof.toString)
-        }.pendingUntilFixed("not new : already silently broken with Scala 2.10")
+          val Sa = Atom( "S", FOLConst( "a" ) :: Nil )
+          val Ra = Atom( "R", FOLConst( "a" ) :: Nil )
+          val QawPa = And( Qa, Pa )
+          val lkProof = WeakeningRightRule( WeakeningLeftRule( AndLeft2Rule( Axiom( List( Pa ), List( Pa ) ), Qa, Pa ), Sa ), Ra )
+          PCNF( FSequent( List( Sa, QawPa ), List( Ra ) ), cPa ).toString must beEqualTo( lkProof.toString )
+        }.pendingUntilFixed( "not new : already silently broken with Scala 2.10" )
         "Qa |- ¬Pa ∧ Qa" in {
-          val nPavQa = And(nPa,Qa)
-          val lkProof = AndRightRule(NegRightRule(Axiom(List(Pa),List(Pa)),Pa), Axiom(List(Qa),List(Qa)), nPa,Qa)
-          PCNF(FSequent(List(Qa), List(nPavQa)), cPa).toString must beEqualTo (lkProof.toString)
-        }.pendingUntilFixed("not new : already silently broken with Scala 2.10")
+          val nPavQa = And( nPa, Qa )
+          val lkProof = AndRightRule( NegRightRule( Axiom( List( Pa ), List( Pa ) ), Pa ), Axiom( List( Qa ), List( Qa ) ), nPa, Qa )
+          PCNF( FSequent( List( Qa ), List( nPavQa ) ), cPa ).toString must beEqualTo( lkProof.toString )
+        }.pendingUntilFixed( "not new : already silently broken with Scala 2.10" )
         /*"add tests for imp right and left" in {
 
         } */
       }
       "an atom Px in the CNF(-f(s)) where s is the sequent" in {
         "∀xPx |-" in {
-          val Px = Atom("P", FOLVar("x")::Nil)
-          val x = FOLVar("x")
-          val axPx = AllVar(x,Px)
-          val lkProof = ForallLeftRule(Axiom(List(Px),List(Px)),Px, axPx, x)
-          val cPx = FClause(List(), List(Px))
-          PCNF(FSequent(List(axPx),List()),cPx).toString must beEqualTo (lkProof.toString)
+          val Px = Atom( "P", FOLVar( "x" ) :: Nil )
+          val x = FOLVar( "x" )
+          val axPx = AllVar( x, Px )
+          val lkProof = ForallLeftRule( Axiom( List( Px ), List( Px ) ), Px, axPx, x )
+          val cPx = FClause( List(), List( Px ) )
+          PCNF( FSequent( List( axPx ), List() ), cPx ).toString must beEqualTo( lkProof.toString )
         }
         "|- ∃xPx" in {
-          val Px = Atom("P", FOLVar("x")::Nil)
-          val x = FOLVar("x")
-          val exPx = ExVar(x,Px)
-          val lkProof = ExistsRightRule(Axiom(List(Px),List(Px)),Px, exPx, x)
-          val cPx = FClause(List(Px), List())
-          PCNF(FSequent(List(),List(exPx)),cPx).toString must beEqualTo (lkProof.toString)
+          val Px = Atom( "P", FOLVar( "x" ) :: Nil )
+          val x = FOLVar( "x" )
+          val exPx = ExVar( x, Px )
+          val lkProof = ExistsRightRule( Axiom( List( Px ), List( Px ) ), Px, exPx, x )
+          val cPx = FClause( List( Px ), List() )
+          PCNF( FSequent( List(), List( exPx ) ), cPx ).toString must beEqualTo( lkProof.toString )
         }
       }
       /*"a negation ¬Pa in the CNF(-s) where s is the sequent" in {

--- a/src/test/scala/at/logic/algorithms/resolution/ResolutionToLKTest.scala
+++ b/src/test/scala/at/logic/algorithms/resolution/ResolutionToLKTest.scala
@@ -10,238 +10,238 @@ import at.logic.calculi.lk._
 import at.logic.calculi.resolution.robinson._
 import at.logic.calculi.resolution.FClause
 import at.logic.algorithms.lk.applySubstitution
-import collection.immutable.Map.{Map1, Map2}
+import collection.immutable.Map.{ Map1, Map2 }
 
 // we compare toStrings as proofs have only pointer equality. This needs to be changed by allowing syntaxEquals in graphs and vertices should
 // have syntaxEquals as well
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ResolutionToLKTest extends SpecificationWithJUnit {
 
   object UNSproof {
-    val v0 = FOLVar("v0")
-    val v1 = FOLVar("v1")
-    val v2 = FOLVar("v2")
+    val v0 = FOLVar( "v0" )
+    val v1 = FOLVar( "v1" )
+    val v2 = FOLVar( "v2" )
 
-    val m01 = Function("multiply", v0::v1::Nil)
-    val m10 = Function("multiply", v1::v0::Nil)
-    val m02 = Function("multiply", v0::v2::Nil)
-    val m12 = Function("multiply", v1::v2::Nil)
-    val add01 = Function("add", v0::v1::Nil)
-    val am02m12 = Function("add", m02::m12::Nil)
-    val ma012 = Function("multiply", add01::v2::Nil)
-    val m2a01 = Function("multiply", v2::add01::Nil)
-    
+    val m01 = Function( "multiply", v0 :: v1 :: Nil )
+    val m10 = Function( "multiply", v1 :: v0 :: Nil )
+    val m02 = Function( "multiply", v0 :: v2 :: Nil )
+    val m12 = Function( "multiply", v1 :: v2 :: Nil )
+    val add01 = Function( "add", v0 :: v1 :: Nil )
+    val am02m12 = Function( "add", m02 :: m12 :: Nil )
+    val ma012 = Function( "multiply", add01 :: v2 :: Nil )
+    val m2a01 = Function( "multiply", v2 :: add01 :: Nil )
+
     // =(multiply(v0, v1), multiply(v1, v0))
-    val c1 = Equation(m01, m10)
+    val c1 = Equation( m01, m10 )
     // =(multiply(add(v0, v1), v2), add(multiply(v0, v2), multiply(v1, v2)))
-    val c2 = Equation(ma012, am02m12)
+    val c2 = Equation( ma012, am02m12 )
     // =(multiply(v2, add(v0, v1)), add(multiply(v0, v2), multiply(v1, v2)))
-    val c3 = Equation(m2a01, am02m12)
+    val c3 = Equation( m2a01, am02m12 )
 
-    val sub = Substitution(Map((v0,v2), (v1, add01)))
+    val sub = Substitution( Map( ( v0, v2 ), ( v1, add01 ) ) )
 
-    val p1 = InitialClause(Nil, c1::Nil)
-    val p2 = Instance(p1,sub )
-    val p3 = InitialClause(Nil, c2::Nil)
-    val p4 = Paramodulation(p2, p3, p2.root.succedent(0), p3.root.succedent(0), c3, Substitution())
+    val p1 = InitialClause( Nil, c1 :: Nil )
+    val p2 = Instance( p1, sub )
+    val p3 = InitialClause( Nil, c2 :: Nil )
+    val p4 = Paramodulation( p2, p3, p2.root.succedent( 0 ), p3.root.succedent( 0 ), c3, Substitution() )
 
   }
   object UNSproofFreshvars {
-    val v0 = FOLVar("v0")
-    val v0u = FOLVar("v0_")
-    val v1 = FOLVar("v1")
-    val v1u = FOLVar("v1_")
-    val v2 = FOLVar("v2")
+    val v0 = FOLVar( "v0" )
+    val v0u = FOLVar( "v0_" )
+    val v1 = FOLVar( "v1" )
+    val v1u = FOLVar( "v1_" )
+    val v2 = FOLVar( "v2" )
 
-    val m01u = Function("multiply", v0u::v1u::Nil)
-    val m10u = Function("multiply", v1u::v0u::Nil)
-    val m02 = Function("multiply", v0::v2::Nil)
-    val m12 = Function("multiply", v1::v2::Nil)
-    val add01 = Function("add", v0::v1::Nil)
-    val am02m12 = Function("add", m02::m12::Nil)
-    val ma012 = Function("multiply", add01::v2::Nil)
-    val m2a01 = Function("multiply", v2::add01::Nil)
-   
+    val m01u = Function( "multiply", v0u :: v1u :: Nil )
+    val m10u = Function( "multiply", v1u :: v0u :: Nil )
+    val m02 = Function( "multiply", v0 :: v2 :: Nil )
+    val m12 = Function( "multiply", v1 :: v2 :: Nil )
+    val add01 = Function( "add", v0 :: v1 :: Nil )
+    val am02m12 = Function( "add", m02 :: m12 :: Nil )
+    val ma012 = Function( "multiply", add01 :: v2 :: Nil )
+    val m2a01 = Function( "multiply", v2 :: add01 :: Nil )
+
     // =(multiply(v0_, v1_), multiply(v1_, v0_))
-    val c1 = Equation(m01u, m10u)
+    val c1 = Equation( m01u, m10u )
     // =(multiply(add(v0, v1), v2), add(multiply(v0, v2), multiply(v1, v2)))
-    val c2 = Equation(ma012, am02m12)
+    val c2 = Equation( ma012, am02m12 )
     // =(multiply(v2, add(v0, v1)), add(multiply(v0, v2), multiply(v1, v2)))
-    val c3 = Equation(m2a01, am02m12)  
+    val c3 = Equation( m2a01, am02m12 )
 
-    val sub = Substitution(Map((v0,v2), (v1, add01)))
+    val sub = Substitution( Map( ( v0, v2 ), ( v1, add01 ) ) )
 
-    val p1 = InitialClause(Nil, c1::Nil)
-    val p2 = Instance(p1,sub )
-    val p3 = InitialClause(Nil, c2::Nil)
-    val p4 = Paramodulation(p2, p3, p2.root.succedent(0), p3.root.succedent(0), c3, Substitution())
+    val p1 = InitialClause( Nil, c1 :: Nil )
+    val p2 = Instance( p1, sub )
+    val p3 = InitialClause( Nil, c2 :: Nil )
+    val p4 = Paramodulation( p2, p3, p2.root.succedent( 0 ), p3.root.succedent( 0 ), c3, Substitution() )
 
   }
   object UNSproofVariant {
-    val v0 = FOLVar("v0")
-    val v0u = FOLVar("v0_")
-    val v1 = FOLVar("v1")
-    val v1u = FOLVar("v1_")
-    val v2 = FOLVar("v2")
+    val v0 = FOLVar( "v0" )
+    val v0u = FOLVar( "v0_" )
+    val v1 = FOLVar( "v1" )
+    val v1u = FOLVar( "v1_" )
+    val v2 = FOLVar( "v2" )
 
-    val m01 = Function("multiply", v0::v1::Nil)
-    val m10 = Function("multiply", v1::v0::Nil)
-    val m02 = Function("multiply", v0::v2::Nil)
-    val m12 = Function("multiply", v1::v2::Nil)
-    val add01 = Function("add", v0::v1::Nil)
-    val am02m12 = Function("add", m02::m12::Nil)
-    val ma012 = Function("multiply", add01::v2::Nil)
-    val m2a01 = Function("multiply", v2::add01::Nil)
-   
+    val m01 = Function( "multiply", v0 :: v1 :: Nil )
+    val m10 = Function( "multiply", v1 :: v0 :: Nil )
+    val m02 = Function( "multiply", v0 :: v2 :: Nil )
+    val m12 = Function( "multiply", v1 :: v2 :: Nil )
+    val add01 = Function( "add", v0 :: v1 :: Nil )
+    val am02m12 = Function( "add", m02 :: m12 :: Nil )
+    val ma012 = Function( "multiply", add01 :: v2 :: Nil )
+    val m2a01 = Function( "multiply", v2 :: add01 :: Nil )
+
     // =(multiply(v0, v1), multiply(v1, v0))
-    val c1 = Equation(m01, m10)
+    val c1 = Equation( m01, m10 )
     // =(multiply(add(v0, v1), v2), add(multiply(v0, v2), multiply(v1, v2)))
-    val c2 = Equation(ma012, am02m12)
+    val c2 = Equation( ma012, am02m12 )
     // =(multiply(v2, add(v0, v1)), add(multiply(v0, v2), multiply(v1, v2)))
-    val c3 = Equation(m2a01, am02m12)     
+    val c3 = Equation( m2a01, am02m12 )
 
-    val sub1 = Substitution(Map((v0,v0u), (v1, v1u)))
-    val sub2 = Substitution(Map((v0u,v2), (v1u, add01)))
+    val sub1 = Substitution( Map( ( v0, v0u ), ( v1, v1u ) ) )
+    val sub2 = Substitution( Map( ( v0u, v2 ), ( v1u, add01 ) ) )
 
-    val p1 = InitialClause(Nil, c1::Nil)
-    val p1_ = Variant(p1,sub1 )
-    val p2 = Instance(p1,sub2 )
-    val p3 = InitialClause(Nil, c2::Nil)
-    val p4 = Paramodulation(p2, p3, p2.root.succedent(0), p3.root.succedent(0), c3, Substitution())
+    val p1 = InitialClause( Nil, c1 :: Nil )
+    val p1_ = Variant( p1, sub1 )
+    val p2 = Instance( p1, sub2 )
+    val p3 = InitialClause( Nil, c2 :: Nil )
+    val p4 = Paramodulation( p2, p3, p2.root.succedent( 0 ), p3.root.succedent( 0 ), c3, Substitution() )
 
   }
 
   "RobinsonToLK" should {
     "transform the following resolution proof into an LK proof of the empty sequent" in {
       "containing only an initial clause" in {
-        val Pa = Atom("P", FOLConst("a")::Nil)
-        val resProof = InitialClause(Pa :: List.empty, Pa :: List.empty)
-        val lkProof = Axiom(Pa :: List.empty, Pa :: List.empty)
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val Pa = Atom( "P", FOLConst( "a" ) :: Nil )
+        val resProof = InitialClause( Pa :: List.empty, Pa :: List.empty )
+        val lkProof = Axiom( Pa :: List.empty, Pa :: List.empty )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
       "containing a factorized clause" in {
-        val a = FOLConst("a")
-        val x = FOLVar("x")
-        val y = FOLVar("y")
-        val fa = Function("f", a::Nil)
-        val fy = Function("f", y::Nil)
-        val Pfa = Atom("P", fa::Nil)
-        val Pfy = Atom("P", fy::Nil)
-        val Px = Atom("P", x::Nil)
+        val a = FOLConst( "a" )
+        val x = FOLVar( "x" )
+        val y = FOLVar( "y" )
+        val fa = Function( "f", a :: Nil )
+        val fy = Function( "f", y :: Nil )
+        val Pfa = Atom( "P", fa :: Nil )
+        val Pfy = Atom( "P", fy :: Nil )
+        val Px = Atom( "P", x :: Nil )
 
-        val p1 = InitialClause(Pfa :: Px :: Pfy :: List.empty, List.empty)
-        val resProof = Factor(p1, p1.root.negative(1), List(p1.root.negative(0), p1.root.negative(2)), Substitution(new Map2(x, fa, y, a)))
+        val p1 = InitialClause( Pfa :: Px :: Pfy :: List.empty, List.empty )
+        val resProof = Factor( p1, p1.root.negative( 1 ), List( p1.root.negative( 0 ), p1.root.negative( 2 ) ), Substitution( new Map2( x, fa, y, a ) ) )
 
-        val l1 = Axiom(List(Pfa, Pfa, Pfa), List())
-        val l2 = ContractionLeftRule(l1, l1.root.antecedent(1), l1.root.antecedent(0))
-        val lkProof = ContractionLeftRule(l2, l2.root.antecedent(0), l2.root.antecedent(1))
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val l1 = Axiom( List( Pfa, Pfa, Pfa ), List() )
+        val l2 = ContractionLeftRule( l1, l1.root.antecedent( 1 ), l1.root.antecedent( 0 ) )
+        val lkProof = ContractionLeftRule( l2, l2.root.antecedent( 0 ), l2.root.antecedent( 1 ) )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
       "containing a variant clause" in {
-        val x = FOLVar("x")
-        val y = FOLVar("y")
-        val Px = Atom("P", x::Nil)
-        val Py = Atom("P", y::Nil)
+        val x = FOLVar( "x" )
+        val y = FOLVar( "y" )
+        val Px = Atom( "P", x :: Nil )
+        val Py = Atom( "P", y :: Nil )
 
-        val p1 = InitialClause(List(Px), List.empty)
-        val resProof = Variant(p1, Substitution(new Map1(x, y)))
+        val p1 = InitialClause( List( Px ), List.empty )
+        val resProof = Variant( p1, Substitution( new Map1( x, y ) ) )
 
-        val lkProof = Axiom(List(Py), List())
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val lkProof = Axiom( List( Py ), List() )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
       "containing a resolution clause" in {
-        val x = FOLVar("x")
-        val a = FOLConst("a")
-        val fa = Function("f", a::Nil)
-        val ffa = Function("f", fa::Nil)
-        val fx = Function("f", x::Nil)
-        val Px = Atom("P", x::Nil)
-        val Pfx = Atom("P", fx::Nil)
-        val Pfa = Atom("P", fa::Nil)
-        val Pffa = Atom("P", ffa::Nil)
+        val x = FOLVar( "x" )
+        val a = FOLConst( "a" )
+        val fa = Function( "f", a :: Nil )
+        val ffa = Function( "f", fa :: Nil )
+        val fx = Function( "f", x :: Nil )
+        val Px = Atom( "P", x :: Nil )
+        val Pfx = Atom( "P", fx :: Nil )
+        val Pfa = Atom( "P", fa :: Nil )
+        val Pffa = Atom( "P", ffa :: Nil )
 
-        val p1 = InitialClause(List(Px), List(Pfx))
-        val p2 = InitialClause(List(Pffa), List(Pfa))
-        val resProof = Resolution(p2, p1, p2.root.positive(0), p1.root.negative(0), Substitution(new Map1(x, fa)))
+        val p1 = InitialClause( List( Px ), List( Pfx ) )
+        val p2 = InitialClause( List( Pffa ), List( Pfa ) )
+        val resProof = Resolution( p2, p1, p2.root.positive( 0 ), p1.root.negative( 0 ), Substitution( new Map1( x, fa ) ) )
 
-        val l1 = Axiom(List(Pfa), List(Pffa))
-        val l2 = Axiom(List(Pffa), List(Pfa))
-        val lkProof = CutRule(l2, l1, l2.root.succedent(0), l1.root.antecedent(0))
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val l1 = Axiom( List( Pfa ), List( Pffa ) )
+        val l2 = Axiom( List( Pffa ), List( Pfa ) )
+        val lkProof = CutRule( l2, l1, l2.root.succedent( 0 ), l1.root.antecedent( 0 ) )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
       "containing a paramodulation clause for rule 1" in {
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val x = FOLVar("x")
-        val exb = Equation(x, b)
-        val eab = Equation(a, b)
-        val Pfa = Atom("P", Function("f", a::Nil)::Nil)
-        val Pfb = Atom("P", Function("f", b::Nil)::Nil)
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val x = FOLVar( "x" )
+        val exb = Equation( x, b )
+        val eab = Equation( a, b )
+        val Pfa = Atom( "P", Function( "f", a :: Nil ) :: Nil )
+        val Pfb = Atom( "P", Function( "f", b :: Nil ) :: Nil )
 
-        val p1 = InitialClause(List(), List(exb))
-        val p2 = InitialClause(List(Pfa), List())
-        val resProof = Paramodulation(p1, p2, p1.root.positive(0), p2.root.negative(0), Pfb, Substitution(new Map1(x, a)))
+        val p1 = InitialClause( List(), List( exb ) )
+        val p2 = InitialClause( List( Pfa ), List() )
+        val resProof = Paramodulation( p1, p2, p1.root.positive( 0 ), p2.root.negative( 0 ), Pfb, Substitution( new Map1( x, a ) ) )
 
-        val l1 = Axiom(List(), List(eab))
-        val l2 = Axiom(List(Pfa), List())
-        val lkProof = EquationLeft1Rule(l1, l2, l1.root.succedent(0), l2.root.antecedent(0), Pfb)
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val l1 = Axiom( List(), List( eab ) )
+        val l2 = Axiom( List( Pfa ), List() )
+        val lkProof = EquationLeft1Rule( l1, l2, l1.root.succedent( 0 ), l2.root.antecedent( 0 ), Pfb )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
       "containing a paramodulation clause for rule 2" in {
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        val x = FOLVar("x")
-        val ebx = Equation(b, x)
-        val eba = Equation(b, a)
-        val Pfa = Atom("P", Function("f", a::Nil)::Nil)
-        val Pfb = Atom("P", Function("f", b::Nil)::Nil)
+        val a = FOLConst( "a" )
+        val b = FOLConst( "b" )
+        val x = FOLVar( "x" )
+        val ebx = Equation( b, x )
+        val eba = Equation( b, a )
+        val Pfa = Atom( "P", Function( "f", a :: Nil ) :: Nil )
+        val Pfb = Atom( "P", Function( "f", b :: Nil ) :: Nil )
 
-        val p1 = InitialClause(List(), List(ebx))
-        val p2 = InitialClause(List(Pfa), List())
-        val resProof = Paramodulation(p1, p2, p1.root.positive(0), p2.root.negative(0), Pfb, Substitution(new Map1(x, a)))
+        val p1 = InitialClause( List(), List( ebx ) )
+        val p2 = InitialClause( List( Pfa ), List() )
+        val resProof = Paramodulation( p1, p2, p1.root.positive( 0 ), p2.root.negative( 0 ), Pfb, Substitution( new Map1( x, a ) ) )
 
-        val l1 = Axiom(List(), List(eba))
-        val l2 = Axiom(List(Pfa), List())
-        val lkProof = EquationLeft2Rule(l1, l2, l1.root.succedent(0), l2.root.antecedent(0), Pfb)
-        RobinsonToLK(resProof).toString must beEqualTo(lkProof.toString)
+        val l1 = Axiom( List(), List( eba ) )
+        val l2 = Axiom( List( Pfa ), List() )
+        val lkProof = EquationLeft2Rule( l1, l2, l1.root.succedent( 0 ), l2.root.antecedent( 0 ), Pfb )
+        RobinsonToLK( resProof ).toString must beEqualTo( lkProof.toString )
       }
     }
     "transform a resolution proof into an LK proof of the weakly quantified sequent" in {
       "∀xPx |-  Pa" in {
-        val x = FOLVar("x")
-        val y = FOLVar("y")
-        val a = FOLConst("a")
-        val Px = Atom("P", x::Nil)
-        val Pa = Atom("P", a::Nil)
-        val f1 = AllVar(x, Px)
+        val x = FOLVar( "x" )
+        val y = FOLVar( "y" )
+        val a = FOLConst( "a" )
+        val Px = Atom( "P", x :: Nil )
+        val Pa = Atom( "P", a :: Nil )
+        val f1 = AllVar( x, Px )
 
-        val seq = FSequent(List(f1),List(Pa))
-        val p1 = InitialClause(List(), List(Px))
-        val p2 = InitialClause(List(Pa), List())
-        val v1 = Variant(p1, Substitution(new Map1(x, y)))
-        val resProof = Resolution(v1,p2,v1.root.positive(0), p2.root.negative(0), Substitution(new Map1(y, a)))
-        RobinsonToLK(resProof, seq).root.toFSequent.toString must beEqualTo(FSequent(List(f1),List(Pa)).toString)
+        val seq = FSequent( List( f1 ), List( Pa ) )
+        val p1 = InitialClause( List(), List( Px ) )
+        val p2 = InitialClause( List( Pa ), List() )
+        val v1 = Variant( p1, Substitution( new Map1( x, y ) ) )
+        val resProof = Resolution( v1, p2, v1.root.positive( 0 ), p2.root.negative( 0 ), Substitution( new Map1( y, a ) ) )
+        RobinsonToLK( resProof, seq ).root.toFSequent.toString must beEqualTo( FSequent( List( f1 ), List( Pa ) ).toString )
       }
       "transform the original subproof of the UNS example" in {
-        val r = RobinsonToLK(UNSproof.p4).root
+        val r = RobinsonToLK( UNSproof.p4 ).root
         r.antecedent must beEmpty
-        r.succedent.size mustEqual(1)
-        r.succedent(0).formula mustEqual(UNSproof.c3)
+        r.succedent.size mustEqual ( 1 )
+        r.succedent( 0 ).formula mustEqual ( UNSproof.c3 )
       }
       "transform the subproof of the UNS example with unique variables" in {
-        skipped("does not work! fix!")
-        val r = RobinsonToLK(UNSproofFreshvars.p4).root
+        skipped( "does not work! fix!" )
+        val r = RobinsonToLK( UNSproofFreshvars.p4 ).root
         r.antecedent must beEmpty
-        r.succedent.size mustEqual(1)
-        r.succedent(0).formula mustEqual(UNSproofFreshvars.c3)
+        r.succedent.size mustEqual ( 1 )
+        r.succedent( 0 ).formula mustEqual ( UNSproofFreshvars.c3 )
       }
       "transform the subproof of the UNS example with introduced variant" in {
-        skipped("does not work! fix!")
-        val r = RobinsonToLK(UNSproofVariant.p4).root
+        skipped( "does not work! fix!" )
+        val r = RobinsonToLK( UNSproofVariant.p4 ).root
         r.antecedent must beEmpty
-        r.succedent.size mustEqual(1)
-        r.succedent(0).formula mustEqual(UNSproofVariant.c3)
+        r.succedent.size mustEqual ( 1 )
+        r.succedent( 0 ).formula mustEqual ( UNSproofVariant.c3 )
       }
     }
   }

--- a/src/test/scala/at/logic/algorithms/resolution/fixDerivationTest.scala
+++ b/src/test/scala/at/logic/algorithms/resolution/fixDerivationTest.scala
@@ -4,88 +4,88 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import at.logic.language.lambda.types.To
-import at.logic.language.fol.{Equation => FOLEquation, And, Or, Neg, Atom, FOLConst, Imp, FOLVar, Substitution}
+import at.logic.language.fol.{ Equation => FOLEquation, And, Or, Neg, Atom, FOLConst, Imp, FOLVar, Substitution }
 import at.logic.calculi.resolution._
 import at.logic.calculi.resolution.robinson._
 import at.logic.calculi.lk.base.FSequent
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class FixDerivationTest extends SpecificationWithJUnit {
   "fixDerivation" should {
     "not say that p :- is derivable from p :- p, r by symmetry" in {
       val p = Atom( "p", Nil )
       val r = Atom( "r", Nil )
-      val to = FClause( p::Nil, Nil )
-      val from = FSequent( p::Nil, p::r::Nil )
+      val to = FClause( p :: Nil, Nil )
+      val from = FSequent( p :: Nil, p :: r :: Nil )
 
       fixDerivation.canDeriveBySymmetry( to, from ) must beFalse
     }
 
     "say that a=b, b=c :- c=d is derivable from c=b, a=b :- d=c" in {
-      val a = FOLConst("a")
-      val b = FOLConst("b")
-      val c = FOLConst("c")
-      val d = FOLConst("d")
+      val a = FOLConst( "a" )
+      val b = FOLConst( "b" )
+      val c = FOLConst( "c" )
+      val d = FOLConst( "d" )
       val ab = FOLEquation( a, b )
       val bc = FOLEquation( b, c )
       val cd = FOLEquation( c, d )
       val cb = FOLEquation( c, b )
       val dc = FOLEquation( d, c )
-      val from = FSequent( ab::bc::Nil, cd::Nil )
-      val to = FClause( cb::ab::Nil, dc::Nil )
+      val from = FSequent( ab :: bc :: Nil, cd :: Nil )
+      val to = FClause( cb :: ab :: Nil, dc :: Nil )
 
       fixDerivation.canDeriveBySymmetry( to, from ) must beTrue
     }
 
     "say that p(a) :- q(x) can be derived by factoring from p(x), p(y) :- q(u), q(v)" in {
-      val a = FOLConst("a")
-      val x = FOLVar("x")
-      val y = FOLVar("y")
-      val u = FOLVar("u")
-      val v = FOLVar("v")
-      val pa = Atom("p", a::Nil)
-      val px = Atom("p", x::Nil)
-      val py = Atom("p", y::Nil)
-      val qx = Atom("q", x::Nil)
-      val qu = Atom("q", u::Nil)
-      val qv = Atom("q", v::Nil)
+      val a = FOLConst( "a" )
+      val x = FOLVar( "x" )
+      val y = FOLVar( "y" )
+      val u = FOLVar( "u" )
+      val v = FOLVar( "v" )
+      val pa = Atom( "p", a :: Nil )
+      val px = Atom( "p", x :: Nil )
+      val py = Atom( "p", y :: Nil )
+      val qx = Atom( "q", x :: Nil )
+      val qu = Atom( "q", u :: Nil )
+      val qv = Atom( "q", v :: Nil )
 
-      val to = FClause( pa::Nil, qx::Nil )
-      val from = FSequent( px::py::Nil, qu::qv::Nil )
+      val to = FClause( pa :: Nil, qx :: Nil )
+      val from = FSequent( px :: py :: Nil, qu :: qv :: Nil )
 
       fixDerivation.canDeriveByFactor( to, from ) must beTrue
     }
 
     "obtain a derivation of :- p from { :- q; q :- p } from a derivation of :- p, r from { :- q, r; q :- p }" in {
-      val p = Atom("p")
-      val q = Atom("q")
-      val r = Atom("r")
+      val p = Atom( "p" )
+      val q = Atom( "q" )
+      val r = Atom( "r" )
 
-      val der = Resolution(InitialClause(Nil, q::r::Nil), InitialClause(q::Nil, p::Nil), q, q, Substitution())
-      val cq = FSequent(Nil, q::Nil)
-      val cqp = FSequent(q::Nil, p::Nil)
+      val der = Resolution( InitialClause( Nil, q :: r :: Nil ), InitialClause( q :: Nil, p :: Nil ), q, q, Substitution() )
+      val cq = FSequent( Nil, q :: Nil )
+      val cqp = FSequent( q :: Nil, p :: Nil )
 
-      val cp = FSequent(Nil, p::Nil)
+      val cp = FSequent( Nil, p :: Nil )
 
-      fixDerivation( der, cq::cqp::Nil ).root.toFSequent must beEqualTo(cp)
+      fixDerivation( der, cq :: cqp :: Nil ).root.toFSequent must beEqualTo( cp )
     }
 
     "obtain a derivation of :- p from { :- q; q :- p } from a derivation of :- p, r from { :- q, r; q :- p, p }" in {
-      val p = Atom("p")
-      val q = Atom("q")
-      val r = Atom("r")
+      val p = Atom( "p" )
+      val q = Atom( "q" )
+      val r = Atom( "r" )
 
-      val der = Resolution(InitialClause(Nil, q::r::Nil), 
+      val der = Resolution( InitialClause( Nil, q :: r :: Nil ),
         Factor(
-          InitialClause(q::Nil, p::p::Nil),
-        p, 2, true, Substitution()),
-      q, q, Substitution())
-      val cq = FSequent(Nil, q::Nil)
-      val cqp = FSequent(q::Nil, p::Nil)
+          InitialClause( q :: Nil, p :: p :: Nil ),
+          p, 2, true, Substitution() ),
+        q, q, Substitution() )
+      val cq = FSequent( Nil, q :: Nil )
+      val cqp = FSequent( q :: Nil, p :: Nil )
 
-      val cp = FSequent(Nil, p::Nil)
+      val cp = FSequent( Nil, p :: Nil )
 
-      fixDerivation( der, cq::cqp::Nil ).root.toFSequent must beEqualTo(cp)
+      fixDerivation( der, cq :: cqp :: Nil ).root.toFSequent must beEqualTo( cp )
     }
 
   }

--- a/src/test/scala/at/logic/algorithms/rewriting/TermReplacementTest.scala
+++ b/src/test/scala/at/logic/algorithms/rewriting/TermReplacementTest.scala
@@ -10,115 +10,115 @@ import at.logic.calculi.resolution.robinson._
 /**
  * Test for replacment of constant symbols by terms
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class TermReplacementTest extends SpecificationWithJUnit {
-    
-  val c1 = Atom("P", Function("g", FOLConst("a")::Nil)::Nil)
-  val c2 = Atom("P", Function("g", FOLVar("x")::Nil)::Nil)
-  val c3 = Atom("Q", Function("f", FOLConst("ladr0")::Nil)::Nil)
-  val c4 = Atom("Q", FOLVar("x")::Nil)
-  
-  val x = FOLVar("x")
-  val a = FOLConst("a")
-  val fl = Function("f", FOLConst("ladr0")::Nil)
-  
-  val d1 = Atom("R", Function("f", FOLConst("a")::Nil)::Nil)
-  val d2 = Atom("R", Function("f", FOLVar("x")::Nil)::Nil)
-  val d3 = Atom("Q", Function("h", FOLConst("c0")::Nil)::Nil)
-  val d4 = Atom("Q", FOLVar("x")::Nil)
-  
-  val hc = Function("h", FOLConst("c0")::Nil)
+
+  val c1 = Atom( "P", Function( "g", FOLConst( "a" ) :: Nil ) :: Nil )
+  val c2 = Atom( "P", Function( "g", FOLVar( "x" ) :: Nil ) :: Nil )
+  val c3 = Atom( "Q", Function( "f", FOLConst( "ladr0" ) :: Nil ) :: Nil )
+  val c4 = Atom( "Q", FOLVar( "x" ) :: Nil )
+
+  val x = FOLVar( "x" )
+  val a = FOLConst( "a" )
+  val fl = Function( "f", FOLConst( "ladr0" ) :: Nil )
+
+  val d1 = Atom( "R", Function( "f", FOLConst( "a" ) :: Nil ) :: Nil )
+  val d2 = Atom( "R", Function( "f", FOLVar( "x" ) :: Nil ) :: Nil )
+  val d3 = Atom( "Q", Function( "h", FOLConst( "c0" ) :: Nil ) :: Nil )
+  val d4 = Atom( "Q", FOLVar( "x" ) :: Nil )
+
+  val hc = Function( "h", FOLConst( "c0" ) :: Nil )
 
   object proof1 {
-    val s1 = Substitution(Map(x -> a))
-    val s2 = Substitution(Map(x -> fl))
-    val p1 = InitialClause(List(c1,c1), List(c3))
-    val p2 = InitialClause(Nil, List(c2))
-    val p3 = InitialClause(List(c4), Nil)
-    val p5 = Resolution(p2, p1, p2.root.positive(0), p1.root.negative(1), s1)
-    val p6 = Resolution(p5, p3, p5.root.positive(0) ,p3.root.negative(0), s2)
-    val p7 = Resolution(p2, p6, p2.root.positive(0), p6.root.negative(0), s1)
+    val s1 = Substitution( Map( x -> a ) )
+    val s2 = Substitution( Map( x -> fl ) )
+    val p1 = InitialClause( List( c1, c1 ), List( c3 ) )
+    val p2 = InitialClause( Nil, List( c2 ) )
+    val p3 = InitialClause( List( c4 ), Nil )
+    val p5 = Resolution( p2, p1, p2.root.positive( 0 ), p1.root.negative( 1 ), s1 )
+    val p6 = Resolution( p5, p3, p5.root.positive( 0 ), p3.root.negative( 0 ), s2 )
+    val p7 = Resolution( p2, p6, p2.root.positive( 0 ), p6.root.negative( 0 ), s1 )
   }
 
   object proof2 {
-    val r1 = Substitution(Map(x -> a))
-    val r2 = Substitution(Map(x -> hc))
-    val q1 = InitialClause(List(d1,d1), List(d3))
-    val q2 = InitialClause(Nil, List(d2))
-    val q3 = InitialClause(List(d4), Nil)
-    val q5 = Resolution(q2, q1, q2.root.positive(0), q1.root.negative(1), r1)
-    val q6 = Resolution(q5, q3, q5.root.positive(0) ,q3.root.negative(0), r2)
-    val q7 = Resolution(q2, q6, q2.root.positive(0), q6.root.negative(0), r1)
+    val r1 = Substitution( Map( x -> a ) )
+    val r2 = Substitution( Map( x -> hc ) )
+    val q1 = InitialClause( List( d1, d1 ), List( d3 ) )
+    val q2 = InitialClause( Nil, List( d2 ) )
+    val q3 = InitialClause( List( d4 ), Nil )
+    val q5 = Resolution( q2, q1, q2.root.positive( 0 ), q1.root.negative( 1 ), r1 )
+    val q6 = Resolution( q5, q3, q5.root.positive( 0 ), q3.root.negative( 0 ), r2 )
+    val q7 = Resolution( q2, q6, q2.root.positive( 0 ), q6.root.negative( 0 ), r1 )
   }
 
   object proof3 {
-    val s1 = Substitution(Map(x -> a))
-    val s2 = Substitution(Map(x -> fl))
-    val p0 = InitialClause(List(c1,c2), List(c3))
-    val p1 = Factor(p0, p0.root.negative(1), p0.root.negative(0)::Nil, Substitution())
-    val p2 = InitialClause(Nil, List(c2))
-    val p3 = InitialClause(List(c4), Nil)
-    val p5 = Resolution(p2, p1, p2.root.positive(0), p1.root.negative(0), s1)
-    val p6 = Resolution(p5, p3, p5.root.positive(0) ,p3.root.negative(0), s2)
+    val s1 = Substitution( Map( x -> a ) )
+    val s2 = Substitution( Map( x -> fl ) )
+    val p0 = InitialClause( List( c1, c2 ), List( c3 ) )
+    val p1 = Factor( p0, p0.root.negative( 1 ), p0.root.negative( 0 ) :: Nil, Substitution() )
+    val p2 = InitialClause( Nil, List( c2 ) )
+    val p3 = InitialClause( List( c4 ), Nil )
+    val p5 = Resolution( p2, p1, p2.root.positive( 0 ), p1.root.negative( 0 ), s1 )
+    val p6 = Resolution( p5, p3, p5.root.positive( 0 ), p3.root.negative( 0 ), s2 )
   }
 
   object proof4 {
-    val r1 = Substitution(Map(x -> a))
-    val r2 = Substitution(Map(x -> hc))
+    val r1 = Substitution( Map( x -> a ) )
+    val r2 = Substitution( Map( x -> hc ) )
     val r3 = Substitution()
-    val q0 = InitialClause(List(d1,d2), List(d3))
-    val q1 = Factor(q0, q0.root.negative(0), q0.root.negative(1)::Nil, r2)
-    val q2 = InitialClause(Nil, List(d2))
-    val q3 = InitialClause(List(d4), Nil)
-    val q5 = Resolution(q2, q1, q2.root.positive(0), q1.root.negative(0), r1)
-    val q6 = Resolution(q5, q3, q5.root.positive(0) ,q3.root.negative(0), r2)
+    val q0 = InitialClause( List( d1, d2 ), List( d3 ) )
+    val q1 = Factor( q0, q0.root.negative( 0 ), q0.root.negative( 1 ) :: Nil, r2 )
+    val q2 = InitialClause( Nil, List( d2 ) )
+    val q3 = InitialClause( List( d4 ), Nil )
+    val q5 = Resolution( q2, q1, q2.root.positive( 0 ), q1.root.negative( 0 ), r1 )
+    val q6 = Resolution( q5, q3, q5.root.positive( 0 ), q3.root.negative( 0 ), r2 )
 
   }
-  
+
   "Term replacement " should {
     " work on lambda terms " in {
-      
-      val termx = Function("term", FOLVar("x")::Nil)
-      val terma = Function("term", FOLConst("a")::Nil)
-      val hihix = Function("hihi", FOLVar("x")::Nil)
 
-      val o1 = Function("g", Function("f", Function("g", FOLConst("f")::Nil)::FOLConst("c")::Nil) :: Function("f", FOLVar("x")::FOLConst("f")::Nil) :: Nil)
-      val o2 = Function("term", termx :: terma :: terma :: termx :: Nil)
+      val termx = Function( "term", FOLVar( "x" ) :: Nil )
+      val terma = Function( "term", FOLConst( "a" ) :: Nil )
+      val hihix = Function( "hihi", FOLVar( "x" ) :: Nil )
 
-      val r1 = Function("g", Function("f", Function("g", FOLVar("x")::Nil)::FOLConst("c")::Nil) :: Function("f", FOLVar("x")::FOLVar("x")::Nil) :: Nil)
-      val r2 = Function("term", hihix :: terma :: terma :: hihix :: Nil)
+      val o1 = Function( "g", Function( "f", Function( "g", FOLConst( "f" ) :: Nil ) :: FOLConst( "c" ) :: Nil ) :: Function( "f", FOLVar( "x" ) :: FOLConst( "f" ) :: Nil ) :: Nil )
+      val o2 = Function( "term", termx :: terma :: terma :: termx :: Nil )
 
-      val t1 = FOLConst("f")
-      val t2 = FOLVar("x")
-      val t3 = Function("term", FOLVar("x")::Nil)
-      val t4 = Function("hihi", FOLVar("x")::Nil)
+      val r1 = Function( "g", Function( "f", Function( "g", FOLVar( "x" ) :: Nil ) :: FOLConst( "c" ) :: Nil ) :: Function( "f", FOLVar( "x" ) :: FOLVar( "x" ) :: Nil ) :: Nil )
+      val r2 = Function( "term", hihix :: terma :: terma :: hihix :: Nil )
 
-      val rt1 = TermReplacement(o1, t1,t2)
-      val rt2 = TermReplacement(o2, t3,t4)
-      rt1 must be_==(r1)
-      rt2 must be_==(r2)
+      val t1 = FOLConst( "f" )
+      val t2 = FOLVar( "x" )
+      val t3 = Function( "term", FOLVar( "x" ) :: Nil )
+      val t4 = Function( "hihi", FOLVar( "x" ) :: Nil )
 
-      val map = Map[FOLExpression, FOLExpression]((t1 -> t2), (t3 -> t4))
-      rt1 must be_==(TermReplacement(o1,map))
-      rt2 must be_==(TermReplacement(o2,map))
+      val rt1 = TermReplacement( o1, t1, t2 )
+      val rt2 = TermReplacement( o2, t3, t4 )
+      rt1 must be_==( r1 )
+      rt2 must be_==( r2 )
+
+      val map = Map[FOLExpression, FOLExpression]( ( t1 -> t2 ), ( t3 -> t4 ) )
+      rt1 must be_==( TermReplacement( o1, map ) )
+      rt2 must be_==( TermReplacement( o2, map ) )
     }
 
     " work on simple proofs " in {
-      
-      val t1 = Function("replacement", FOLVar("x0") :: FOLVar("y0") :: Nil)
-      val t2 = Function("really", FOLVar("x1") :: Nil)
-      
-      val map : RenameResproof.SymbolMap = RenameResproof.emptySymbolMap ++ List((a,t1), (hc,t2))
 
-      val initial = RenameResproof.rename_resproof(proof4.q0, Set[RobinsonResolutionProof](), map)
+      val t1 = Function( "replacement", FOLVar( "x0" ) :: FOLVar( "y0" ) :: Nil )
+      val t2 = Function( "really", FOLVar( "x1" ) :: Nil )
 
-      val r1 = Atom("R", Function("f", t1::Nil)::Nil)
-      val r2 = Atom("R", Function("f", FOLVar("x")::Nil)::Nil)
-      val r3 = Atom("Q", t2::Nil)
+      val map: RenameResproof.SymbolMap = RenameResproof.emptySymbolMap ++ List( ( a, t1 ), ( hc, t2 ) )
 
-      initial.root.occurrences.toList.map(_.formula) must_== (List(r1, r2, r3))
+      val initial = RenameResproof.rename_resproof( proof4.q0, Set[RobinsonResolutionProof](), map )
 
-      val more = RenameResproof.rename_resproof(proof4.q6, Set[RobinsonResolutionProof](), map)
+      val r1 = Atom( "R", Function( "f", t1 :: Nil ) :: Nil )
+      val r2 = Atom( "R", Function( "f", FOLVar( "x" ) :: Nil ) :: Nil )
+      val r3 = Atom( "Q", t2 :: Nil )
+
+      initial.root.occurrences.toList.map( _.formula ) must_== ( List( r1, r2, r3 ) )
+
+      val more = RenameResproof.rename_resproof( proof4.q6, Set[RobinsonResolutionProof](), map )
 
       true must beTrue
     }

--- a/src/test/scala/at/logic/algorithms/rewriting/definition_eliminationTest.scala
+++ b/src/test/scala/at/logic/algorithms/rewriting/definition_eliminationTest.scala
@@ -4,117 +4,117 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import at.logic.language.fol._
-import at.logic.language.lambda.symbols.{StringSymbol}
+import at.logic.language.lambda.symbols.{ StringSymbol }
 import at.logic.calculi.lk._
 import at.logic.language.hol.HOLExpression
-import at.logic.calculi.lk.base.{beSyntacticFSequentEqual, FSequent, Sequent, LKProof}
+import at.logic.calculi.lk.base.{ beSyntacticFSequentEqual, FSequent, Sequent, LKProof }
 import at.logic.calculi.proofs.NullaryProof
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class definition_eliminationTest extends SpecificationWithJUnit {
   object proof1 {
-    val List(alphasym, betasym, xsym, ysym) = List("\\alpha","\\beta","x","y")
-    val List(p,q,a,b,tsym) = List("P","Q","A","B","t")
-    val List(t) = List(tsym) map (FOLConst.apply)
-    val List(alpha,beta,x,y) = List(alphasym, betasym, xsym, ysym).map(FOLVar.apply)
-    val qa = Atom(q, alpha::Nil)
-    val qx = Atom(q, x::Nil)
-    val pab = Atom(p, List(alpha,beta))
-    val pay = Atom(p, List(alpha,y))
-    val pty = Atom(p, List(t,y))
-    val pxy = Atom(p, List(x,y))
-    val ax =  Atom(a,x::Nil)
-    val at =  Atom(a,t::Nil)
-    val aa =  Atom(a,alpha::Nil)
-    val bx = Atom(b,x::Nil)
-    val eqxt = Equation(x,t)
-    val allypay = AllVar(y,pay)
-    val allypty = AllVar(y,pty)
-    val allypxy = AllVar(y, pxy)
-    val allxypxy = AllVar(x, allypxy )
-    val allxax = AllVar(x, ax)
-    val exformula = ExVar(x, And(qx, ax))
+    val List( alphasym, betasym, xsym, ysym ) = List( "\\alpha", "\\beta", "x", "y" )
+    val List( p, q, a, b, tsym ) = List( "P", "Q", "A", "B", "t" )
+    val List( t ) = List( tsym ) map ( FOLConst.apply )
+    val List( alpha, beta, x, y ) = List( alphasym, betasym, xsym, ysym ).map( FOLVar.apply )
+    val qa = Atom( q, alpha :: Nil )
+    val qx = Atom( q, x :: Nil )
+    val pab = Atom( p, List( alpha, beta ) )
+    val pay = Atom( p, List( alpha, y ) )
+    val pty = Atom( p, List( t, y ) )
+    val pxy = Atom( p, List( x, y ) )
+    val ax = Atom( a, x :: Nil )
+    val at = Atom( a, t :: Nil )
+    val aa = Atom( a, alpha :: Nil )
+    val bx = Atom( b, x :: Nil )
+    val eqxt = Equation( x, t )
+    val allypay = AllVar( y, pay )
+    val allypty = AllVar( y, pty )
+    val allypxy = AllVar( y, pxy )
+    val allxypxy = AllVar( x, allypxy )
+    val allxax = AllVar( x, ax )
+    val exformula = ExVar( x, And( qx, ax ) )
 
-    val i1 = Axiom(List(qa), List(qa))
-    val i2 = ForallLeftRule(i1, i1.root.antecedent(0), AllVar(x,qx), alpha)
+    val i1 = Axiom( List( qa ), List( qa ) )
+    val i2 = ForallLeftRule( i1, i1.root.antecedent( 0 ), AllVar( x, qx ), alpha )
 
-    val i3 = Axiom(List(pab),List(pab))
-    val i4 = ForallLeftRule(i3, i3.root.antecedent(0), allypay, beta)
-    val i5 = ForallRightRule(i4, i4.root.succedent(0), allypay, beta)
-    val i6 = DefinitionRightRule(i5, i5.root.succedent(0), aa)
-    val i7 = ForallLeftRule(i6, i6.root.antecedent(0), allxypxy , alpha)
-    val i8 = DefinitionLeftRule(i7, i7.root.antecedent(0), allxax )
-    val i9 = AndRightRule(i2, i8, i2.root.succedent(0), i8.root.succedent(0))
-    val i10 = ExistsRightRule(i9, i9.root.succedent(0), exformula , alpha)
-    val i11 = DefinitionRightRule(i10, i10.root.succedent(0), ExVar(x, bx))
-    val i12 = AndLeft2Rule(i11, ax, i11.root.antecedent(0))
+    val i3 = Axiom( List( pab ), List( pab ) )
+    val i4 = ForallLeftRule( i3, i3.root.antecedent( 0 ), allypay, beta )
+    val i5 = ForallRightRule( i4, i4.root.succedent( 0 ), allypay, beta )
+    val i6 = DefinitionRightRule( i5, i5.root.succedent( 0 ), aa )
+    val i7 = ForallLeftRule( i6, i6.root.antecedent( 0 ), allxypxy, alpha )
+    val i8 = DefinitionLeftRule( i7, i7.root.antecedent( 0 ), allxax )
+    val i9 = AndRightRule( i2, i8, i2.root.succedent( 0 ), i8.root.succedent( 0 ) )
+    val i10 = ExistsRightRule( i9, i9.root.succedent( 0 ), exformula, alpha )
+    val i11 = DefinitionRightRule( i10, i10.root.succedent( 0 ), ExVar( x, bx ) )
+    val i12 = AndLeft2Rule( i11, ax, i11.root.antecedent( 0 ) )
 
-    val i13 = Axiom(eqxt::Nil, eqxt::Nil)
-    val i14 = EquationLeft1Rule(i13,i12,i13.root.succedent(0), i12.root.antecedent(1), And(at, AllVar(x, qx)) )
-    getoccids(i14, Nil) map println
+    val i13 = Axiom( eqxt :: Nil, eqxt :: Nil )
+    val i14 = EquationLeft1Rule( i13, i12, i13.root.succedent( 0 ), i12.root.antecedent( 1 ), And( at, AllVar( x, qx ) ) )
+    getoccids( i14, Nil ) map println
 
-    val def1 = (ax, AllVar(y, pxy))
-    val def2 = (bx, And(qx,ax))
-    val dmap = Map[HOLExpression, HOLExpression]() + def1 +def2
+    val def1 = ( ax, AllVar( y, pxy ) )
+    val def2 = ( bx, And( qx, ax ) )
+    val dmap = Map[HOLExpression, HOLExpression]() + def1 + def2
 
-    def getoccids(p:LKProof, l : List[String]) : List[String] = p match {
-      case r:NullaryProof[Sequent] =>
-        val line = r.rule +": "+  r.root.antecedent.map(_.id).mkString(",") + " :- " + (r.root.succedent.map(_.id).mkString(","))
-        line::Nil
-      case r@UnaryLKProof(_, p1, root, _, _) =>
-        val line = r.rule +": "+ root.antecedent.map(_.id).mkString(",") + " :- " + (root.succedent.map(_.id).mkString(","))
-        getoccids(p1, line::l) :+ line
-      case r@BinaryLKProof(_, p1, p2, root, _, _,  _) =>
-        val line = r.rule +": "+ root.antecedent.map(_.id).mkString(",") + " :- " + (root.succedent.map(_.id).mkString(","))
-        val rec1 = getoccids(p1, line::l)
-        val rec2 = getoccids(p2, rec1)
-        (rec1 ++ rec2) :+ line
+    def getoccids( p: LKProof, l: List[String] ): List[String] = p match {
+      case r: NullaryProof[Sequent] =>
+        val line = r.rule + ": " + r.root.antecedent.map( _.id ).mkString( "," ) + " :- " + ( r.root.succedent.map( _.id ).mkString( "," ) )
+        line :: Nil
+      case r @ UnaryLKProof( _, p1, root, _, _ ) =>
+        val line = r.rule + ": " + root.antecedent.map( _.id ).mkString( "," ) + " :- " + ( root.succedent.map( _.id ).mkString( "," ) )
+        getoccids( p1, line :: l ) :+ line
+      case r @ BinaryLKProof( _, p1, p2, root, _, _, _ ) =>
+        val line = r.rule + ": " + root.antecedent.map( _.id ).mkString( "," ) + " :- " + ( root.succedent.map( _.id ).mkString( "," ) )
+        val rec1 = getoccids( p1, line :: l )
+        val rec2 = getoccids( p2, rec1 )
+        ( rec1 ++ rec2 ) :+ line
 
     }
 
   }
 
   /**
-    * The following tests are all commented out for the same reason. One of the
-    * definitions used for them is the following:
-    * 
-    * A(x) -> \forall x. P(x, y)
-    *
-    * Which seems ok in principle. The problem happens when the
-    * NaiveIncompleteMatchingAlgorithm is run. It sees that these are two
-    * applications (of A to x and of forall to P(x,y)) and recursively calls
-    * itself. When it gets to the variable x, it tries to create a substitution 
-    * x <- P(x, y)
-    *
-    * But the substitution cannot be created, since the requirement that both
-    * things need to have the same type fails. In this case, x has type i and
-    * P(x,y) has type (i -> o).
-    *
-    */
+   * The following tests are all commented out for the same reason. One of the
+   * definitions used for them is the following:
+   *
+   * A(x) -> \forall x. P(x, y)
+   *
+   * Which seems ok in principle. The problem happens when the
+   * NaiveIncompleteMatchingAlgorithm is run. It sees that these are two
+   * applications (of A to x and of forall to P(x,y)) and recursively calls
+   * itself. When it gets to the variable x, it tries to create a substitution
+   * x <- P(x, y)
+   *
+   * But the substitution cannot be created, since the requirement that both
+   * things need to have the same type fails. In this case, x has type i and
+   * P(x,y) has type (i -> o).
+   *
+   */
 
   "Definition elimination" should {
     "work on formulas" in {
-      skipped("Failing on HOL matching")
-      val f = And(proof1.ax,Or(Atom(proof1.a,proof1.t::Nil), proof1.bx))
-      val f_ = DefinitionElimination(proof1.dmap,f)
-      println(f_)
-      val correct_f = And(proof1.allypxy,Or(proof1.allypty, And(proof1.qx, proof1.allypxy)))
-      f_ mustEqual(correct_f)
+      skipped( "Failing on HOL matching" )
+      val f = And( proof1.ax, Or( Atom( proof1.a, proof1.t :: Nil ), proof1.bx ) )
+      val f_ = DefinitionElimination( proof1.dmap, f )
+      println( f_ )
+      val correct_f = And( proof1.allypxy, Or( proof1.allypty, And( proof1.qx, proof1.allypxy ) ) )
+      f_ mustEqual ( correct_f )
     }
 
     "work on a simple proof" in {
-      skipped("Failing on HOL matching")
+      skipped( "Failing on HOL matching" )
       import proof1._
       val elp = DefinitionElimination( dmap, i12 )
-      println(elp)
-      val expected = FSequent(List(AllVar(x,AllVar(y, pxy)), And(AllVar(y,pxy), AllVar(x,qx))), List(ExVar(x, And(qx, AllVar(y,pxy)))))
-      expected must beSyntacticFSequentEqual(elp.root.toFSequent)
+      println( elp )
+      val expected = FSequent( List( AllVar( x, AllVar( y, pxy ) ), And( AllVar( y, pxy ), AllVar( x, qx ) ) ), List( ExVar( x, And( qx, AllVar( y, pxy ) ) ) ) )
+      expected must beSyntacticFSequentEqual( elp.root.toFSequent )
     }
 
     "work on a simple proof with equality" in {
-      skipped("Failing on HOL matching")
+      skipped( "Failing on HOL matching" )
       val elp = DefinitionElimination( proof1.dmap, proof1.i14 )
-      println(elp)
+      println( elp )
       ok
     }
 

--- a/src/test/scala/at/logic/algorithms/rewriting/name_replacementTest.scala
+++ b/src/test/scala/at/logic/algorithms/rewriting/name_replacementTest.scala
@@ -4,165 +4,163 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import at.logic.language.fol._
-import at.logic.language.hol.{HOLConst, HOLVar, Atom => HOLAtom, Function => HOLFunction, And => HOLAnd, Or => HOLOr, Neg => HOLNeg}
+import at.logic.language.hol.{ HOLConst, HOLVar, Atom => HOLAtom, Function => HOLFunction, And => HOLAnd, Or => HOLOr, Neg => HOLNeg }
 import at.logic.language.lambda.types._
 import at.logic.calculi.resolution.robinson._
 import at.logic.calculi.resolution._
-import at.logic.utils.ds.acyclicGraphs.{BinaryAGraph, UnaryAGraph, LeafAGraph, AGraph}
+import at.logic.utils.ds.acyclicGraphs.{ BinaryAGraph, UnaryAGraph, LeafAGraph, AGraph }
 
 /**
  * Test for renaming of constant symbols
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class name_replacementTest extends SpecificationWithJUnit {
 
-  val c1 = Atom("P", Function("g", FOLConst("a")::Nil)::Nil)
-  val c2 = Atom("P", Function("g", FOLVar("x")::Nil)::Nil)
-  val c3 = Atom("Q", Function("f", FOLConst("ladr0")::Nil)::Nil)
-  val c4 = Atom("Q", FOLVar("x")::Nil)
+  val c1 = Atom( "P", Function( "g", FOLConst( "a" ) :: Nil ) :: Nil )
+  val c2 = Atom( "P", Function( "g", FOLVar( "x" ) :: Nil ) :: Nil )
+  val c3 = Atom( "Q", Function( "f", FOLConst( "ladr0" ) :: Nil ) :: Nil )
+  val c4 = Atom( "Q", FOLVar( "x" ) :: Nil )
 
-  val x = FOLVar("x")
-  val a = FOLConst("a")
-  val fl = Function("f", FOLConst("ladr0")::Nil)
+  val x = FOLVar( "x" )
+  val a = FOLConst( "a" )
+  val fl = Function( "f", FOLConst( "ladr0" ) :: Nil )
 
-  val d1 = Atom("R", Function("f", FOLConst("a")::Nil)::Nil)
-  val d2 = Atom("R", Function("f", FOLVar("x")::Nil)::Nil)
-  val d3 = Atom("Q", Function("h", FOLConst("c0")::Nil)::Nil)
-  val d4 = Atom("Q", FOLVar("x")::Nil)
+  val d1 = Atom( "R", Function( "f", FOLConst( "a" ) :: Nil ) :: Nil )
+  val d2 = Atom( "R", Function( "f", FOLVar( "x" ) :: Nil ) :: Nil )
+  val d3 = Atom( "Q", Function( "h", FOLConst( "c0" ) :: Nil ) :: Nil )
+  val d4 = Atom( "Q", FOLVar( "x" ) :: Nil )
 
-  val hc = Function("h", FOLConst("c0")::Nil)
+  val hc = Function( "h", FOLConst( "c0" ) :: Nil )
 
   object proof1 {
-    val s1 = Substitution(Map(x -> a))
-    val s2 = Substitution(Map(x -> fl))
-    val p1 = InitialClause(List(c1,c1), List(c3))
-    val p2 = InitialClause(Nil, List(c2))
-    val p3 = InitialClause(List(c4), Nil)
-    val p5 = Resolution(p2, p1, p2.root.positive(0), p1.root.negative(1), s1)
-    val p6 = Resolution(p5, p3, p5.root.positive(0) ,p3.root.negative(0), s2)
-    val p7 = Resolution(p2, p6, p2.root.positive(0), p6.root.negative(0), s1)
+    val s1 = Substitution( Map( x -> a ) )
+    val s2 = Substitution( Map( x -> fl ) )
+    val p1 = InitialClause( List( c1, c1 ), List( c3 ) )
+    val p2 = InitialClause( Nil, List( c2 ) )
+    val p3 = InitialClause( List( c4 ), Nil )
+    val p5 = Resolution( p2, p1, p2.root.positive( 0 ), p1.root.negative( 1 ), s1 )
+    val p6 = Resolution( p5, p3, p5.root.positive( 0 ), p3.root.negative( 0 ), s2 )
+    val p7 = Resolution( p2, p6, p2.root.positive( 0 ), p6.root.negative( 0 ), s1 )
   }
 
   object proof2 {
-    val r1 = Substitution(Map(x -> a))
-    val r2 = Substitution(Map(x -> hc))
-    val q1 = InitialClause(List(d1,d1), List(d3))
-    val q2 = InitialClause(Nil, List(d2))
-    val q3 = InitialClause(List(d4), Nil)
-    val q5 = Resolution(q2, q1, q2.root.positive(0), q1.root.negative(1), r1)
-    val q6 = Resolution(q5, q3, q5.root.positive(0) ,q3.root.negative(0), r2)
-    val q7 = Resolution(q2, q6, q2.root.positive(0), q6.root.negative(0), r1)
+    val r1 = Substitution( Map( x -> a ) )
+    val r2 = Substitution( Map( x -> hc ) )
+    val q1 = InitialClause( List( d1, d1 ), List( d3 ) )
+    val q2 = InitialClause( Nil, List( d2 ) )
+    val q3 = InitialClause( List( d4 ), Nil )
+    val q5 = Resolution( q2, q1, q2.root.positive( 0 ), q1.root.negative( 1 ), r1 )
+    val q6 = Resolution( q5, q3, q5.root.positive( 0 ), q3.root.negative( 0 ), r2 )
+    val q7 = Resolution( q2, q6, q2.root.positive( 0 ), q6.root.negative( 0 ), r1 )
   }
 
   object proof3 {
-    val s1 = Substitution(Map(x -> a))
-    val s2 = Substitution(Map(x -> fl))
-    val p0 = InitialClause(List(c1,c2), List(c3))
-    val p1 = Factor(p0, p0.root.negative(1), p0.root.negative(0)::Nil, Substitution())
-    val p2 = InitialClause(Nil, List(c2))
-    val p3 = InitialClause(List(c4), Nil)
-    val p5 = Resolution(p2, p1, p2.root.positive(0), p1.root.negative(0), s1)
-    val p6 = Resolution(p5, p3, p5.root.positive(0) ,p3.root.negative(0), s2)
+    val s1 = Substitution( Map( x -> a ) )
+    val s2 = Substitution( Map( x -> fl ) )
+    val p0 = InitialClause( List( c1, c2 ), List( c3 ) )
+    val p1 = Factor( p0, p0.root.negative( 1 ), p0.root.negative( 0 ) :: Nil, Substitution() )
+    val p2 = InitialClause( Nil, List( c2 ) )
+    val p3 = InitialClause( List( c4 ), Nil )
+    val p5 = Resolution( p2, p1, p2.root.positive( 0 ), p1.root.negative( 0 ), s1 )
+    val p6 = Resolution( p5, p3, p5.root.positive( 0 ), p3.root.negative( 0 ), s2 )
   }
 
   object proof4 {
     //this proof has errors: the factor rule needs a unification
-    val r1 = Substitution(Map(x -> a))
-    val r2 = Substitution(Map(x -> hc))
-    val q0 = InitialClause(List(d1,d2), List(d3))
-    val q1 = Factor(q0, q0.root.negative(1), q0.root.negative(0)::Nil, Substitution())
-    val q2 = InitialClause(Nil, List(d2))
-    val q3 = InitialClause(List(d4), Nil)
-    val q5 = Resolution(q2, q1, q2.root.positive(0), q1.root.negative(0), r1)
-    val q6 = Resolution(q5, q3, q5.root.positive(0) ,q3.root.negative(0), r2)
+    val r1 = Substitution( Map( x -> a ) )
+    val r2 = Substitution( Map( x -> hc ) )
+    val q0 = InitialClause( List( d1, d2 ), List( d3 ) )
+    val q1 = Factor( q0, q0.root.negative( 1 ), q0.root.negative( 0 ) :: Nil, Substitution() )
+    val q2 = InitialClause( Nil, List( d2 ) )
+    val q3 = InitialClause( List( d4 ), Nil )
+    val q5 = Resolution( q2, q1, q2.root.positive( 0 ), q1.root.negative( 0 ), r1 )
+    val q6 = Resolution( q5, q3, q5.root.positive( 0 ), q3.root.negative( 0 ), r2 )
 
   }
 
-  def checkClause(c: Clause, d:Clause) = c.toFSequent multiSetEquals(d.toFSequent)
-  def checkTree(r : AGraph[Clause], o : AGraph[Clause]) : Option[(AGraph[Clause], AGraph[Clause])] = {
-    val pair : (AGraph[Clause], AGraph[Clause]) = (r,o)
+  def checkClause( c: Clause, d: Clause ) = c.toFSequent multiSetEquals ( d.toFSequent )
+  def checkTree( r: AGraph[Clause], o: AGraph[Clause] ): Option[( AGraph[Clause], AGraph[Clause] )] = {
+    val pair: ( AGraph[Clause], AGraph[Clause] ) = ( r, o )
     pair match {
-      case (LeafAGraph(c), LeafAGraph(d)) =>
-        if (checkClause(c.asInstanceOf[Clause],d.asInstanceOf[Clause])) None else Some((r,o))
-      case (UnaryAGraph(c,p), UnaryAGraph(d,q)) =>
-        checkTree(p.asInstanceOf[AGraph[Clause]],q.asInstanceOf[AGraph[Clause]]) match {
+      case ( LeafAGraph( c ), LeafAGraph( d ) ) =>
+        if ( checkClause( c.asInstanceOf[Clause], d.asInstanceOf[Clause] ) ) None else Some( ( r, o ) )
+      case ( UnaryAGraph( c, p ), UnaryAGraph( d, q ) ) =>
+        checkTree( p.asInstanceOf[AGraph[Clause]], q.asInstanceOf[AGraph[Clause]] ) match {
           case None =>
-            if (checkClause(c.asInstanceOf[Clause],d.asInstanceOf[Clause])) None else Some((r,o))
-          case e@Some(_) => e
+            if ( checkClause( c.asInstanceOf[Clause], d.asInstanceOf[Clause] ) ) None else Some( ( r, o ) )
+          case e @ Some( _ ) => e
         }
-      case (BinaryAGraph(c,p1,p2), BinaryAGraph(d,q1,q2)) =>
-        checkTree(p1.asInstanceOf[AGraph[Clause]],q1.asInstanceOf[AGraph[Clause]]) match {
+      case ( BinaryAGraph( c, p1, p2 ), BinaryAGraph( d, q1, q2 ) ) =>
+        checkTree( p1.asInstanceOf[AGraph[Clause]], q1.asInstanceOf[AGraph[Clause]] ) match {
           case None =>
-            checkTree(p2.asInstanceOf[AGraph[Clause]],q2.asInstanceOf[AGraph[Clause]]) match {
+            checkTree( p2.asInstanceOf[AGraph[Clause]], q2.asInstanceOf[AGraph[Clause]] ) match {
               case None =>
-                if (checkClause(c.asInstanceOf[Clause],d.asInstanceOf[Clause])) None else Some((r,o))
-              case Some(e) => Some(e)
+                if ( checkClause( c.asInstanceOf[Clause], d.asInstanceOf[Clause] ) ) None else Some( ( r, o ) )
+              case Some( e ) => Some( e )
             }
-          case Some(e) => Some(e)
+          case Some( e ) => Some( e )
         }
-      case _ => Some((r,o))
-    }}
+      case _ => Some( ( r, o ) )
+    }
+  }
 
-
-  val map : NameReplacement.SymbolMap = Map[String, (Int,String)](
-    "P" -> (2, "R"),
-    "f" -> (1, "h"),
-    "g" -> (2, "f"),
-    "ladr0" -> (0, "c0")
-  )
+  val map: NameReplacement.SymbolMap = Map[String, ( Int, String )](
+    "P" -> ( 2, "R" ),
+    "f" -> ( 1, "h" ),
+    "g" -> ( 2, "f" ),
+    "ladr0" -> ( 0, "c0" ) )
 
   "The renaming interface " should {
     "rewrite fol formulas" in {
-      val p_ladr_fladr = Atom("P", FOLConst("ladr0")::Function("f", FOLConst("ladr0")::Nil)::Nil)
-      val p_a_ladr = Atom("P", FOLConst("a")::FOLConst("ladr0")::Nil)
-      val q_gx = Atom("Q", Function("g", FOLVar("x")::Nil)::Nil)
+      val p_ladr_fladr = Atom( "P", FOLConst( "ladr0" ) :: Function( "f", FOLConst( "ladr0" ) :: Nil ) :: Nil )
+      val p_a_ladr = Atom( "P", FOLConst( "a" ) :: FOLConst( "ladr0" ) :: Nil )
+      val q_gx = Atom( "Q", Function( "g", FOLVar( "x" ) :: Nil ) :: Nil )
 
-      val fol1 = And(p_ladr_fladr, Or(Neg(p_a_ladr), q_gx))
+      val fol1 = And( p_ladr_fladr, Or( Neg( p_a_ladr ), q_gx ) )
 
-      val r_c_hc = Atom("R", FOLConst("c0")::Function("h", FOLConst("c0")::Nil)::Nil)
-      val r_a_c = Atom("R", FOLConst("a")::FOLConst("c0")::Nil)
+      val r_c_hc = Atom( "R", FOLConst( "c0" ) :: Function( "h", FOLConst( "c0" ) :: Nil ) :: Nil )
+      val r_a_c = Atom( "R", FOLConst( "a" ) :: FOLConst( "c0" ) :: Nil )
 
-      val fol1_ = And(r_c_hc, Or(Neg(r_a_c), q_gx))
+      val fol1_ = And( r_c_hc, Or( Neg( r_a_c ), q_gx ) )
 
-      fol1_ must beEqualTo( NameReplacement(fol1, map ))
+      fol1_ must beEqualTo( NameReplacement( fol1, map ) )
     }
 
     "rewrite hol formulas" in {
-      val P = HOLConst("P", Ti -> (Ti -> To))
-      val Q = HOLConst("Q", Ti -> To)
-      val R = HOLConst("R", Ti -> (Ti -> To))
-      val f = HOLConst("f", Ti -> Ti)
-      val g = HOLConst("g", Ti -> Ti)
-      val h = HOLConst("h", Ti -> Ti)
+      val P = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val Q = HOLConst( "Q", Ti -> To )
+      val R = HOLConst( "R", Ti -> ( Ti -> To ) )
+      val f = HOLConst( "f", Ti -> Ti )
+      val g = HOLConst( "g", Ti -> Ti )
+      val h = HOLConst( "h", Ti -> Ti )
 
-      val ladr = HOLConst("ladr0", Ti)
-      val c0 = HOLConst("c0", Ti)
+      val ladr = HOLConst( "ladr0", Ti )
+      val c0 = HOLConst( "c0", Ti )
 
-      val p_ladr_fladr = HOLAtom(P, ladr::HOLFunction(f, ladr::Nil)::Nil)
-      val p_a_ladr = HOLAtom(P, HOLConst("a", Ti)::ladr::Nil)
-      val q_gx = HOLAtom(Q, HOLFunction(g, HOLVar("x", Ti)::Nil)::Nil)
+      val p_ladr_fladr = HOLAtom( P, ladr :: HOLFunction( f, ladr :: Nil ) :: Nil )
+      val p_a_ladr = HOLAtom( P, HOLConst( "a", Ti ) :: ladr :: Nil )
+      val q_gx = HOLAtom( Q, HOLFunction( g, HOLVar( "x", Ti ) :: Nil ) :: Nil )
 
-      val fol1 = HOLAnd(p_ladr_fladr, HOLOr(HOLNeg(p_a_ladr), q_gx))
+      val fol1 = HOLAnd( p_ladr_fladr, HOLOr( HOLNeg( p_a_ladr ), q_gx ) )
 
-      val r_c_hc = HOLAtom(R, c0::HOLFunction(h, c0::Nil)::Nil)
-      val r_a_c = HOLAtom(R, HOLConst("a", Ti)::c0::Nil)
+      val r_c_hc = HOLAtom( R, c0 :: HOLFunction( h, c0 :: Nil ) :: Nil )
+      val r_a_c = HOLAtom( R, HOLConst( "a", Ti ) :: c0 :: Nil )
 
-      val fol1_ = HOLAnd(r_c_hc, HOLOr(HOLNeg(r_a_c), q_gx))
+      val fol1_ = HOLAnd( r_c_hc, HOLOr( HOLNeg( r_a_c ), q_gx ) )
 
-      fol1_ must beEqualTo( NameReplacement(fol1, map ))
+      fol1_ must beEqualTo( NameReplacement( fol1, map ) )
     }
 
     "rewrite of resolution proofs must work" in {
       //      println(proof1.p7)
       //      println(proof2.q7)
-      val map : NameReplacement.SymbolMap = Map[String, (Int,String)](
-        "P" -> (1, "R"),
-        "f" -> (1, "h"),
-        "g" -> (1, "f"),
-        "ladr0" -> (0, "c0")
-      )
+      val map: NameReplacement.SymbolMap = Map[String, ( Int, String )](
+        "P" -> ( 1, "R" ),
+        "f" -> ( 1, "h" ),
+        "g" -> ( 1, "f" ),
+        "ladr0" -> ( 0, "c0" ) )
 
-      val (_,proof) = NameReplacement.rename_resproof(proof1.p7, map)
+      val ( _, proof ) = NameReplacement.rename_resproof( proof1.p7, map )
       //println
       //proof4.q0.root.negative map println
       //println
@@ -175,11 +173,11 @@ class name_replacementTest extends SpecificationWithJUnit {
 
       //proof4.q1 match { case Factor(c,p,aux,s) => aux map println}
 
-      checkTree(proof, proof2.q7) must beEmpty
+      checkTree( proof, proof2.q7 ) must beEmpty
 
-      val (_,fproof) = NameReplacement.rename_resproof(proof3.p6, map)
+      val ( _, fproof ) = NameReplacement.rename_resproof( proof3.p6, map )
       //fproof.nodes map println
-      checkTree(fproof, proof4.q6) must beEmpty
+      checkTree( fproof, proof4.q6 ) must beEmpty
     }
   }
 }

--- a/src/test/scala/at/logic/algorithms/shlk/BussGeneratorAutoPropTest.scala
+++ b/src/test/scala/at/logic/algorithms/shlk/BussGeneratorAutoPropTest.scala
@@ -12,24 +12,24 @@ import at.logic.calculi.lk.base.FSequent
 import at.logic.algorithms.lk._
 
 // Seems like this is testing auto-propositional for HOL... why is it here?
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class BussGeneratorAutoPropTest extends SpecificationWithJUnit {
   "BussGeneratorAutoPropTest" should {
     "continue autopropositional" in {
 
-      val a = HOLConst("a", Ti)
+      val a = HOLConst( "a", Ti )
 
-      val Pc1 = Atom(HOLConst("Pc1", Ti -> To), a::Nil)
-      val Pc2 = Atom(HOLConst("Pc2", Ti -> To), a::Nil)
-      val Pd1 = Atom(HOLConst("Pd1", Ti -> To), a::Nil)
-      val Pd2 = Atom(HOLConst("Pd2", Ti -> To), a::Nil)
-      val Pc1_or_Pd1 = Or(Pc1, Pd1)
-      val imp_Pc1_or_Pd1_Pc2 = Imp(Pc1_or_Pd1, Pc2)
-      val imp_Pc1_or_Pd1_Pd2 = Imp(Pc1_or_Pd1, Pd2)
-      val imp_Pc1_or_Pd1_Pc2__or__imp_Pc1_or_Pd1_Pd2 = at.logic.language.hol.Or(imp_Pc1_or_Pd1_Pc2, imp_Pc1_or_Pd1_Pd2)
-//      val fs = FSequent(imp_Pc1_or_Pd1_Pc2__or__imp_Pc1_or_Pd1_Pd2 :: Pc1_or_Pd1 :: Nil , Pc2::Pd2::Nil)
-      val fs = BussTautology(2)
-      val bussGen = solve.solvePropositional(fs)
+      val Pc1 = Atom( HOLConst( "Pc1", Ti -> To ), a :: Nil )
+      val Pc2 = Atom( HOLConst( "Pc2", Ti -> To ), a :: Nil )
+      val Pd1 = Atom( HOLConst( "Pd1", Ti -> To ), a :: Nil )
+      val Pd2 = Atom( HOLConst( "Pd2", Ti -> To ), a :: Nil )
+      val Pc1_or_Pd1 = Or( Pc1, Pd1 )
+      val imp_Pc1_or_Pd1_Pc2 = Imp( Pc1_or_Pd1, Pc2 )
+      val imp_Pc1_or_Pd1_Pd2 = Imp( Pc1_or_Pd1, Pd2 )
+      val imp_Pc1_or_Pd1_Pc2__or__imp_Pc1_or_Pd1_Pd2 = at.logic.language.hol.Or( imp_Pc1_or_Pd1_Pc2, imp_Pc1_or_Pd1_Pd2 )
+      //      val fs = FSequent(imp_Pc1_or_Pd1_Pc2__or__imp_Pc1_or_Pd1_Pd2 :: Pc1_or_Pd1 :: Nil , Pc2::Pd2::Nil)
+      val fs = BussTautology( 2 )
+      val bussGen = solve.solvePropositional( fs )
 
       Success()
     }
@@ -37,21 +37,21 @@ class BussGeneratorAutoPropTest extends SpecificationWithJUnit {
 }
 
 object BussTautology {
-  def apply( n: Int ) : FSequent = FSequent( Ant( n ), c( n )::d( n )::Nil )
+  def apply( n: Int ): FSequent = FSequent( Ant( n ), c( n ) :: d( n ) :: Nil )
 
-  val a = HOLConst("a", Ti)
+  val a = HOLConst( "a", Ti )
 
-  def c( i: Int ) = Atom( HOLConst("c_" + i, Ti -> To), a::Nil )
-  def d( i: Int ) = Atom( HOLConst("d_" + i, Ti -> To), a::Nil )
-  def F( i: Int ) : HOLFormula =  if ( i == 1 )
-                                      Or( c( 1 ), d( 1 ) )
-                                  else
-                                      And( F( i - 1 ), Or( c( i ), d( i ) ) )
-  def A( i: Int ) = if ( i == 1 )  c( 1 )
-                    else Imp( F( i - 1 ), c( i ) )
-  def B( i: Int ) = if ( i == 1 )  d( 1 )
-                    else Imp( F( i - 1 ), d( i ) )
+  def c( i: Int ) = Atom( HOLConst( "c_" + i, Ti -> To ), a :: Nil )
+  def d( i: Int ) = Atom( HOLConst( "d_" + i, Ti -> To ), a :: Nil )
+  def F( i: Int ): HOLFormula = if ( i == 1 )
+    Or( c( 1 ), d( 1 ) )
+  else
+    And( F( i - 1 ), Or( c( i ), d( i ) ) )
+  def A( i: Int ) = if ( i == 1 ) c( 1 )
+  else Imp( F( i - 1 ), c( i ) )
+  def B( i: Int ) = if ( i == 1 ) d( 1 )
+  else Imp( F( i - 1 ), d( i ) )
 
   // the antecedens of the final sequent
-  def Ant( i: Int ) : List[HOLFormula] = if ( i == 0 ) Nil else Or( A( i ), B( i ))::Ant( i - 1 )
+  def Ant( i: Int ): List[HOLFormula] = if ( i == 0 ) Nil else Or( A( i ), B( i ) ) :: Ant( i - 1 )
 }

--- a/src/test/scala/at/logic/algorithms/shlk/SimpleSLKParserTest.scala
+++ b/src/test/scala/at/logic/algorithms/shlk/SimpleSLKParserTest.scala
@@ -14,36 +14,36 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import scala.io._
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.specs2.execute.Success
 import at.logic.language.schema._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimpleSLKParserTest extends SpecificationWithJUnit {
-    "SimpleSLKParser" should {
+  "SimpleSLKParser" should {
 
-      sequential
-        "parse correctly a SLK-proof" in {
-          val var3 = Atom(SchemaVar("x3",To), Nil)
-          val var4 = Atom(SchemaVar("x4",To), Nil)
-          val ax1  = Axiom(var3::Nil, var3::Nil)
-          val ax2  = Axiom(var4::Nil, var4::Nil)
-          val negl = NegLeftRule(ax1, var3)
-          val proof  = OrLeftRule(negl, ax2, var3, var4)
+    sequential
+    "parse correctly a SLK-proof" in {
+      val var3 = Atom( SchemaVar( "x3", To ), Nil )
+      val var4 = Atom( SchemaVar( "x4", To ), Nil )
+      val ax1 = Axiom( var3 :: Nil, var3 :: Nil )
+      val ax2 = Axiom( var4 :: Nil, var4 :: Nil )
+      val negl = NegLeftRule( ax1, var3 )
+      val proof = OrLeftRule( negl, ax2, var3, var4 )
 
-          val A0 = IndexedPredicate("A", IntZero())
-          val i = IntVar("i")
-          val Ai2 = IndexedPredicate("A", Succ(Succ(i)))
-          val Ai = IndexedPredicate("A", Succ(i))
-          val f1 = at.logic.language.schema.And(A0, BigAnd(i,Ai,IntZero(),Succ(i)))
-          val ax11 = Axiom(A0::Nil, A0::Nil)
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val i = IntVar( "i" )
+      val Ai2 = IndexedPredicate( "A", Succ( Succ( i ) ) )
+      val Ai = IndexedPredicate( "A", Succ( i ) )
+      val f1 = at.logic.language.schema.And( A0, BigAnd( i, Ai, IntZero(), Succ( i ) ) )
+      val ax11 = Axiom( A0 :: Nil, A0 :: Nil )
 
-          val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("shlk-adder.lks"))
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "shlk-adder.lks" ) )
 
-          val map = SHLK.parseProof(s)
+      val map = SHLK.parseProof( s )
 
-          Success()
+      Success()
 
-        }
     }
+  }
 }

--- a/src/test/scala/at/logic/algorithms/shlk/sFOparserCNTTest.scala
+++ b/src/test/scala/at/logic/algorithms/shlk/sFOparserCNTTest.scala
@@ -5,61 +5,59 @@
 
 package at.logic.parsing.shlk_parsing
 
-import at.logic.algorithms.lk.{getCutAncestors, getAncestors}
+import at.logic.algorithms.lk.{ getCutAncestors, getAncestors }
 import at.logic.calculi.lk._
 import at.logic.calculi.occurrences.FormulaOccurrence
-import at.logic.calculi.slk.{TermEquivalenceRule1, TermRightEquivalenceRule1}
+import at.logic.calculi.slk.{ TermEquivalenceRule1, TermRightEquivalenceRule1 }
 import at.logic.language.lambda.types._
 import at.logic.language.schema._
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import scala.io._
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class sFOparserCNTTest extends SpecificationWithJUnit {
   "sFOparserCNT" should {
 
     sequential
     "parse correctly David's proof " in {
-      skipped("has eigenvariable condition errors")
+      skipped( "has eigenvariable condition errors" )
 
-      val A0 = IndexedPredicate("A", IntZero())
-      val i = IntVar("i")
-      val k = IntVar("k")
-      val Ai2 = IndexedPredicate("A", Succ(Succ(i)))
-      val Ai = IndexedPredicate("A", Succ(i))
-      val f1 = at.logic.language.schema.And(A0, BigAnd(i,Ai,IntZero(),Succ(i)))
-      val ax11 = Axiom(A0::Nil, A0::Nil)
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val i = IntVar( "i" )
+      val k = IntVar( "k" )
+      val Ai2 = IndexedPredicate( "A", Succ( Succ( i ) ) )
+      val Ai = IndexedPredicate( "A", Succ( i ) )
+      val f1 = at.logic.language.schema.And( A0, BigAnd( i, Ai, IntZero(), Succ( i ) ) )
+      val ax11 = Axiom( A0 :: Nil, A0 :: Nil )
 
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("David.lks"))
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "David.lks" ) )
 
-      val map = sFOParserCNT.parseProof(s)
+      val map = sFOParserCNT.parseProof( s )
 
-      val p1 = map.get("\\mu").get._2.get("root").get
-      val p2 = map.get("\\rho").get._2.get("root").get
-      val p3 = map.get("\\zeta").get._2.get("root").get
-      val p4 = map.get("\\omega").get._2.get("root").get
-      val p5 = map.get("\\xi").get._2.get("root").get
-      val p6 = map.get("\\varphi").get._2.get("root").get
+      val p1 = map.get( "\\mu" ).get._2.get( "root" ).get
+      val p2 = map.get( "\\rho" ).get._2.get( "root" ).get
+      val p3 = map.get( "\\zeta" ).get._2.get( "root" ).get
+      val p4 = map.get( "\\omega" ).get._2.get( "root" ).get
+      val p5 = map.get( "\\xi" ).get._2.get( "root" ).get
+      val p6 = map.get( "\\varphi" ).get._2.get( "root" ).get
 
-      val cc2:FormulaOccurrence = p2.root.antecedent.tail.tail.head
-      val cc_zeta_1:FormulaOccurrence = p3.root.succedent.head
-      val cc_zeta_2:FormulaOccurrence = p3.root.antecedent.tail.tail.head
-      val cc4:FormulaOccurrence = p4.root.succedent.head
-      val cc_xi_1:FormulaOccurrence = p5.root.antecedent.last
-      val cc_xi_2:FormulaOccurrence = p5.root.succedent.head
-      val cc_xi_3:FormulaOccurrence = p5.root.antecedent.tail.head
-      val cc6 = p6.root.antecedent.tail.head :: p6.root.antecedent.last ::Nil
+      val cc2: FormulaOccurrence = p2.root.antecedent.tail.tail.head
+      val cc_zeta_1: FormulaOccurrence = p3.root.succedent.head
+      val cc_zeta_2: FormulaOccurrence = p3.root.antecedent.tail.tail.head
+      val cc4: FormulaOccurrence = p4.root.succedent.head
+      val cc_xi_1: FormulaOccurrence = p5.root.antecedent.last
+      val cc_xi_2: FormulaOccurrence = p5.root.succedent.head
+      val cc_xi_3: FormulaOccurrence = p5.root.antecedent.tail.head
+      val cc6 = p6.root.antecedent.tail.head :: p6.root.antecedent.last :: Nil
 
       Success()
 
     }
   }
 }
-
 

--- a/src/test/scala/at/logic/algorithms/shlk/sFOparserTest.scala
+++ b/src/test/scala/at/logic/algorithms/shlk/sFOparserTest.scala
@@ -9,91 +9,88 @@ import at.logic.calculi.lk._
 import at.logic.language.lambda.types._
 import at.logic.language.schema._
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import scala.io._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class sFOparserTest extends SpecificationWithJUnit {
 
   sequential
   "sFOparser" should {
 
     "parse correctly a FO SLK-proof" in {
-      val var3 = Atom(SchemaVar("x3", To),Nil)
-      val var4 = Atom(SchemaVar("x4", To),Nil)
-      val ax1  = Axiom(var3::Nil, var3::Nil)
-      val ax2  = Axiom(var4::Nil, var4::Nil)
-      val negl = NegLeftRule(ax1, var3)
-      val proof  = OrLeftRule(negl, ax2, var3, var4)
+      val var3 = Atom( SchemaVar( "x3", To ), Nil )
+      val var4 = Atom( SchemaVar( "x4", To ), Nil )
+      val ax1 = Axiom( var3 :: Nil, var3 :: Nil )
+      val ax2 = Axiom( var4 :: Nil, var4 :: Nil )
+      val negl = NegLeftRule( ax1, var3 )
+      val proof = OrLeftRule( negl, ax2, var3, var4 )
 
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val i = IntVar( "i" )
+      val Ai2 = IndexedPredicate( "A", Succ( Succ( i ) ) )
+      val Ai = IndexedPredicate( "A", Succ( i ) )
+      val f1 = at.logic.language.schema.And( A0, BigAnd( i, Ai, IntZero(), Succ( i ) ) )
+      val ax11 = Axiom( A0 :: Nil, A0 :: Nil )
 
-      val A0 = IndexedPredicate("A", IntZero())
-      val i = IntVar("i")
-      val Ai2 = IndexedPredicate("A", Succ(Succ(i)))
-      val Ai = IndexedPredicate("A", Succ(i))
-      val f1 = at.logic.language.schema.And(A0, BigAnd(i,Ai,IntZero(),Succ(i)))
-      val ax11 = Axiom(A0::Nil, A0::Nil)
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sIND.lks" ) )
 
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sIND.lks"))
+      val map = sFOParser.parseProof( s )
 
-      val map = sFOParser.parseProof(s)
-
-      def f = SchemaConst("f", Ti->Ti)
-      def h = SchemaConst("h", ->(Tindex , ->(Ti, Ti)))
-      def g = SchemaConst("g", ->(Tindex , ->(Ti, Ti)))
-      val k = IntVar("k")
-      val x = foVar("x")
+      def f = SchemaConst( "f", Ti -> Ti )
+      def h = SchemaConst( "h", ->( Tindex, ->( Ti, Ti ) ) )
+      def g = SchemaConst( "g", ->( Tindex, ->( Ti, Ti ) ) )
+      val k = IntVar( "k" )
+      val x = foVar( "x" )
       val base2 = x
-      val step2 = foTerm("f",  sTerm(g, Succ(k), x::Nil)::Nil)
-      val base1 = sTerm(g, IntZero(), x::Nil)
-      val step1 = sTerm(g, Succ(k), x::Nil)
+      val step2 = foTerm( "f", sTerm( g, Succ( k ), x :: Nil ) :: Nil )
+      val base1 = sTerm( g, IntZero(), x :: Nil )
+      val step1 = sTerm( g, Succ( k ), x :: Nil )
       dbTRS.clear
-      dbTRS.add(g, Tuple2(base1, base2), Tuple2(step1, step2))
+      dbTRS.add( g, Tuple2( base1, base2 ), Tuple2( step1, step2 ) )
       Success()
 
     }
 
-
     "parse correctly the journal example" in {
 
-      val var3 = Atom(SchemaVar("x3",To), Nil)
-      val var4 = Atom(SchemaVar("x4",To), Nil)
-      val ax1  = Axiom(var3::Nil, var3::Nil)
-      val ax2  = Axiom(var4::Nil, var4::Nil)
-      val negl = NegLeftRule(ax1, var3)
-      val proof  = OrLeftRule(negl, ax2, var3, var4)
+      val var3 = Atom( SchemaVar( "x3", To ), Nil )
+      val var4 = Atom( SchemaVar( "x4", To ), Nil )
+      val ax1 = Axiom( var3 :: Nil, var3 :: Nil )
+      val ax2 = Axiom( var4 :: Nil, var4 :: Nil )
+      val negl = NegLeftRule( ax1, var3 )
+      val proof = OrLeftRule( negl, ax2, var3, var4 )
 
-      val A0 = IndexedPredicate("A", IntZero())
-      val i = IntVar("i")
-      val Ai2 = IndexedPredicate("A", Succ(Succ(i)))
-      val Ai = IndexedPredicate("A", Succ(i))
-      val f1 = And(A0, BigAnd(i,Ai,IntZero(),Succ(i)))
-      val ax11 = Axiom(A0::Nil, A0::Nil)
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val i = IntVar( "i" )
+      val Ai2 = IndexedPredicate( "A", Succ( Succ( i ) ) )
+      val Ai = IndexedPredicate( "A", Succ( i ) )
+      val f1 = And( A0, BigAnd( i, Ai, IntZero(), Succ( i ) ) )
+      val ax11 = Axiom( A0 :: Nil, A0 :: Nil )
 
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("shlk-journal_example.lks"))
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "shlk-journal_example.lks" ) )
 
-      val map = sFOParser.parseProof(s)
+      val map = sFOParser.parseProof( s )
 
-      def f = SchemaConst("f", Ti->Ti)
-      def h = SchemaConst("h", ->(Tindex , ->(Ti, Ti)))
-      def g = SchemaConst("g", ->(Tindex , ->(Ti, Ti)))
-      val k = IntVar("k")
-      val x = foVar("x")
+      def f = SchemaConst( "f", Ti -> Ti )
+      def h = SchemaConst( "h", ->( Tindex, ->( Ti, Ti ) ) )
+      def g = SchemaConst( "g", ->( Tindex, ->( Ti, Ti ) ) )
+      val k = IntVar( "k" )
+      val x = foVar( "x" )
       val base2 = x
-      val step2 = foTerm("f",  sTerm(g, Succ(k), x::Nil)::Nil)
-      val base1 = sTerm(g, IntZero(), x::Nil)
-      val step1 = sTerm(g, Succ(k), x::Nil)
+      val step2 = foTerm( "f", sTerm( g, Succ( k ), x :: Nil ) :: Nil )
+      val base1 = sTerm( g, IntZero(), x :: Nil )
+      val step1 = sTerm( g, Succ( k ), x :: Nil )
       dbTRS.clear
-      dbTRS.add(g, Tuple2(base1, base2), Tuple2(step1, step2))
+      dbTRS.add( g, Tuple2( base1, base2 ), Tuple2( step1, step2 ) )
 
       Success()
 
     }
   }
 }
-
 

--- a/src/test/scala/at/logic/algorithms/subsumption/StillmanSubsumptionAlgorithmTest.scala
+++ b/src/test/scala/at/logic/algorithms/subsumption/StillmanSubsumptionAlgorithmTest.scala
@@ -10,169 +10,169 @@ import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import at.logic.calculi.lk.base.FSequent
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class StillmanSubsumptionAlgorithmFOLTest extends SpecificationWithJUnit {
-import at.logic.language.fol._
+  import at.logic.language.fol._
   "StillmanSubsumptionAlgorithmFOL" should {
     val P = "P"
     val Q = "Q"
     val R = "R"
     val f = "f"
-    val a = FOLConst("a")
-    val b = FOLConst("b")
-    val x = FOLVar("x")
-    val y = FOLVar("y")
-    val z = FOLVar("z")
-    val Px = Atom(P, x::Nil)
-    val Py = Atom(P, y::Nil)
-    val Pz = Atom(P, z::Nil)
-    val fxy = Function(f, x::y::Nil)
-    val Pfxy = Atom(P, fxy::Nil)
-    val Pa = Atom(P, a::Nil)
-    val Pb = Atom(P, b::Nil)
-    val fba = Function(f, b::a::Nil)
-    val Pfba = Atom(P, fba::Nil)
-    val Pxx = Atom(P, x::x::Nil)
-    val Pxa = Atom(P, x::a::Nil)
-    val Paa = Atom(P, a::a::Nil)
-    val Pxb = Atom(P, x::b::Nil)
-    val Pab = Atom(P, a::b::Nil)
-    val Pba = Atom(P, b::a::Nil)
-    val fx = Function(f, x::Nil)
-    val fa = Function(f, a::Nil)
-    val fb = Function(f, b::Nil)
-    val Pfx = Atom(P, fx::Nil)
-    val Pfa = Atom(P, fa::Nil)
-    val Pfb = Atom(P, fb::Nil)
-    val Qxy = Atom(Q, x::y::Nil)
-    val Qay = Atom(Q, a::y::Nil)
-    val Rx = Atom(R, x::Nil)
+    val a = FOLConst( "a" )
+    val b = FOLConst( "b" )
+    val x = FOLVar( "x" )
+    val y = FOLVar( "y" )
+    val z = FOLVar( "z" )
+    val Px = Atom( P, x :: Nil )
+    val Py = Atom( P, y :: Nil )
+    val Pz = Atom( P, z :: Nil )
+    val fxy = Function( f, x :: y :: Nil )
+    val Pfxy = Atom( P, fxy :: Nil )
+    val Pa = Atom( P, a :: Nil )
+    val Pb = Atom( P, b :: Nil )
+    val fba = Function( f, b :: a :: Nil )
+    val Pfba = Atom( P, fba :: Nil )
+    val Pxx = Atom( P, x :: x :: Nil )
+    val Pxa = Atom( P, x :: a :: Nil )
+    val Paa = Atom( P, a :: a :: Nil )
+    val Pxb = Atom( P, x :: b :: Nil )
+    val Pab = Atom( P, a :: b :: Nil )
+    val Pba = Atom( P, b :: a :: Nil )
+    val fx = Function( f, x :: Nil )
+    val fa = Function( f, a :: Nil )
+    val fb = Function( f, b :: Nil )
+    val Pfx = Atom( P, fx :: Nil )
+    val Pfa = Atom( P, fa :: Nil )
+    val Pfb = Atom( P, fb :: Nil )
+    val Qxy = Atom( Q, x :: y :: Nil )
+    val Qay = Atom( Q, a :: y :: Nil )
+    val Rx = Atom( R, x :: Nil )
 
     "return true on the following clauses" in {
       "P(x) | P(f(x,y)) and P(a) | P(b) | P(f(b,a))" in {
-        val c1 = FSequent(Nil, Px::Pfxy::Nil)
-        val c2 = FSequent(Nil, Pa::Pb::Pfba::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Px :: Pfxy :: Nil )
+        val c2 = FSequent( Nil, Pa :: Pb :: Pfba :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "Nil and P(a) | P(b) | P(f(b,a))" in {
-        val c1 = FSequent(Nil, Nil)
-        val c2 = FSequent(Nil, Pa::Pb::Pfba::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Nil )
+        val c2 = FSequent( Nil, Pa :: Pb :: Pfba :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x) and P(x) | P(f(x,y))" in {
-        val c1 = FSequent(Nil, Px::Nil)
-        val c2 = FSequent(Nil, Px::Pfxy::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Px :: Nil )
+        val c2 = FSequent( Nil, Px :: Pfxy :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x) and P(x)" in {
-        val c1 = FSequent(Nil, Px::Nil)
-        val c2 = FSequent(Nil, Px::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Px :: Nil )
+        val c2 = FSequent( Nil, Px :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x) and P(y)" in {
-        val c1 = FSequent(Nil, Px::Nil)
-        val c2 = FSequent(Nil, Py::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Px :: Nil )
+        val c2 = FSequent( Nil, Py :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x,x) | P(x,a) and P(a,a)" in {
-        val c1 = FSequent(Nil, Pxx::Pxa::Nil)
-        val c2 = FSequent(Nil, Paa::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Pxx :: Pxa :: Nil )
+        val c2 = FSequent( Nil, Paa :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x) | Q(x,y) and P(a) | Q(a,y) | R(x)" in {
-        skipped("I am failing failing :( Please check me!")
-        val c1 = FSequent(Nil, Px::Qxy::Nil)
-        val c2 = FSequent(Nil, Pa::Qay::Rx::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        skipped( "I am failing failing :( Please check me!" )
+        val c1 = FSequent( Nil, Px :: Qxy :: Nil )
+        val c2 = FSequent( Nil, Pa :: Qay :: Rx :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
     }
     "return false on the following clauses" in {
       "P(x) | P(f(x)) and P(f(a)) | P(f(b))" in {
-        val c1 = FSequent(Nil, Px::Pfx::Nil)
-        val c2 = FSequent(Nil, Pfa::Pfb::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (false)
+        val c1 = FSequent( Nil, Px :: Pfx :: Nil )
+        val c2 = FSequent( Nil, Pfa :: Pfb :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( false )
       }
       "P(a,a) and P(x,x) | P(x,a)" in {
-        val c1 = FSequent(Nil, Paa::Nil)
-        val c2 = FSequent(Nil, Pxx::Pxa::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (false)
+        val c1 = FSequent( Nil, Paa :: Nil )
+        val c2 = FSequent( Nil, Pxx :: Pxa :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( false )
       }
       "P(x,x) | P(x,b) and P(b,a) | P(a,b)" in {
-        val c1 = FSequent(Nil, Pxx::Pxb::Nil)
-        val c2 = FSequent(Nil, Pba::Pab::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (false)
+        val c1 = FSequent( Nil, Pxx :: Pxb :: Nil )
+        val c2 = FSequent( Nil, Pba :: Pab :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( false )
       }
       "P(x) | -P(x) and P(a) | -P(b)" in {
-        val c1 = FSequent(Px::Nil, Px::Nil)
-        val c2 = FSequent(Pb::Nil, Pa::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (false)
+        val c1 = FSequent( Px :: Nil, Px :: Nil )
+        val c2 = FSequent( Pb :: Nil, Pa :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( false )
       }
       "P(x) | -P(x) and P(y) | -P(z)" in {
-        val c1 = FSequent(Px::Nil, Px::Nil)
-        val c2 = FSequent(Pz::Nil, Py::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (false)
+        val c1 = FSequent( Px :: Nil, Px :: Nil )
+        val c2 = FSequent( Pz :: Nil, Py :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( false )
       }
       "P(x) and P(a) | P(y)" in {
-        val c1 = FSequent(Nil, Px::Nil)
-        val c2 = FSequent(Nil, Pa::Py::Nil)
-        StillmanSubsumptionAlgorithmFOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Px :: Nil )
+        val c2 = FSequent( Nil, Pa :: Py :: Nil )
+        StillmanSubsumptionAlgorithmFOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
     }
   }
 }
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class StillmanSubsumptionAlgorithmHOLTest extends SpecificationWithJUnit {
-import at.logic.language.hol._
-import at.logic.language.lambda.types._
+  import at.logic.language.hol._
+  import at.logic.language.lambda.types._
   "StillmanSubsumptionAlgorithmHOL" should {
     "return true on the following clauses" in {
-      val P = HOLConst("P", Ti -> (Ti -> To))
-      val P1 = HOLConst("P", Ti -> To)
-      val Q = HOLConst("Q", Ti -> To)
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val z = HOLVar("z", Ti)
-      val q = HOLVar("q", Ti -> To)
-      val a = HOLConst("a", Ti)
-      val b = HOLConst("b", Ti)
-      val f = HOLConst("f", Ti -> (Ti -> (Ti -> Ti)))
-      val f1 = HOLConst("f", Ti -> Ti)
-      val f2 = HOLConst("f", (Ti -> To) -> (Ti -> (Ti -> Ti)))
-      val f2qza = Function(f2, q::z::a::Nil)
-      val f1b = Function(f1, b::Nil)
-      val fyza = Function(f, y::z::a::Nil)
-      val Pxx = Atom(P, x::x::Nil)
-      val Pxa = Atom(P, x::a::Nil)
-      val Paa = Atom(P, a::a::Nil)
-      val Pfyza_fyza = Atom(P, fyza::fyza::Nil)
-      val Qf1b = Atom(Q, f1b::Nil)
-      val Pf2qza = Atom(P, f2qza::f2qza::Nil)
-      val Px = Atom(P1, x::Nil)
-      val Pa = Atom(P1, a::Nil)
-      val Qx = Atom(Q, x::Nil)
+      val P = HOLConst( "P", Ti -> ( Ti -> To ) )
+      val P1 = HOLConst( "P", Ti -> To )
+      val Q = HOLConst( "Q", Ti -> To )
+      val x = HOLVar( "x", Ti )
+      val y = HOLVar( "y", Ti )
+      val z = HOLVar( "z", Ti )
+      val q = HOLVar( "q", Ti -> To )
+      val a = HOLConst( "a", Ti )
+      val b = HOLConst( "b", Ti )
+      val f = HOLConst( "f", Ti -> ( Ti -> ( Ti -> Ti ) ) )
+      val f1 = HOLConst( "f", Ti -> Ti )
+      val f2 = HOLConst( "f", ( Ti -> To ) -> ( Ti -> ( Ti -> Ti ) ) )
+      val f2qza = Function( f2, q :: z :: a :: Nil )
+      val f1b = Function( f1, b :: Nil )
+      val fyza = Function( f, y :: z :: a :: Nil )
+      val Pxx = Atom( P, x :: x :: Nil )
+      val Pxa = Atom( P, x :: a :: Nil )
+      val Paa = Atom( P, a :: a :: Nil )
+      val Pfyza_fyza = Atom( P, fyza :: fyza :: Nil )
+      val Qf1b = Atom( Q, f1b :: Nil )
+      val Pf2qza = Atom( P, f2qza :: f2qza :: Nil )
+      val Px = Atom( P1, x :: Nil )
+      val Pa = Atom( P1, a :: Nil )
+      val Qx = Atom( Q, x :: Nil )
 
       "P(x:i,x:i) | P(x:i,a:i) and P(a:i,a:i)" in {
-        val c1 = FSequent(Nil, Pxx::Pxa::Nil)
-        val c2 = FSequent(Nil, Paa::Nil)
-        StillmanSubsumptionAlgorithmHOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Pxx :: Pxa :: Nil )
+        val c2 = FSequent( Nil, Paa :: Nil )
+        StillmanSubsumptionAlgorithmHOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x:i,x:i) and P(f(y:i,z:i,a:i):i,f(y:i,z:i,a:i):i)" in {
-        val c1 = FSequent(Nil, Pxx::Nil)
-        val c2 = FSequent(Nil, Pfyza_fyza::Nil)
-        StillmanSubsumptionAlgorithmHOL.subsumes(c1, c2) must beEqualTo (true)
+        val c1 = FSequent( Nil, Pxx :: Nil )
+        val c2 = FSequent( Nil, Pfyza_fyza :: Nil )
+        StillmanSubsumptionAlgorithmHOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x:i,x:i) and P(f(q:(i->o),z:i,a:i):i,f(q:(i->o),z:i,a:i):i) | -Q(f(b:i):(i->i))" in {
-        skipped("I am failing failing :( Please check me!")
-        val c1 = FSequent(Nil, Pxx::Nil)
-        val c2 = FSequent(Qf1b::Nil, Pf2qza::Nil) 
-        StillmanSubsumptionAlgorithmHOL.subsumes(c1, c2) must beEqualTo (true)
+        skipped( "I am failing failing :( Please check me!" )
+        val c1 = FSequent( Nil, Pxx :: Nil )
+        val c2 = FSequent( Qf1b :: Nil, Pf2qza :: Nil )
+        StillmanSubsumptionAlgorithmHOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
       "P(x:i) and P(a:i) | Q(x:i)" in {
-        skipped("I am failing failing :( Please check me!")
-        val c1 = FSequent(Nil, Px::Nil)
-        val c2 = FSequent(Nil, Pa::Qx::Nil)
-        StillmanSubsumptionAlgorithmHOL.subsumes(c1, c2) must beEqualTo (true)
+        skipped( "I am failing failing :( Please check me!" )
+        val c1 = FSequent( Nil, Px :: Nil )
+        val c2 = FSequent( Nil, Pa :: Qx :: Nil )
+        StillmanSubsumptionAlgorithmHOL.subsumes( c1, c2 ) must beEqualTo( true )
       }
     }
   }

--- a/src/test/scala/at/logic/algorithms/unification/UnificationTest.scala
+++ b/src/test/scala/at/logic/algorithms/unification/UnificationTest.scala
@@ -10,111 +10,111 @@ import at.logic.language.fol._
 //import at.logic.language.hol.logicSymbols._
 import at.logic.algorithms.unification.fol.FOLUnificationAlgorithm
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class UnificationTest extends SpecificationWithJUnit {
-  
+
   "FOL Unification" should {
     "unify the terms" in {
       "P(x_1), P(x_2)" in {
-        val x1 = FOLVar("x_1")
-        val x2 = FOLVar("x_2")
-        val px1 = Atom("P", x1::Nil)
-        val px2 = Atom("P", x2::Nil)
-        (FOLUnificationAlgorithm.unify(px1,px2)) must_== 
-          (List(Substitution(FOLVar("x_1"), FOLVar("x_2"))))
+        val x1 = FOLVar( "x_1" )
+        val x2 = FOLVar( "x_2" )
+        val px1 = Atom( "P", x1 :: Nil )
+        val px2 = Atom( "P", x2 :: Nil )
+        ( FOLUnificationAlgorithm.unify( px1, px2 ) ) must_==
+          ( List( Substitution( FOLVar( "x_1" ), FOLVar( "x_2" ) ) ) )
 
       }
     }
     "return Nil if terms are not unifiable" in
-    {
-      "- both are constants" in
       {
-        val a = FOLConst("a")
-        val b = FOLConst("b")
-        (FOLUnificationAlgorithm.unify(a,b)) must beEqualTo (Nil)
+        "- both are constants" in
+          {
+            val a = FOLConst( "a" )
+            val b = FOLConst( "b" )
+            ( FOLUnificationAlgorithm.unify( a, b ) ) must beEqualTo( Nil )
+          }
+        "- both are functions" in {
+          val a = Function( "f", FOLConst( "a" ) :: Nil )
+          val b = Function( "g", FOLConst( "a" ) :: Nil )
+          ( FOLUnificationAlgorithm.unify( a, b ) ) must beEqualTo( Nil )
+        }
       }
-      "- both are functions" in {
-        val a = Function("f", FOLConst("a")::Nil)
-        val b = Function("g", FOLConst("a")::Nil)
-        (FOLUnificationAlgorithm.unify(a,b)) must beEqualTo (Nil)
-      }
-    }
     "return Empty substitution if both terms are" in {
       "constants" in {
-        val a = FOLConst("a")
-        val b = FOLConst("a")
-        (FOLUnificationAlgorithm.unify(a,b)) must beEqualTo (Substitution(Nil)::Nil)
+        val a = FOLConst( "a" )
+        val b = FOLConst( "a" )
+        ( FOLUnificationAlgorithm.unify( a, b ) ) must beEqualTo( Substitution( Nil ) :: Nil )
       }
       "functions" in {
-        val a = Function("f", FOLConst("a")::Nil)
-        val b = Function("f", FOLConst("a")::Nil)
-        (FOLUnificationAlgorithm.unify(a,b)) must beEqualTo (Substitution(Nil)::Nil)
+        val a = Function( "f", FOLConst( "a" ) :: Nil )
+        val b = Function( "f", FOLConst( "a" ) :: Nil )
+        ( FOLUnificationAlgorithm.unify( a, b ) ) must beEqualTo( Substitution( Nil ) :: Nil )
       }
     }
     "returns the substitution {x->a} where a is a constant, x is a variable" in {
-        val x = FOLVar("x")
-        val a = FOLConst("a")
-        (FOLUnificationAlgorithm.unify(x, a)) must beEqualTo (Substitution( FOLVar("x"), FOLConst("a"))::Nil)
+      val x = FOLVar( "x" )
+      val a = FOLConst( "a" )
+      ( FOLUnificationAlgorithm.unify( x, a ) ) must beEqualTo( Substitution( FOLVar( "x" ), FOLConst( "a" ) ) :: Nil )
     }
     "return a unifier for the pair <z,f(g(x,a),y,b)>, where x,y,z are vars, a and b are consts" in {
-        val z = FOLVar("z")
-        val t5 = Function("g", FOLVar("x")::FOLConst("b")::Nil)
-        val t6 = Function("f", t5::FOLConst("a")::FOLVar("y")::Nil)
-        (FOLUnificationAlgorithm.unify(z, t6)) must beEqualTo (Substitution( FOLVar("z"), t6)::Nil)
+      val z = FOLVar( "z" )
+      val t5 = Function( "g", FOLVar( "x" ) :: FOLConst( "b" ) :: Nil )
+      val t6 = Function( "f", t5 :: FOLConst( "a" ) :: FOLVar( "y" ) :: Nil )
+      ( FOLUnificationAlgorithm.unify( z, t6 ) ) must beEqualTo( Substitution( FOLVar( "z" ), t6 ) :: Nil )
     }
     "return Nil for the pair <a,f(g(x,a),y,b)>, where x,y are vars, a and b are consts" in {
-        val a = FOLConst("a")
-        val t7 = Function("g", FOLVar("x")::FOLConst("b")::Nil)
-        val t8 = Function("f", t7::FOLConst("a")::FOLVar("y")::Nil)
-        (FOLUnificationAlgorithm.unify(a, t8)) must beEqualTo (Nil)
+      val a = FOLConst( "a" )
+      val t7 = Function( "g", FOLVar( "x" ) :: FOLConst( "b" ) :: Nil )
+      val t8 = Function( "f", t7 :: FOLConst( "a" ) :: FOLVar( "y" ) :: Nil )
+      ( FOLUnificationAlgorithm.unify( a, t8 ) ) must beEqualTo( Nil )
     }
     "return Nil for the pair <x,f(g(x,a),y,b)>, where x,y are vars, a and b are consts" in {
-        val x = FOLVar("x")
-        val t7 = Function("g", FOLVar("x")::FOLConst("b")::Nil)
-        val t8 = Function("f", t7::FOLConst("a")::FOLVar("y")::Nil)
-        (FOLUnificationAlgorithm.unify(x, t8)) must beEqualTo (Nil)
+      val x = FOLVar( "x" )
+      val t7 = Function( "g", FOLVar( "x" ) :: FOLConst( "b" ) :: Nil )
+      val t8 = Function( "f", t7 :: FOLConst( "a" ) :: FOLVar( "y" ) :: Nil )
+      ( FOLUnificationAlgorithm.unify( x, t8 ) ) must beEqualTo( Nil )
     }
 
     "return Nil for the pair <f(g(c),y), f(y,g(b))> where x,y are vars, a,c are consts" in {
-        val x = FOLVar("x")
-        val y = FOLVar("y")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val gx = Function("g",x::Nil)
-        val gb = Function("g",b::Nil)
-        val gc = Function("g",c::Nil)
-        val f_gc_y = Function("f", gc::y::Nil)
-        val t_y_gb = Function("f", y::gb::Nil)
-       (FOLUnificationAlgorithm.unify(f_gc_y, t_y_gb)) must beEqualTo (Nil)
+      val x = FOLVar( "x" )
+      val y = FOLVar( "y" )
+      val b = FOLConst( "b" )
+      val c = FOLConst( "c" )
+      val gx = Function( "g", x :: Nil )
+      val gb = Function( "g", b :: Nil )
+      val gc = Function( "g", c :: Nil )
+      val f_gc_y = Function( "f", gc :: y :: Nil )
+      val t_y_gb = Function( "f", y :: gb :: Nil )
+      ( FOLUnificationAlgorithm.unify( f_gc_y, t_y_gb ) ) must beEqualTo( Nil )
     }
 
     "return the unifier {y->g(b), x->b} for the pair <f(g(x),y), f(y,g(b))> where x,y are vars, a and b are consts" in {
-        val x = FOLVar("x")
-        val y = FOLVar("y")
-        val b = FOLConst("b")
-        val c = FOLConst("c")
-        val gx = Function("g",x::Nil)
-        val gb = Function("g",b::Nil)
-        val gc = Function("g",c::Nil)
-        val t9 = Function("f", gx::y::Nil)
-        val t10 = Function("f", y::gb::Nil)
-        (FOLUnificationAlgorithm.unify(t9,t10)) must beEqualTo (Substitution( (y,gb)::(x,b)::Nil )::Nil)
+      val x = FOLVar( "x" )
+      val y = FOLVar( "y" )
+      val b = FOLConst( "b" )
+      val c = FOLConst( "c" )
+      val gx = Function( "g", x :: Nil )
+      val gb = Function( "g", b :: Nil )
+      val gc = Function( "g", c :: Nil )
+      val t9 = Function( "f", gx :: y :: Nil )
+      val t10 = Function( "f", y :: gb :: Nil )
+      ( FOLUnificationAlgorithm.unify( t9, t10 ) ) must beEqualTo( Substitution( ( y, gb ) :: ( x, b ) :: Nil ) :: Nil )
     }
 
     "return the substitution {x->a,y->b} where a and b are constants, x and y are variables" in {
-        val t1 = Function("f", FOLVar("x")::FOLConst("b")::Nil)
-        val t2 = Function("f", FOLConst("a")::FOLVar("y")::Nil)
-        (FOLUnificationAlgorithm.unify(t1, t2)) must beEqualTo (Substitution( (FOLVar("x"), FOLConst("a") )::(FOLVar("y"), FOLConst("b"))::Nil)::Nil)
+      val t1 = Function( "f", FOLVar( "x" ) :: FOLConst( "b" ) :: Nil )
+      val t2 = Function( "f", FOLConst( "a" ) :: FOLVar( "y" ) :: Nil )
+      ( FOLUnificationAlgorithm.unify( t1, t2 ) ) must beEqualTo( Substitution( ( FOLVar( "x" ), FOLConst( "a" ) ) :: ( FOLVar( "y" ), FOLConst( "b" ) ) :: Nil ) :: Nil )
     }
 
     // the following test was automatically generated using the toCode function
     "unify two formulas from a real-world example" in {
-      val t1 = Or(Neg(Atom(  "=" , FOLConst(  "ladr1"  )::Function(  "ladr3" , Function(  "ladr2" , FOLVar(  "B"  )::FOLVar(  "A"  )::Nil)::Nil)::Nil)), Atom(  "=" , FOLConst(  "ladr0"  )::Function(  "ladr3" , Function(  "ladr2" , Function(  "ladr2" , FOLConst(  "ladr0"  )::Function(  "ladr2" , FOLVar(  "B"  )::FOLVar(  "A"  )::Nil)::Nil)::FOLVar(  "C"  )::Nil)::Nil)::Nil))
+      val t1 = Or( Neg( Atom( "=", FOLConst( "ladr1" ) :: Function( "ladr3", Function( "ladr2", FOLVar( "B" ) :: FOLVar( "A" ) :: Nil ) :: Nil ) :: Nil ) ), Atom( "=", FOLConst( "ladr0" ) :: Function( "ladr3", Function( "ladr2", Function( "ladr2", FOLConst( "ladr0" ) :: Function( "ladr2", FOLVar( "B" ) :: FOLVar( "A" ) :: Nil ) :: Nil ) :: FOLVar( "C" ) :: Nil ) :: Nil ) :: Nil ) )
 
-      val t2 = Or(Neg(Atom(  "=" , FOLConst(  "ladr1"  )::Function(  "ladr3" , Function(  "ladr2" , FOLVar(  "x_{3}"  )::FOLVar(  "x_{2}"  )::Nil)::Nil)::Nil)), Atom(  "=" , FOLConst(  "ladr0"  )::Function(  "ladr3" , Function(  "ladr2" , Function(  "ladr2" , FOLConst(  "ladr0"  )::Function(  "ladr2" , FOLVar(  "x_{3}"  )::FOLVar(  "x_{2}"  )::Nil)::Nil)::FOLVar(  "x_{4}"  )::Nil)::Nil)::Nil))
+      val t2 = Or( Neg( Atom( "=", FOLConst( "ladr1" ) :: Function( "ladr3", Function( "ladr2", FOLVar( "x_{3}" ) :: FOLVar( "x_{2}" ) :: Nil ) :: Nil ) :: Nil ) ), Atom( "=", FOLConst( "ladr0" ) :: Function( "ladr3", Function( "ladr2", Function( "ladr2", FOLConst( "ladr0" ) :: Function( "ladr2", FOLVar( "x_{3}" ) :: FOLVar( "x_{2}" ) :: Nil ) :: Nil ) :: FOLVar( "x_{4}" ) :: Nil ) :: Nil ) :: Nil ) )
 
-      (FOLUnificationAlgorithm.unify(t1, t2)) must beEqualTo (Substitution( (FOLVar(  "B"  ), FOLVar(  "x_{3}"  ))::(FOLVar(  "A"  ), FOLVar(  "x_{2}"  ))
-                                                                        ::(FOLVar(  "C"  ), FOLVar(  "x_{4}"  ))::Nil)::Nil)
+      ( FOLUnificationAlgorithm.unify( t1, t2 ) ) must beEqualTo( Substitution( ( FOLVar( "B" ), FOLVar( "x_{3}" ) ) :: ( FOLVar( "A" ), FOLVar( "x_{2}" ) )
+        :: ( FOLVar( "C" ), FOLVar( "x_{4}" ) ) :: Nil ) :: Nil )
     }
 
   }

--- a/src/test/scala/at/logic/algorithms/unification/fol/FOLUnificationAlgorithmTest.scala
+++ b/src/test/scala/at/logic/algorithms/unification/fol/FOLUnificationAlgorithmTest.scala
@@ -5,26 +5,25 @@
 
 package at.logic.algorithms.unification.fol
 
-
 import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.algorithms.unification.fol._
 import at.logic.language.fol._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class FOLUnificationAlgorithmTest extends SpecificationWithJUnit {
 
   "UnificationBasedFOLMatchingAlgorithm" should {
     "match correctly the lambda expressions f(x1, x2, c) and f(a,b,c)" in {
-      val x = FOLVar("x")
-      val a = FOLConst("a")
-      val b = FOLConst("b")
-      val term = Function("f", x::x::Nil)
-      val posInstance = Function("f", a::b::Nil)
+      val x = FOLVar( "x" )
+      val a = FOLConst( "a" )
+      val b = FOLConst( "b" )
+      val term = Function( "f", x :: x :: Nil )
+      val posInstance = Function( "f", a :: b :: Nil )
 
-      val sub = FOLUnificationAlgorithm.unify(term,posInstance)
-      sub must beEqualTo (Nil)
+      val sub = FOLUnificationAlgorithm.unify( term, posInstance )
+      sub must beEqualTo( Nil )
     }
   }
 

--- a/src/test/scala/at/logic/calculi/expansionTrees/ExpansionTreeTest.scala
+++ b/src/test/scala/at/logic/calculi/expansionTrees/ExpansionTreeTest.scala
@@ -4,193 +4,168 @@ package at.logic.calculi.expansionTrees
 import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import at.logic.language.hol.{Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _}
-import at.logic.language.lambda.types.{Ti => i, To => o, ->}
+import at.logic.language.hol.{ Atom => AtomHOL, And => AndHOL, Or => OrHOL, Imp => ImpHOL, _ }
+import at.logic.language.lambda.types.{ Ti => i, To => o, -> }
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ExpansionTreeTest extends SpecificationWithJUnit {
 
-  val alpha = HOLVar(("\\alpha" ), i)
-  val beta = HOLVar(("\\beta" ), i)
-  val c = HOLConst(("c" ), i)
-  val d = HOLConst(("d" ), i)
-  val a = HOLConst(("a" ), i)
-  val f = HOLConst("f", i -> i)
-  val x = HOLVar(("x" ), i)
-  val y = HOLVar(("y" ), i)
-  val z = HOLVar(("z" ), i)
-  val eq = HOLConst("=", i -> (i -> o) )
-  val P = HOLConst("P", i -> (i -> (i -> o)))
-  val Q = HOLConst("Q", i -> o)
-  val R = HOLConst("R", i -> o)
+  val alpha = HOLVar( ( "\\alpha" ), i )
+  val beta = HOLVar( ( "\\beta" ), i )
+  val c = HOLConst( ( "c" ), i )
+  val d = HOLConst( ( "d" ), i )
+  val a = HOLConst( ( "a" ), i )
+  val f = HOLConst( "f", i -> i )
+  val x = HOLVar( ( "x" ), i )
+  val y = HOLVar( ( "y" ), i )
+  val z = HOLVar( ( "z" ), i )
+  val eq = HOLConst( "=", i -> ( i -> o ) )
+  val P = HOLConst( "P", i -> ( i -> ( i -> o ) ) )
+  val Q = HOLConst( "Q", i -> o )
+  val R = HOLConst( "R", i -> o )
 
   val et1 = WeakQuantifier(
-    ExVar(x, AtomHOL(eq, x::x::Nil)),
-    List((Atom( AtomHOL(eq, c::c::Nil) ) , c))
-  )
+    ExVar( x, AtomHOL( eq, x :: x :: Nil ) ),
+    List( ( Atom( AtomHOL( eq, c :: c :: Nil ) ), c ) ) )
 
   val et2 = WeakQuantifier(
-    ExVar(x, AtomHOL(P, x::y::c::Nil)),
-    List((Atom( AtomHOL(P, z::y::c::Nil) ), z))
-  )
+    ExVar( x, AtomHOL( P, x :: y :: c :: Nil ) ),
+    List( ( Atom( AtomHOL( P, z :: y :: c :: Nil ) ), z ) ) )
 
   val et3 = StrongQuantifier(
-    AllVar(x, AtomHOL(P, x::d::z::Nil)),
+    AllVar( x, AtomHOL( P, x :: d :: z :: Nil ) ),
     z,
-    Atom( AtomHOL(P, z::d::z::Nil) )
-  )
+    Atom( AtomHOL( P, z :: d :: z :: Nil ) ) )
 
   val et4 = WeakQuantifier(
-    ExVar(x, AtomHOL(P, x::c::a::Nil)),
+    ExVar( x, AtomHOL( P, x :: c :: a :: Nil ) ),
     List(
-      (Atom( AtomHOL(P, z::c::a::Nil) ), z),
-      (Atom( AtomHOL(P, y::c::a::Nil) ), y)
-    )
-  )
-  
+      ( Atom( AtomHOL( P, z :: c :: a :: Nil ) ), z ),
+      ( Atom( AtomHOL( P, y :: c :: a :: Nil ) ), y ) ) )
+
   val et5 = Imp(
     WeakQuantifier(
-      AllVar(x, AtomHOL(R, x::Nil)),
+      AllVar( x, AtomHOL( R, x :: Nil ) ),
       List(
-        (Atom(AtomHOL(R, c::Nil)), c),
-        (Atom(AtomHOL(R, d::Nil)), d)
-      )
-    ),
+        ( Atom( AtomHOL( R, c :: Nil ) ), c ),
+        ( Atom( AtomHOL( R, d :: Nil ) ), d ) ) ),
     And(
-      Atom(AtomHOL(R, c::Nil)),
-      Atom(AtomHOL(R, d::Nil))
-    )
-  )
+      Atom( AtomHOL( R, c :: Nil ) ),
+      Atom( AtomHOL( R, d :: Nil ) ) ) )
 
   "Expansion Trees substitution" should {
 
     "replace variables correctly 1" in {
-      val s = Substitution(y, d)
-      val etPrime = substitute(s, et2)
+      val s = Substitution( y, d )
+      val etPrime = substitute( s, et2 )
 
       etPrime mustEqual WeakQuantifier(
-        ExVar(x, AtomHOL(P, x :: d :: c :: Nil)),
-        List((Atom(AtomHOL(P, z :: d :: c :: Nil)), z))
-      )
+        ExVar( x, AtomHOL( P, x :: d :: c :: Nil ) ),
+        List( ( Atom( AtomHOL( P, z :: d :: c :: Nil ) ), z ) ) )
     }
 
     "replace variables correctly 2" in {
-      val s = Substitution(z, d)
-      val etPrime = substitute(s, et2)
+      val s = Substitution( z, d )
+      val etPrime = substitute( s, et2 )
 
       etPrime mustEqual WeakQuantifier(
-        ExVar(x, AtomHOL(P, x :: y :: c :: Nil)),
-        List((Atom(AtomHOL(P, d :: y :: c :: Nil)), d))
-      )
+        ExVar( x, AtomHOL( P, x :: y :: c :: Nil ) ),
+        List( ( Atom( AtomHOL( P, d :: y :: c :: Nil ) ), d ) ) )
     }
 
     "replace variables correctly 3" in {
-      val s = Substitution(z, y)
-      val etPrime = substitute(s, et3)
+      val s = Substitution( z, y )
+      val etPrime = substitute( s, et3 )
 
       etPrime mustEqual StrongQuantifier(
-        AllVar(x, AtomHOL(P, x::d::y::Nil)),
+        AllVar( x, AtomHOL( P, x :: d :: y :: Nil ) ),
         y,
-        Atom( AtomHOL(P, y::d::y::Nil) )
-      )
+        Atom( AtomHOL( P, y :: d :: y :: Nil ) ) )
     }
 
     "not replace const " in {
-      val s = Substitution(HOLVar("c", i), HOLConst("d", i))
-      val etPrime = substitute(s, et1)
+      val s = Substitution( HOLVar( "c", i ), HOLConst( "d", i ) )
+      val etPrime = substitute( s, et1 )
 
       etPrime mustEqual et1
     }
 
     "create merge node in case of collapse in weak quantifier instances " in {
-      val s = Substitution(z, y)
-      val etPrime = substitute.applyNoMerge(s, et4)
+      val s = Substitution( z, y )
+      val etPrime = substitute.applyNoMerge( s, et4 )
 
-        etPrime mustEqual WeakQuantifier(
-        ExVar(x, AtomHOL(P, x::c::a::Nil)),
+      etPrime mustEqual WeakQuantifier(
+        ExVar( x, AtomHOL( P, x :: c :: a :: Nil ) ),
         List(
-          (MergeNode(Atom(AtomHOL(P, y::c::a::Nil)), Atom(AtomHOL(P, y::c::a::Nil))), y)
-        )
-      )
+          ( MergeNode( Atom( AtomHOL( P, y :: c :: a :: Nil ) ), Atom( AtomHOL( P, y :: c :: a :: Nil ) ) ), y ) ) )
     }
   }
 
   "Expansion Trees merge" should {
     "merge identical trees" in {
-      merge(MergeNode(et4, et4)) mustEqual( et4 )
+      merge( MergeNode( et4, et4 ) ) mustEqual ( et4 )
     }
 
     "do simple substitution as result of merge" in {
-      val etSubst1 = Neg( StrongQuantifier(AllVar(x, AtomHOL(Q, x::Nil) ), z, Atom( AtomHOL(Q, z::Nil)) ) )
-      val etSubst2 = Neg( StrongQuantifier(AllVar(x, AtomHOL(Q, x::Nil) ), y, Atom( AtomHOL(Q, y::Nil)) ) )
+      val etSubst1 = Neg( StrongQuantifier( AllVar( x, AtomHOL( Q, x :: Nil ) ), z, Atom( AtomHOL( Q, z :: Nil ) ) ) )
+      val etSubst2 = Neg( StrongQuantifier( AllVar( x, AtomHOL( Q, x :: Nil ) ), y, Atom( AtomHOL( Q, y :: Nil ) ) ) )
 
       // from a theoretical point of view, the result could also be equal to the second tree, but users probably expect the algo to work from left to right
-      merge( MergeNode(etSubst1, etSubst2) ) mustEqual etSubst1
+      merge( MergeNode( etSubst1, etSubst2 ) ) mustEqual etSubst1
     }
 
     "do simple substitution as result of merge with context" in {
-      val etSubst1 = Neg( StrongQuantifier(AllVar(x, AtomHOL(Q, x::Nil) ), z, Atom( AtomHOL(Q, z::Nil)) ) )
-      val etSubst2 = Neg( StrongQuantifier(AllVar(x, AtomHOL(Q, x::Nil) ), y, Atom( AtomHOL(Q, y::Nil)) ) )
-      merge( MergeNode(etSubst1, etSubst2) ) mustEqual etSubst1
+      val etSubst1 = Neg( StrongQuantifier( AllVar( x, AtomHOL( Q, x :: Nil ) ), z, Atom( AtomHOL( Q, z :: Nil ) ) ) )
+      val etSubst2 = Neg( StrongQuantifier( AllVar( x, AtomHOL( Q, x :: Nil ) ), y, Atom( AtomHOL( Q, y :: Nil ) ) ) )
+      merge( MergeNode( etSubst1, etSubst2 ) ) mustEqual etSubst1
     }
 
     "do merge with substitution in other tree of sequent triggered by merge" in {
       // example from Chaudhuri et.al : A multi-focused proof system isomorphic to expansion proofs
-      val etSubst1 = StrongQuantifier(AllVar(x, AtomHOL(R, x::Nil) ), z, Atom( AtomHOL(R, z::Nil)) )
-      val etSubst2 = StrongQuantifier(AllVar(x, AtomHOL(R, x::Nil) ), y, Atom( AtomHOL(R, y::Nil)) )
-      val fy = Function(f, y::Nil)
-      val fz = Function(f, z::Nil)
-      val seq = (Nil,
+      val etSubst1 = StrongQuantifier( AllVar( x, AtomHOL( R, x :: Nil ) ), z, Atom( AtomHOL( R, z :: Nil ) ) )
+      val etSubst2 = StrongQuantifier( AllVar( x, AtomHOL( R, x :: Nil ) ), y, Atom( AtomHOL( R, y :: Nil ) ) )
+      val fy = Function( f, y :: Nil )
+      val fz = Function( f, z :: Nil )
+      val seq = ( Nil,
         // only succedent:
-        MergeNode(etSubst1, etSubst2) ::
-        WeakQuantifier(ExVar(x, AtomHOL(R, x::Nil)), List(
-          (Atom(AtomHOL(R, fz::Nil)), fz ),
-          (Atom(AtomHOL(R, fy::Nil)), fy )
-        )) ::
-        Atom( AtomHOL(R, z::Nil) ) ::
-        Atom( AtomHOL(R, y::Nil) ) ::
-        Nil
-        )
-      val mergedSeq = merge(seq)
+        MergeNode( etSubst1, etSubst2 ) ::
+        WeakQuantifier( ExVar( x, AtomHOL( R, x :: Nil ) ), List(
+          ( Atom( AtomHOL( R, fz :: Nil ) ), fz ),
+          ( Atom( AtomHOL( R, fy :: Nil ) ), fy ) ) ) ::
+        Atom( AtomHOL( R, z :: Nil ) ) ::
+        Atom( AtomHOL( R, y :: Nil ) ) ::
+        Nil )
+      val mergedSeq = merge( seq )
 
       // merge will trigger a substitution y -> z
 
-      val testResult = new ExpansionSequent(Nil,
-        (StrongQuantifier(AllVar(x, AtomHOL(R, x::Nil)), z, Atom( AtomHOL(R, z::Nil))) ::
-        WeakQuantifier(ExVar(x, AtomHOL(R, x::Nil)), List( (Atom(AtomHOL(R, fz::Nil)), fz))) ::
-        Atom( AtomHOL(R, z::Nil) ) ::
-        Atom( AtomHOL(R, z::Nil) ) ::
-        Nil).asInstanceOf[Seq[ExpansionTree]]
-      )
-
+      val testResult = new ExpansionSequent( Nil,
+        ( StrongQuantifier( AllVar( x, AtomHOL( R, x :: Nil ) ), z, Atom( AtomHOL( R, z :: Nil ) ) ) ::
+          WeakQuantifier( ExVar( x, AtomHOL( R, x :: Nil ) ), List( ( Atom( AtomHOL( R, fz :: Nil ) ), fz ) ) ) ::
+          Atom( AtomHOL( R, z :: Nil ) ) ::
+          Atom( AtomHOL( R, z :: Nil ) ) ::
+          Nil ).asInstanceOf[Seq[ExpansionTree]] )
 
       mergedSeq mustEqual testResult
     }
 
-
-
   }
-  
+
   "toDeep" should {
     "correctly compute the deep formula" in {
       val form = ImpHOL(
         AndHOL(
-          AtomHOL(R, c::Nil),
-          AtomHOL(R, d::Nil)
-        ),
+          AtomHOL( R, c :: Nil ),
+          AtomHOL( R, d :: Nil ) ),
         AndHOL(
-          AtomHOL(R, c::Nil),
-          AtomHOL(R, d::Nil)
-        )
-      )
-      
-      val deep = toDeep(et5, 1)
-      
+          AtomHOL( R, c :: Nil ),
+          AtomHOL( R, d :: Nil ) ) )
+
+      val deep = toDeep( et5, 1 )
+
       deep mustEqual form
     }
   }
 
 }
-
 

--- a/src/test/scala/at/logic/calculi/lk/LKTest.scala
+++ b/src/test/scala/at/logic/calculi/lk/LKTest.scala
@@ -13,34 +13,34 @@ import at.logic.language.hol._
 import at.logic.language.lambda.types._
 import at.logic.language.hol.logicSymbols._
 import base._
-import at.logic.language.fol.{Atom => FOLAtom, AllVar => FOLAllVar, ExVar => FOLExVar, FOLFormula, FOLConst, FOLVar}
+import at.logic.language.fol.{ Atom => FOLAtom, AllVar => FOLAllVar, ExVar => FOLExVar, FOLFormula, FOLConst, FOLVar }
 
 /**
-* The following properties of each rule are tested:
-* 1) The right principal formula is created
-* 2) The principal formula is managed correctly
-* 3) The Auxiliaries formulas are managed in the correct way
-* 4) The context is unchanged with regard to multiset equality
-* 5) The formula occurrences are different from the upper sequents occurrences
-*
-* Still missing for each rule:
-* 1) To check that all exceptions are thrown when needed
-*/
-@RunWith(classOf[JUnitRunner])
+ * The following properties of each rule are tested:
+ * 1) The right principal formula is created
+ * 2) The principal formula is managed correctly
+ * 3) The Auxiliaries formulas are managed in the correct way
+ * 4) The context is unchanged with regard to multiset equality
+ * 5) The formula occurrences are different from the upper sequents occurrences
+ *
+ * Still missing for each rule:
+ * 1) To check that all exceptions are thrown when needed
+ */
+@RunWith( classOf[JUnitRunner] )
 class LKTest extends SpecificationWithJUnit {
 
-  val c1 = HOLVar("a", Ti->To)
-  val v1 = HOLVar("x", Ti)
-  val f1 = Atom(c1,v1::Nil)
-  val ax = Axiom(f1::Nil, f1::Nil)
+  val c1 = HOLVar( "a", Ti -> To )
+  val v1 = HOLVar( "x", Ti )
+  val f1 = Atom( c1, v1 :: Nil )
+  val ax = Axiom( f1 :: Nil, f1 :: Nil )
   val a1 = ax // Axiom return a pair of the proof and a mapping and we want only the proof here
-  val c2 = HOLVar("b", Ti->To)
-  val v2 = HOLVar("c", Ti)
-  val f2 = Atom(c1,v1::Nil)
-  val f3 = Atom(HOLVar("e", To))
-  val a2 = Axiom(f2::f3::Nil, f2::f3::Nil)
-  val a3 = Axiom(f2::f2::f3::Nil, f2::f2::f3::Nil)
-  val ap = Axiom(f1::f1::Nil, Nil)
+  val c2 = HOLVar( "b", Ti -> To )
+  val v2 = HOLVar( "c", Ti )
+  val f2 = Atom( c1, v1 :: Nil )
+  val f3 = Atom( HOLVar( "e", To ) )
+  val a2 = Axiom( f2 :: f3 :: Nil, f2 :: f3 :: Nil )
+  val a3 = Axiom( f2 :: f2 :: f3 :: Nil, f2 :: f2 :: f3 :: Nil )
+  val ap = Axiom( f1 :: f1 :: Nil, Nil )
   val a4 = ap
   val pr = WeakeningRightRule( ax, f1 )
   val pr1 = OrRightRule( pr, f1, f1 )
@@ -51,203 +51,203 @@ class LKTest extends SpecificationWithJUnit {
 
     "work for Axioms" in {
       "- Formula occurrences have correct formulas" in {
-        (a1) must beLike {case Axiom(Sequent(x,y)) => (x(0).formula == f1) && (y(0).formula == f1) must_== true}
+        ( a1 ) must beLike { case Axiom( Sequent( x, y ) ) => ( x( 0 ).formula == f1 ) && ( y( 0 ).formula == f1 ) must_== true }
       }
       "- Same formulas on the same side must become different occurrences" in {
         val ant = a4.root.antecedent.toList
-        (ant.length) must beEqualTo(2)
-        (ant.head) must not be(ant.last)
+        ( ant.length ) must beEqualTo( 2 )
+        ( ant.head ) must not be ( ant.last )
       }
     }
 
     "work for WeakeningLeftRule" in {
-      val a = WeakeningLeftRule(a2, f1)
-      val (up1, Sequent(x,y), prin1) = WeakeningLeftRule.unapply(a).get
+      val a = WeakeningLeftRule( a2, f1 )
+      val ( up1, Sequent( x, y ), prin1 ) = WeakeningLeftRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (f1)
+        ( prin1.formula ) must beEqualTo( f1 )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
-        ((y).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
+        ( ( y ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for WeakeningRightRule" in {
-      val a = WeakeningRightRule(a2, f1)
-      val (up1, Sequent(x,y), prin1) = WeakeningRightRule.unapply(a).get
+      val a = WeakeningRightRule( a2, f1 )
+      val ( up1, Sequent( x, y ), prin1 ) = WeakeningRightRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (f1)
+        ( prin1.formula ) must beEqualTo( f1 )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
-        ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
+        ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
+        ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for ContractionLeftRule" in {
-      val a = ContractionLeftRule(a3, a3.root.antecedent(0), a3.root.antecedent(1))
-      val (up1,  Sequent(x,y), aux1, aux2, prin1) = ContractionLeftRule.unapply(a).get
+      val a = ContractionLeftRule( a3, a3.root.antecedent( 0 ), a3.root.antecedent( 1 ) )
+      val ( up1, Sequent( x, y ), aux1, aux2, prin1 ) = ContractionLeftRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (f2)
+        ( prin1.formula ) must beEqualTo( f2 )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x.map(x => x.formula)) must contain(prin1.formula)
+        ( x.map( x => x.formula ) ) must contain( prin1.formula )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(x => x.formula).filter(y => y == aux1.formula)) must be_!=(2)
+        ( x.map( x => x.formula ).filter( y => y == aux1.formula ) ) must be_!=( 2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.filterNot(_ == aux1).filterNot(_ == aux2)).toList.map(x => x.formula))
-        ((y).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.filterNot( _ == aux1 ).filterNot( _ == aux2 ) ).toList.map( x => x.formula ) )
+        ( ( y ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for ContractionRightRule" in {
-      val a = ContractionRightRule(a3, a3.root.succedent(0),a3.root.succedent(1))
-      val (up1,  Sequent(x,y), aux1, aux2, prin1) = ContractionRightRule.unapply(a).get
+      val a = ContractionRightRule( a3, a3.root.succedent( 0 ), a3.root.succedent( 1 ) )
+      val ( up1, Sequent( x, y ), aux1, aux2, prin1 ) = ContractionRightRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (f2)
+        ( prin1.formula ) must beEqualTo( f2 )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y.map(x => x.formula)) must contain(prin1.formula)
+        ( y.map( x => x.formula ) ) must contain( prin1.formula )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.map(y => y.formula).filter(x => x == aux1.formula)) must be_!=(2)
+        ( y.map( y => y.formula ).filter( x => x == aux1.formula ) ) must be_!=( 2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux1).filterNot(_ == aux2)).toList.map(x => x.formula))
-        ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
+        ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux1 ).filterNot( _ == aux2 ) ).toList.map( x => x.formula ) )
+        ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for CutRule" in {
-      val a = CutRule(a2, a3, a2.root.succedent(0), a3.root.antecedent(0))
-      val (up1, up2, Sequent(x,y), aux1, aux2) = CutRule.unapply(a).get
+      val a = CutRule( a2, a3, a2.root.succedent( 0 ), a3.root.antecedent( 0 ) )
+      val ( up1, up2, Sequent( x, y ), aux1, aux2 ) = CutRule.unapply( a ).get
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.filter(z => z.formula == f2)).size must beEqualTo(2)
-        (x.filter(z => z.formula == f2)).size must beEqualTo(2)
+        ( y.filter( z => z.formula == f2 ) ).size must beEqualTo( 2 )
+        ( x.filter( z => z.formula == f2 ) ).size must beEqualTo( 2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y).map(x => x.formula)) must beEqualTo (((up1.root.succedent.filterNot(_ == aux1)) ++ up2.root.succedent).map(x => x.formula))
-        ((x).map(x => x.formula)) must beEqualTo ((up1.root.antecedent ++ (up2.root.antecedent.filterNot(_ == aux2))).map(x => x.formula))
+        ( ( y ).map( x => x.formula ) ) must beEqualTo( ( ( up1.root.succedent.filterNot( _ == aux1 ) ) ++ up2.root.succedent ).map( x => x.formula ) )
+        ( ( x ).map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ++ ( up2.root.antecedent.filterNot( _ == aux2 ) ) ).map( x => x.formula ) )
       }
     }
 
     "work for AndRightRule" in {
-      val a = AndRightRule(a1, a2, f1, f2)
-      val (up1, up2, Sequent(x,y), aux1, aux2, prin1) = AndRightRule.unapply(a).get
+      val a = AndRightRule( a1, a2, f1, f2 )
+      val ( up1, up2, Sequent( x, y ), aux1, aux2, prin1 ) = AndRightRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (And(f1,f2))
+        ( prin1.formula ) must beEqualTo( And( f1, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.map(z => z.formula)) must not contain(f1)
-        (y.map(z => z.formula)) must not contain(f2)
+        ( y.map( z => z.formula ) ) must not contain ( f1 )
+        ( y.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        (x.toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.toList ++ up2.root.antecedent.toList).map(x => x.formula))
-        ((y.toList.map(x => x.formula).filterNot(x => x == And(f1,f2)))) must beEqualTo (((up1.root.succedent.filterNot(_ == aux1)).toList ++ (up2.root.succedent.filterNot(_ ==  aux2)).toList).map(x => x.formula))
+        ( x.toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.toList ++ up2.root.antecedent.toList ).map( x => x.formula ) )
+        ( ( y.toList.map( x => x.formula ).filterNot( x => x == And( f1, f2 ) ) ) ) must beEqualTo( ( ( up1.root.succedent.filterNot( _ == aux1 ) ).toList ++ ( up2.root.succedent.filterNot( _ == aux2 ) ).toList ).map( x => x.formula ) )
       }
     }
 
     "work for AndLeft1Rule" in {
-      val a = AndLeft1Rule(a2, f2, f1)
-      val (up1,  Sequent(x,y), aux1, prin1) = AndLeft1Rule.unapply(a).get
+      val a = AndLeft1Rule( a2, f2, f1 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = AndLeft1Rule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (And(f2,f1))
+        ( prin1.formula ) must beEqualTo( And( f2, f1 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(z => z.formula)) must not contain(f2)
+        ( x.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.filterNot(_ == aux1)).toList.map(x => x.formula))
-        ((y).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
+        ( ( y ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for AndLeft2Rule" in {
-      val a = AndLeft2Rule(a2, f1, f2)
-      val (up1,  Sequent(x,y), aux1, prin1) = AndLeft2Rule.unapply(a).get
+      val a = AndLeft2Rule( a2, f1, f2 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = AndLeft2Rule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (And(f1,f2))
+        ( prin1.formula ) must beEqualTo( And( f1, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(z => z.formula)) must not contain(f1)
+        ( x.map( z => z.formula ) ) must not contain ( f1 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.filterNot(_ == aux1)).toList.map(x => x.formula))
-        ((y).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
+        ( ( y ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for AndLeftRule" in {
-      val a = AndLeftRule(a2, f1, f3)
+      val a = AndLeftRule( a2, f1, f3 )
       "- Principal formula is created correctly" in {
-        (a.prin.head.formula) must beEqualTo (And(f1,f3))
+        ( a.prin.head.formula ) must beEqualTo( And( f1, f3 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (a.root.antecedent) must contain(a.prin.head)
+        ( a.root.antecedent ) must contain( a.prin.head )
       }
 
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (a.root.antecedent) must not (contain(f1))
-        (a.root.antecedent) must not (contain(f3))
+        ( a.root.antecedent ) must not( contain( f1 ) )
+        ( a.root.antecedent ) must not( contain( f3 ) )
       }
 
       "- Principal formula is created correctly when auxiliary formulas are equal" in {
-        (pr3.prin.head.formula) must beEqualTo (And(f1,f1))
+        ( pr3.prin.head.formula ) must beEqualTo( And( f1, f1 ) )
       }
 
       "- Lower sequent must not contain the auxiliary formulas when auxiliary formulas are equal" in {
-        (pr3.root.antecedent) must not (contain(f1))
+        ( pr3.root.antecedent ) must not( contain( f1 ) )
       }
     }
 
     "work for OrLeftRule" in {
-      val a = OrLeftRule(a1, a2, f1, f2)
-      val (up1, up2, Sequent(x,y), aux1, aux2, prin1) = OrLeftRule.unapply(a).get
+      val a = OrLeftRule( a1, a2, f1, f2 )
+      val ( up1, up2, Sequent( x, y ), aux1, aux2, prin1 ) = OrLeftRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Or(f1,f2))
+        ( prin1.formula ) must beEqualTo( Or( f1, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(z => z.formula)) must not contain(f1)
-        (x.map(z => z.formula)) must not contain(f2)
+        ( x.map( z => z.formula ) ) must not contain ( f1 )
+        ( x.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        (y.toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.toList ++ up2.root.succedent.toList).map(x => x.formula))
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo (((up1.root.antecedent.filterNot(_ == aux1)).toList ++ (up2.root.antecedent .filterNot(_ == aux2)).toList).map(x => x.formula))
+        ( y.toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.toList ++ up2.root.succedent.toList ).map( x => x.formula ) )
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( ( up1.root.antecedent.filterNot( _ == aux1 ) ).toList ++ ( up2.root.antecedent.filterNot( _ == aux2 ) ).toList ).map( x => x.formula ) )
       }
 
       "- Descendants must be correctly computed" in {
         "(1)" in {
           // get descendant of occurrence of left auxiliary formula
-          a.getDescendantInLowerSequent(a1.root.antecedent(0)) must beLike {
-            case Some(x) => x.formula == Or(f1, f2) must_== true
-            case None => ko
+          a.getDescendantInLowerSequent( a1.root.antecedent( 0 ) ) must beLike {
+            case Some( x ) => x.formula == Or( f1, f2 ) must_== true
+            case None      => ko
           }
         }
         "(2)" in {
           // get descendant of occurrence of left premise context in succedent
-          a.getDescendantInLowerSequent(a1.root.succedent(0)) must beLike {
-            case Some(x) => x.formula == f1 must_== true
-            case None => ko
+          a.getDescendantInLowerSequent( a1.root.succedent( 0 ) ) must beLike {
+            case Some( x ) => x.formula == f1 must_== true
+            case None      => ko
           }
         }
       }
@@ -255,121 +255,121 @@ class LKTest extends SpecificationWithJUnit {
 
     "work for OrRightRule" in {
       "- Principal formula is created correctly when auxiliary formulas are equal" in {
-        (pr1.prin.head.formula) must beEqualTo (Or(f1,f1))
+        ( pr1.prin.head.formula ) must beEqualTo( Or( f1, f1 ) )
       }
 
       "- Lower sequent must not contain the auxiliary formulas when auxiliary formulas are equal" in {
-        (pr1.root.succedent) must not (contain(f1))
+        ( pr1.root.succedent ) must not( contain( f1 ) )
       }
     }
 
     "work for OrRight1Rule" in {
-      val a = OrRight1Rule(a2, f2, f1)
-      val (up1,  Sequent(x,y), aux1, prin1) = OrRight1Rule.unapply(a).get
+      val a = OrRight1Rule( a2, f2, f1 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = OrRight1Rule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Or(f2,f1))
+        ( prin1.formula ) must beEqualTo( Or( f2, f1 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.map(z => z.formula)) must not contain(f2)
+        ( y.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux1)).toList.map(x => x.formula))
-        ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
+        ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
+        ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for OrRight2Rule" in {
-      val a = OrRight2Rule(a2, f1, f2)
-      val (up1,  Sequent(x,y), aux1, prin1) = OrRight2Rule.unapply(a).get
+      val a = OrRight2Rule( a2, f1, f2 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = OrRight2Rule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Or(f1,f2))
+        ( prin1.formula ) must beEqualTo( Or( f1, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.map(z => z.formula)) must not contain(f1)
+        ( y.map( z => z.formula ) ) must not contain ( f1 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux1)).toList.map(x => x.formula))
-        ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
+        ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
+        ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
       }
     }
 
     "work for ImpLeftRule" in {
-      val a = ImpLeftRule(a1, a2, f1, f2)
-      val (up1, up2, Sequent(x,y), aux1, aux2, prin1) = ImpLeftRule.unapply(a).get
+      val a = ImpLeftRule( a1, a2, f1, f2 )
+      val ( up1, up2, Sequent( x, y ), aux1, aux2, prin1 ) = ImpLeftRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Imp(f1,f2))
+        ( prin1.formula ) must beEqualTo( Imp( f1, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.filter(z => z.formula == f1)).size must beEqualTo(1)
-        (x.filter(z => z.formula == f2)).size must beEqualTo(1)
+        ( y.filter( z => z.formula == f1 ) ).size must beEqualTo( 1 )
+        ( x.filter( z => z.formula == f2 ) ).size must beEqualTo( 1 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        "1" in { (y.toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux1).toList ++ (up2.root.succedent).toList).map(x => x.formula))}
-        "2" in { ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.toList ++ (up2.root.antecedent.filterNot(_ == aux2)).toList).map(x => x.formula))}
+        "1" in { ( y.toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux1 ).toList ++ ( up2.root.succedent ).toList ).map( x => x.formula ) ) }
+        "2" in { ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.toList ++ ( up2.root.antecedent.filterNot( _ == aux2 ) ).toList ).map( x => x.formula ) ) }
       }
     }
 
     "work for ImpRightRule" in {
-      val a = ImpRightRule(a2, f2, f2)
-      val (up1,  Sequent(x,y), aux1, aux2, prin1) = ImpRightRule.unapply(a).get
+      val a = ImpRightRule( a2, f2, f2 )
+      val ( up1, Sequent( x, y ), aux1, aux2, prin1 ) = ImpRightRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Imp(f2,f2))
+        ( prin1.formula ) must beEqualTo( Imp( f2, f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(z => z.formula)) must not contain(f2)
-        (y.map(z => z.formula)) must not contain(f2)
+        ( x.map( z => z.formula ) ) must not contain ( f2 )
+        ( y.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        "1" in { ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux2)).toList.map(x => x.formula))}
-        "2" in { ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.filterNot(_ == aux1)).toList.map(x => x.formula))}
+        "1" in { ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux2 ) ).toList.map( x => x.formula ) ) }
+        "2" in { ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) ) }
       }
     }
 
     "work for NegRightRule" in {
-      val a = NegRightRule(a2, f2)
-      val (up1,  Sequent(x,y), aux1, prin1) = NegRightRule.unapply(a).get
+      val a = NegRightRule( a2, f2 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = NegRightRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Neg(f2))
+        ( prin1.formula ) must beEqualTo( Neg( f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (y) must contain(prin1)
+        ( y ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (x.map(z => z.formula)) must not contain(f2)
+        ( x.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((y.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent).toList.map(x => x.formula))
-        ((x).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent.filterNot(_ == aux1)).toList.map(x => x.formula))
+        ( ( y.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent ).toList.map( x => x.formula ) )
+        ( ( x ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
       }
     }
 
     "work for NegLeftRule" in {
-      val a = NegLeftRule(a2, f2)
-      val (up1, Sequent(x,y), aux1, prin1) = NegLeftRule.unapply(a).get
+      val a = NegLeftRule( a2, f2 )
+      val ( up1, Sequent( x, y ), aux1, prin1 ) = NegLeftRule.unapply( a ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (Neg(f2))
+        ( prin1.formula ) must beEqualTo( Neg( f2 ) )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (x) must contain(prin1)
+        ( x ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (y.map(z => z.formula)) must not contain(f2)
+        ( y.map( z => z.formula ) ) must not contain ( f2 )
       }
       "- Context should stay unchanged with regard to multiset equality" in {
-        ((x.filterNot(_ == prin1)).toList.map(x => x.formula)) must beEqualTo ((up1.root.antecedent).toList.map(x => x.formula))
-        ((y).toList.map(x => x.formula)) must beEqualTo ((up1.root.succedent.filterNot(_ == aux1)).toList.map(x => x.formula))
+        ( ( x.filterNot( _ == prin1 ) ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.antecedent ).toList.map( x => x.formula ) )
+        ( ( y ).toList.map( x => x.formula ) ) must beEqualTo( ( up1.root.succedent.filterNot( _ == aux1 ) ).toList.map( x => x.formula ) )
       }
     }
 
@@ -377,334 +377,334 @@ class LKTest extends SpecificationWithJUnit {
       val q = HOLVar( "q", Ti -> To )
       val x = HOLVar( "X", Ti )
       val subst = HOLAbs( x, HOLApp( q, x ) ) // lambda x. q(x)
-      val p = HOLVar( "p", (Ti -> To) -> To )
+      val p = HOLVar( "p", ( Ti -> To ) -> To )
       val a = HOLVar( "a", Ti )
-      val qa = Atom( q, a::Nil )
-      val pl = Atom( p, subst::Nil )
-      val aux = Or( pl, qa )                  // p(lambda x. q(x)) or q(a)
+      val qa = Atom( q, a :: Nil )
+      val pl = Atom( p, subst :: Nil )
+      val aux = Or( pl, qa ) // p(lambda x. q(x)) or q(a)
       val z = HOLVar( "Z", Ti -> To )
-      val pz = Atom( p, z::Nil )
-      val za = Atom( z, a::Nil )
-      val main = AllVar( z, Or( pz, za ) )    // forall lambda z. p(z) or z(a)
-      val ax = Axiom(aux::Nil, Nil)
-      val rule = ForallLeftRule(ax, aux, main, subst)
-      val (up1,  Sequent(ant,succ), aux1, prin1, term) = ForallLeftRule.unapply(rule).get
+      val pz = Atom( p, z :: Nil )
+      val za = Atom( z, a :: Nil )
+      val main = AllVar( z, Or( pz, za ) ) // forall lambda z. p(z) or z(a)
+      val ax = Axiom( aux :: Nil, Nil )
+      val rule = ForallLeftRule( ax, aux, main, subst )
+      val ( up1, Sequent( ant, succ ), aux1, prin1, term ) = ForallLeftRule.unapply( rule ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (main)
+        ( prin1.formula ) must beEqualTo( main )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (ant) must contain(prin1)
+        ( ant ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (ant) must not contain(aux1)
+        ( ant ) must not contain ( aux1 )
       }
     }
 
     "work for ForallRightRule" in {
-      val x = HOLVar( "X", Ti -> To)            // eigenvar
-      val p = HOLVar( "p", (Ti -> To) -> To )
+      val x = HOLVar( "X", Ti -> To ) // eigenvar
+      val p = HOLVar( "p", ( Ti -> To ) -> To )
       val a = HOLVar( "a", Ti )
-      val xa = Atom( x, a::Nil )
-      val px = Atom( p, x::Nil )
-      val aux = Or( px, xa )                  // p(x) or x(a)
+      val xa = Atom( x, a :: Nil )
+      val px = Atom( p, x :: Nil )
+      val aux = Or( px, xa ) // p(x) or x(a)
       val z = HOLVar( "Z", Ti -> To )
-      val pz = Atom( p, z::Nil )
-      val za = Atom( z, a::Nil )
-      val main = AllVar( z, Or( pz, za ) )    // forall lambda z. p(z) or z(a)
-      val ax = Axiom(Nil, aux::Nil )
-      val rule = ForallRightRule(ax, aux, main, x)
-      val (up1,  Sequent(ant,succ), aux1, prin1, ev) = ForallRightRule.unapply(rule).get
+      val pz = Atom( p, z :: Nil )
+      val za = Atom( z, a :: Nil )
+      val main = AllVar( z, Or( pz, za ) ) // forall lambda z. p(z) or z(a)
+      val ax = Axiom( Nil, aux :: Nil )
+      val rule = ForallRightRule( ax, aux, main, x )
+      val ( up1, Sequent( ant, succ ), aux1, prin1, ev ) = ForallRightRule.unapply( rule ).get
       "- Principal formula is created correctly" in {
-        (prin1.formula) must beEqualTo (main)
+        ( prin1.formula ) must beEqualTo( main )
       }
       "- Principal formula must be contained in the right part of the sequent" in {
-        (succ) must contain(prin1)
+        ( succ ) must contain( prin1 )
       }
       "- Lower sequent must not contain the auxiliary formulas" in {
-        (succ) must not contain(aux1)
+        ( succ ) must not contain ( aux1 )
       }
     }
 
     "work for weak quantifier rules" in {
-      val List(x,y,z) = List(("x", Ti->Ti),("y",Ti->Ti) ,("z", Ti->Ti)) map (u => HOLVar(u._1,u._2))
-      val List(p,a,b) = List(("P", (Ti->Ti) -> ((Ti->Ti) -> ((Ti->Ti) -> To))),
-                             ("a", Ti->Ti) ,
-                             ("b", Ti->Ti)) map (u => HOLConst(u._1,u._2))
-      val paba = Atom(p,List(a,b,a))
-      val pxba = Atom(p,List(x,b,a))
-      val expxba = ExVar(x,pxba)
-      val allpxba = AllVar(x,pxba)
+      val List( x, y, z ) = List( ( "x", Ti -> Ti ), ( "y", Ti -> Ti ), ( "z", Ti -> Ti ) ) map ( u => HOLVar( u._1, u._2 ) )
+      val List( p, a, b ) = List( ( "P", ( Ti -> Ti ) -> ( ( Ti -> Ti ) -> ( ( Ti -> Ti ) -> To ) ) ),
+        ( "a", Ti -> Ti ),
+        ( "b", Ti -> Ti ) ) map ( u => HOLConst( u._1, u._2 ) )
+      val paba = Atom( p, List( a, b, a ) )
+      val pxba = Atom( p, List( x, b, a ) )
+      val expxba = ExVar( x, pxba )
+      val allpxba = AllVar( x, pxba )
 
-      val ax1 = Axiom(paba::Nil, Nil)
-      ForallLeftRule(ax1, ax1.root.occurrences(0), allpxba, a).root.occurrences(0).formula must_==(allpxba)
+      val ax1 = Axiom( paba :: Nil, Nil )
+      ForallLeftRule( ax1, ax1.root.occurrences( 0 ), allpxba, a ).root.occurrences( 0 ).formula must_== ( allpxba )
 
-      ForallLeftRule(ax1, ax1.root.occurrences(0), allpxba, b).root.occurrences(0).formula must_==(allpxba) must throwAn[Exception]()
+      ForallLeftRule( ax1, ax1.root.occurrences( 0 ), allpxba, b ).root.occurrences( 0 ).formula must_== ( allpxba ) must throwAn[Exception]()
 
-      val ax2 = Axiom(Nil, paba::Nil)
-      ExistsRightRule(ax2, ax2.root.occurrences(0), expxba, a).root.occurrences(0).formula must_==(expxba)
-      ExistsRightRule(ax2, ax2.root.occurrences(0), expxba, b).root.occurrences(0).formula must_==(expxba) must throwAn[Exception]()
+      val ax2 = Axiom( Nil, paba :: Nil )
+      ExistsRightRule( ax2, ax2.root.occurrences( 0 ), expxba, a ).root.occurrences( 0 ).formula must_== ( expxba )
+      ExistsRightRule( ax2, ax2.root.occurrences( 0 ), expxba, b ).root.occurrences( 0 ).formula must_== ( expxba ) must throwAn[Exception]()
     }
 
     "work for first order proofs (1)" in {
-      val List(a,b) = List("a","b") map (FOLConst(_))
-      val List(x,y) = List("x","y") map (FOLVar(_))
+      val List( a, b ) = List( "a", "b" ) map ( FOLConst( _ ) )
+      val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )
       val p = "P"
-      val pay = FOLAtom(p, List(a,y))
-      val allxpax = FOLAllVar(x,FOLAtom(p, List(a,x)))
-      val ax = Axiom(List(pay), List(pay))
-      val i1 = ForallLeftRule(ax, ax.root.antecedent(0), allxpax, y)
-      val i2 = ForallRightRule(i1, i1.root.succedent(0), allxpax, y)
-      val i3 = OrRight1Rule(i2, i2.root.succedent(0), pay)
+      val pay = FOLAtom( p, List( a, y ) )
+      val allxpax = FOLAllVar( x, FOLAtom( p, List( a, x ) ) )
+      val ax = Axiom( List( pay ), List( pay ) )
+      val i1 = ForallLeftRule( ax, ax.root.antecedent( 0 ), allxpax, y )
+      val i2 = ForallRightRule( i1, i1.root.succedent( 0 ), allxpax, y )
+      val i3 = OrRight1Rule( i2, i2.root.succedent( 0 ), pay )
 
       i2.root.toFSequent match {
-        case FSequent(List(f1), List(f2)) =>
-          f1 mustEqual(allxpax)
-          f2 mustEqual(allxpax)
+        case FSequent( List( f1 ), List( f2 ) ) =>
+          f1 mustEqual ( allxpax )
+          f2 mustEqual ( allxpax )
           f1 must beAnInstanceOf[FOLFormula]
           f2 must beAnInstanceOf[FOLFormula]
         case fs @ _ =>
-          ko("Wrong result sequent "+fs)
+          ko( "Wrong result sequent " + fs )
       }
 
-      i3.root.toFSequent.formulas map (_ must beAnInstanceOf[FOLFormula])
+      i3.root.toFSequent.formulas map ( _ must beAnInstanceOf[FOLFormula] )
     }
 
     "work for first order proofs (2)" in {
-      val List(a,b) = List("a","b") map (FOLConst(_))
-      val List(x,y) = List("x","y") map (FOLVar(_))
+      val List( a, b ) = List( "a", "b" ) map ( FOLConst( _ ) )
+      val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )
       val p = "P"
-      val pay = FOLAtom(p, List(a,y))
-      val allxpax = FOLExVar(x,FOLAtom(p, List(a,x)))
-      val ax = Axiom(List(pay), List(pay))
-      val i1 = ExistsRightRule(ax, ax.root.succedent(0), allxpax, y)
-      val i2 = ExistsLeftRule(i1, i1.root.antecedent(0), allxpax, y)
+      val pay = FOLAtom( p, List( a, y ) )
+      val allxpax = FOLExVar( x, FOLAtom( p, List( a, x ) ) )
+      val ax = Axiom( List( pay ), List( pay ) )
+      val i1 = ExistsRightRule( ax, ax.root.succedent( 0 ), allxpax, y )
+      val i2 = ExistsLeftRule( i1, i1.root.antecedent( 0 ), allxpax, y )
       i2.root.toFSequent match {
-        case FSequent(List(f1), List(f2)) =>
-          f1 mustEqual(allxpax)
-          f2 mustEqual(allxpax)
+        case FSequent( List( f1 ), List( f2 ) ) =>
+          f1 mustEqual ( allxpax )
+          f2 mustEqual ( allxpax )
           f1 must beAnInstanceOf[FOLFormula]
           f2 must beAnInstanceOf[FOLFormula]
         case fs @ _ =>
-          ko("Wrong result sequent "+fs)
+          ko( "Wrong result sequent " + fs )
       }
     }
 
   }
 
   "Equality rules" should {
-    val (s, t) = (HOLConst("s", Ti), HOLConst("t", Ti))
-    val P = HOLConst("P", Ti -> To)
-    val Q = HOLConst("Q", Ti -> (Ti -> To))
-    val est = Equation(s, t)
-    val Ps = Atom(P, List(s))
-    val Pt = Atom (P, List(t))
+    val ( s, t ) = ( HOLConst( "s", Ti ), HOLConst( "t", Ti ) )
+    val P = HOLConst( "P", Ti -> To )
+    val Q = HOLConst( "Q", Ti -> ( Ti -> To ) )
+    val est = Equation( s, t )
+    val Ps = Atom( P, List( s ) )
+    val Pt = Atom( P, List( t ) )
 
-    val Qss = Atom(Q, List(s,s))
-    val Qst = Atom(Q, List(s,t))
-    val Qts = Atom(Q, List(t,s))
-    val Qtt = Atom(Q, List(t,t))
+    val Qss = Atom( Q, List( s, s ) )
+    val Qst = Atom( Q, List( s, t ) )
+    val Qts = Atom( Q, List( t, s ) )
+    val Qtt = Atom( Q, List( t, t ) )
 
-    val ax1 = Axiom(List(est), List(est))
-    val ax2 = Axiom(List(Ps), List(Ps))
-    val ax3 = Axiom(List(Pt), List(Pt))
-    val ax4 = Axiom(List(Qss), List(Qss))
-    val ax5 = Axiom(List(Qtt), List(Qtt))
+    val ax1 = Axiom( List( est ), List( est ) )
+    val ax2 = Axiom( List( Ps ), List( Ps ) )
+    val ax3 = Axiom( List( Pt ), List( Pt ) )
+    val ax4 = Axiom( List( Qss ), List( Qss ) )
+    val ax5 = Axiom( List( Qtt ), List( Qtt ) )
 
     "refuse first auxiliary formulas that are not equations" in {
-      EquationLeft1Rule(ax3, ax2, ax3.root.succedent.head, ax2.root.antecedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationLeft2Rule(ax3, ax2, ax3.root.succedent.head, ax2.root.antecedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationRight1Rule(ax3, ax2, ax3.root.succedent.head, ax2.root.succedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationRight2Rule(ax3, ax2, ax3.root.succedent.head, ax2.root.succedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
+      EquationLeft1Rule( ax3, ax2, ax3.root.succedent.head, ax2.root.antecedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationLeft2Rule( ax3, ax2, ax3.root.succedent.head, ax2.root.antecedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationRight1Rule( ax3, ax2, ax3.root.succedent.head, ax2.root.succedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationRight2Rule( ax3, ax2, ax3.root.succedent.head, ax2.root.succedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
     }
 
     "refuse when the wrong term is at the target position" in {
-      EquationLeft1Rule(ax1, ax3, ax1.root.succedent.head, ax3.root.antecedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationLeft2Rule(ax1, ax2, ax1.root.succedent.head, ax2.root.antecedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationRight1Rule(ax1, ax3, ax1.root.succedent.head, ax3.root.succedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
-      EquationRight2Rule(ax1, ax2, ax1.root.succedent.head, ax2.root.succedent.head, HOLPosition(2)) must throwAn[LKRuleCreationException]
+      EquationLeft1Rule( ax1, ax3, ax1.root.succedent.head, ax3.root.antecedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationLeft2Rule( ax1, ax2, ax1.root.succedent.head, ax2.root.antecedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationRight1Rule( ax1, ax3, ax1.root.succedent.head, ax3.root.succedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
+      EquationRight2Rule( ax1, ax2, ax1.root.succedent.head, ax2.root.succedent.head, HOLPosition( 2 ) ) must throwAn[LKRuleCreationException]
     }
 
     "refuse when auxiliary formula cannot be transformed to main formula in one step" in {
-      EquationLeft1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, Qtt) must throwAn[LKRuleCreationException]
-      EquationLeft2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, Qss) must throwAn[LKRuleCreationException]
-      EquationRight1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, Qtt) must throwAn[LKRuleCreationException]
-      EquationRight2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, Qss) must throwAn[LKRuleCreationException]
+      EquationLeft1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, Qtt ) must throwAn[LKRuleCreationException]
+      EquationLeft2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, Qss ) must throwAn[LKRuleCreationException]
+      EquationRight1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, Qtt ) must throwAn[LKRuleCreationException]
+      EquationRight2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, Qss ) must throwAn[LKRuleCreationException]
     }
 
     "correctly perform replacements" in {
 
-      val sequent1 = FSequent(List(est, Qst), List(Qss))
-      val sequent2 = FSequent(List(est, Qts), List(Qss))
+      val sequent1 = FSequent( List( est, Qst ), List( Qss ) )
+      val sequent2 = FSequent( List( est, Qts ), List( Qss ) )
 
-      val sequent3 = FSequent(List(est, Qts), List(Qtt))
-      val sequent4 = FSequent(List(est, Qst), List(Qtt))
+      val sequent3 = FSequent( List( est, Qts ), List( Qtt ) )
+      val sequent4 = FSequent( List( est, Qst ), List( Qtt ) )
 
-      val sequent5 = FSequent(List(est, Qss), List(Qst))
-      val sequent6 = FSequent(List(est, Qss), List(Qts))
+      val sequent5 = FSequent( List( est, Qss ), List( Qst ) )
+      val sequent6 = FSequent( List( est, Qss ), List( Qts ) )
 
-      val sequent7 = FSequent(List(est, Qtt), List(Qts))
-      val sequent8 = FSequent(List(est, Qtt), List(Qst))
+      val sequent7 = FSequent( List( est, Qtt ), List( Qts ) )
+      val sequent8 = FSequent( List( est, Qtt ), List( Qst ) )
 
-      EquationLeft1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent1)
-      EquationLeft1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, Qts).root.toFSequent must beEqualTo(sequent2)
+      EquationLeft1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent1 )
+      EquationLeft1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.antecedent.head, Qts ).root.toFSequent must beEqualTo( sequent2 )
 
-      EquationLeft2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent3)
-      EquationLeft2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, Qst).root.toFSequent must beEqualTo(sequent4)
+      EquationLeft2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent3 )
+      EquationLeft2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.antecedent.head, Qst ).root.toFSequent must beEqualTo( sequent4 )
 
-      EquationRight1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent5)
-      EquationRight1Rule(ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, Qts).root.toFSequent must beEqualTo(sequent6)
+      EquationRight1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent5 )
+      EquationRight1Rule( ax1, ax4, ax1.root.succedent.head, ax4.root.succedent.head, Qts ).root.toFSequent must beEqualTo( sequent6 )
 
-      EquationRight2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent7)
-      EquationRight2Rule(ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, Qst).root.toFSequent must beEqualTo(sequent8)
+      EquationRight2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent7 )
+      EquationRight2Rule( ax1, ax5, ax1.root.succedent.head, ax5.root.succedent.head, Qst ).root.toFSequent must beEqualTo( sequent8 )
     }
   }
 
   "Weakening macro rules" should {
-    val x = FOLVar("x")
-    val y = FOLVar("y")
+    val x = FOLVar( "x" )
+    val y = FOLVar( "y" )
 
-    val Px = FOLAtom("P", List(x))
-    val Py = FOLAtom("P", List(y))
+    val Px = FOLAtom( "P", List( x ) )
+    val Py = FOLAtom( "P", List( y ) )
 
-    val ax = Axiom(List(Px), List(Px))
+    val ax = Axiom( List( Px ), List( Px ) )
     "perform zero weakenings" in {
 
-      WeakeningLeftMacroRule(ax, Nil)  must beEqualTo(ax)
-      WeakeningRightMacroRule(ax, Nil) must beEqualTo(ax)
-      WeakeningMacroRule(ax, Nil, Nil) must beEqualTo(ax)
+      WeakeningLeftMacroRule( ax, Nil ) must beEqualTo( ax )
+      WeakeningRightMacroRule( ax, Nil ) must beEqualTo( ax )
+      WeakeningMacroRule( ax, Nil, Nil ) must beEqualTo( ax )
     }
 
     "correctly perform multiple weakenings" in {
-      val proof  = WeakeningRightRule(WeakeningLeftRule(WeakeningLeftRule(ax, Py), Neg(Py)), Py)
+      val proof = WeakeningRightRule( WeakeningLeftRule( WeakeningLeftRule( ax, Py ), Neg( Py ) ), Py )
 
-      WeakeningMacroRule(ax, List(Neg(Py),Py), List(Py)).root.toFSequent.multiSetEquals(proof.root.toFSequent) must beTrue
+      WeakeningMacroRule( ax, List( Neg( Py ), Py ), List( Py ) ).root.toFSequent.multiSetEquals( proof.root.toFSequent ) must beTrue
     }
   }
 
   "Contraction macro rules" should {
-    val x = FOLVar("x")
-    val y = FOLVar("y")
+    val x = FOLVar( "x" )
+    val y = FOLVar( "y" )
 
-    val Px = FOLAtom("P", List(x))
-    val Py = FOLAtom("P", List(y))
+    val Px = FOLAtom( "P", List( x ) )
+    val Py = FOLAtom( "P", List( y ) )
 
-    val ax = Axiom(List(Px), List(Px))
+    val ax = Axiom( List( Px ), List( Px ) )
 
     "perform zero contractions" in {
-      ContractionLeftMacroRule(ax, Nil) must beEqualTo(ax)
-      ContractionLeftMacroRule(ax, List(ax.root.antecedent.head)) must beEqualTo(ax)
-      ContractionRightMacroRule(ax, Nil) must beEqualTo(ax)
-      ContractionRightMacroRule(ax, List(ax.root.succedent.head)) must beEqualTo(ax)
+      ContractionLeftMacroRule( ax, Nil ) must beEqualTo( ax )
+      ContractionLeftMacroRule( ax, List( ax.root.antecedent.head ) ) must beEqualTo( ax )
+      ContractionRightMacroRule( ax, Nil ) must beEqualTo( ax )
+      ContractionRightMacroRule( ax, List( ax.root.succedent.head ) ) must beEqualTo( ax )
     }
 
     "return the original proof if there is nothing to do" in {
-      ContractionLeftMacroRule(ax, Px).root.toFSequent must beEqualTo(ax.root.toFSequent)
-      ContractionLeftMacroRule(ax, Py).root.toFSequent must beEqualTo(ax.root.toFSequent)
-      ContractionRightMacroRule(ax, Px).root.toFSequent must beEqualTo(ax.root.toFSequent)
-      ContractionRightMacroRule(ax, Py).root.toFSequent must beEqualTo(ax.root.toFSequent)
+      ContractionLeftMacroRule( ax, Px ).root.toFSequent must beEqualTo( ax.root.toFSequent )
+      ContractionLeftMacroRule( ax, Py ).root.toFSequent must beEqualTo( ax.root.toFSequent )
+      ContractionRightMacroRule( ax, Px ).root.toFSequent must beEqualTo( ax.root.toFSequent )
+      ContractionRightMacroRule( ax, Py ).root.toFSequent must beEqualTo( ax.root.toFSequent )
     }
 
     "correctly perform multiple contractions" in {
-      val ax2 = Axiom(List(Px, Px, Py, Px), List(Px, Neg(Px), Neg(Px)))
+      val ax2 = Axiom( List( Px, Px, Py, Px ), List( Px, Neg( Px ), Neg( Px ) ) )
 
-      val sequent1 = FSequent(List(Py, Px), List(Px, Neg(Px), Neg(Px)))
-      val sequent2 = FSequent(List(Px, Px, Py, Px), List(Px, Neg(Px)))
-      ContractionLeftMacroRule(ax2, Px).root.toFSequent must beEqualTo(sequent1)
-      ContractionRightMacroRule(ax2, Neg(Px)).root.toFSequent must beEqualTo(sequent2)
+      val sequent1 = FSequent( List( Py, Px ), List( Px, Neg( Px ), Neg( Px ) ) )
+      val sequent2 = FSequent( List( Px, Px, Py, Px ), List( Px, Neg( Px ) ) )
+      ContractionLeftMacroRule( ax2, Px ).root.toFSequent must beEqualTo( sequent1 )
+      ContractionRightMacroRule( ax2, Neg( Px ) ).root.toFSequent must beEqualTo( sequent2 )
     }
   }
 
   "Equality macro rules" should {
-    val (s, t) = (HOLConst("s", Ti), HOLConst("t", Ti))
-    val P = HOLConst("P", Ti -> To)
-    val Q = HOLConst("Q", Ti -> (Ti -> To))
-    val est = Equation(s, t)
-    val Ps = Atom(P, List(s))
-    val Pt = Atom (P, List(t))
+    val ( s, t ) = ( HOLConst( "s", Ti ), HOLConst( "t", Ti ) )
+    val P = HOLConst( "P", Ti -> To )
+    val Q = HOLConst( "Q", Ti -> ( Ti -> To ) )
+    val est = Equation( s, t )
+    val Ps = Atom( P, List( s ) )
+    val Pt = Atom( P, List( t ) )
 
-    val Qss = Atom(Q, List(s,s))
-    val Qst = Atom(Q, List(s,t))
-    val Qts = Atom(Q, List(t,s))
-    val Qtt = Atom(Q, List(t,t))
+    val Qss = Atom( Q, List( s, s ) )
+    val Qst = Atom( Q, List( s, t ) )
+    val Qts = Atom( Q, List( t, s ) )
+    val Qtt = Atom( Q, List( t, t ) )
 
-    val ax1 = Axiom(List(est), List(est))
-    val ax2 = Axiom(List(Ps), List(Ps))
-    val ax3 = Axiom(List(Pt), List(Pt))
-    val ax4 = Axiom(List(Qss), List(Qss))
-    val ax5 = Axiom(List(Qtt), List(Qtt))
+    val ax1 = Axiom( List( est ), List( est ) )
+    val ax2 = Axiom( List( Ps ), List( Ps ) )
+    val ax3 = Axiom( List( Pt ), List( Pt ) )
+    val ax4 = Axiom( List( Qss ), List( Qss ) )
+    val ax5 = Axiom( List( Qtt ), List( Qtt ) )
 
     val eq = ax1.root.succedent.head
 
     "choose the right rule to use" in {
-      val sequent1 = FSequent(List(est, Ps), List(Pt))
-      val sequent2 = FSequent(List(est, Pt), List(Ps))
+      val sequent1 = FSequent( List( est, Ps ), List( Pt ) )
+      val sequent2 = FSequent( List( est, Pt ), List( Ps ) )
 
-      EquationLeftRule(ax1, ax3, eq, ax3.root.antecedent.head, Ps).root.toFSequent must beEqualTo(sequent1)
-      EquationLeftRule(ax1, ax2, eq, ax2.root.antecedent.head, Pt).root.toFSequent must beEqualTo(sequent2)
+      EquationLeftRule( ax1, ax3, eq, ax3.root.antecedent.head, Ps ).root.toFSequent must beEqualTo( sequent1 )
+      EquationLeftRule( ax1, ax2, eq, ax2.root.antecedent.head, Pt ).root.toFSequent must beEqualTo( sequent2 )
 
-      EquationRightRule(ax1, ax2, eq, ax2.root.succedent.head, Pt).root.toFSequent must beEqualTo(sequent1)
-      EquationRightRule(ax1, ax3, eq, ax3.root.succedent.head, Ps).root.toFSequent must beEqualTo(sequent2)
+      EquationRightRule( ax1, ax2, eq, ax2.root.succedent.head, Pt ).root.toFSequent must beEqualTo( sequent1 )
+      EquationRightRule( ax1, ax3, eq, ax3.root.succedent.head, Ps ).root.toFSequent must beEqualTo( sequent2 )
 
-      EquationLeftRule(ax1, ax3, eq, ax3.root.antecedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent1)
-      EquationLeftRule(ax1, ax2, eq, ax2.root.antecedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent2)
+      EquationLeftRule( ax1, ax3, eq, ax3.root.antecedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent1 )
+      EquationLeftRule( ax1, ax2, eq, ax2.root.antecedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent2 )
 
-      EquationRightRule(ax1, ax2, eq, ax2.root.succedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent1)
-      EquationRightRule(ax1, ax3, eq, ax3.root.succedent.head, HOLPosition(2)).root.toFSequent must beEqualTo(sequent2)
+      EquationRightRule( ax1, ax2, eq, ax2.root.succedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent1 )
+      EquationRightRule( ax1, ax3, eq, ax3.root.succedent.head, HOLPosition( 2 ) ).root.toFSequent must beEqualTo( sequent2 )
     }
 
     "perform correctly if there is only one replacement to be made" in {
 
-      val sequent1 = FSequent(List(est, Qst), List(Qss))
-      val sequent2 = FSequent(List(est, Qts), List(Qss))
+      val sequent1 = FSequent( List( est, Qst ), List( Qss ) )
+      val sequent2 = FSequent( List( est, Qts ), List( Qss ) )
 
-      val sequent3 = FSequent(List(est, Qts), List(Qtt))
-      val sequent4 = FSequent(List(est, Qst), List(Qtt))
+      val sequent3 = FSequent( List( est, Qts ), List( Qtt ) )
+      val sequent4 = FSequent( List( est, Qst ), List( Qtt ) )
 
-      val sequent5 = FSequent(List(est, Qss), List(Qst))
-      val sequent6 = FSequent(List(est, Qss), List(Qts))
+      val sequent5 = FSequent( List( est, Qss ), List( Qst ) )
+      val sequent6 = FSequent( List( est, Qss ), List( Qts ) )
 
-      val sequent7 = FSequent(List(est, Qtt), List(Qts))
-      val sequent8 = FSequent(List(est, Qtt), List(Qst))
+      val sequent7 = FSequent( List( est, Qtt ), List( Qts ) )
+      val sequent8 = FSequent( List( est, Qtt ), List( Qst ) )
 
-      val proof1 = EquationLeftMacroRule(ax1, ax4, eq, ax4.root.antecedent.head, Nil, List(HOLPosition(2)))
-      val proof2 = EquationLeftMacroRule(ax1, ax4, eq, ax4.root.antecedent.head, Qts)
-      val proof3 = EquationLeftMacroRule(ax1, ax5, eq, ax5.root.antecedent.head, List(HOLPosition(2)), Nil)
-      val proof4 = EquationLeftMacroRule(ax1, ax5, eq, ax5.root.antecedent.head, Qst)
-      val proof5 = EquationRightMacroRule(ax1, ax4, eq, ax4.root.succedent.head, Nil, List(HOLPosition(2)))
-      val proof6 = EquationRightMacroRule(ax1, ax4, eq, ax4.root.succedent.head, Qts)
-      val proof7 = EquationRightMacroRule(ax1, ax5, eq, ax5.root.succedent.head, List(HOLPosition(2)), Nil)
-      val proof8 = EquationRightMacroRule(ax1, ax5, eq, ax5.root.succedent.head, Qst)
+      val proof1 = EquationLeftMacroRule( ax1, ax4, eq, ax4.root.antecedent.head, Nil, List( HOLPosition( 2 ) ) )
+      val proof2 = EquationLeftMacroRule( ax1, ax4, eq, ax4.root.antecedent.head, Qts )
+      val proof3 = EquationLeftMacroRule( ax1, ax5, eq, ax5.root.antecedent.head, List( HOLPosition( 2 ) ), Nil )
+      val proof4 = EquationLeftMacroRule( ax1, ax5, eq, ax5.root.antecedent.head, Qst )
+      val proof5 = EquationRightMacroRule( ax1, ax4, eq, ax4.root.succedent.head, Nil, List( HOLPosition( 2 ) ) )
+      val proof6 = EquationRightMacroRule( ax1, ax4, eq, ax4.root.succedent.head, Qts )
+      val proof7 = EquationRightMacroRule( ax1, ax5, eq, ax5.root.succedent.head, List( HOLPosition( 2 ) ), Nil )
+      val proof8 = EquationRightMacroRule( ax1, ax5, eq, ax5.root.succedent.head, Qst )
 
-      proof1.root.toFSequent must beEqualTo(sequent1)
-      proof2.root.toFSequent must beEqualTo(sequent2)
+      proof1.root.toFSequent must beEqualTo( sequent1 )
+      proof2.root.toFSequent must beEqualTo( sequent2 )
 
-      proof3.root.toFSequent must beEqualTo(sequent3)
-      proof4.root.toFSequent must beEqualTo(sequent4)
+      proof3.root.toFSequent must beEqualTo( sequent3 )
+      proof4.root.toFSequent must beEqualTo( sequent4 )
 
-      proof5.root.toFSequent must beEqualTo(sequent5)
-      proof6.root.toFSequent must beEqualTo(sequent6)
+      proof5.root.toFSequent must beEqualTo( sequent5 )
+      proof6.root.toFSequent must beEqualTo( sequent6 )
 
-      proof7.root.toFSequent must beEqualTo(sequent7)
-      proof8.root.toFSequent must beEqualTo(sequent8)
+      proof7.root.toFSequent must beEqualTo( sequent7 )
+      proof8.root.toFSequent must beEqualTo( sequent8 )
     }
 
     "perform correctly when several replacements are made" in {
-      val sequent1 = FSequent(List(est, Qtt), List(Qss))
-      val sequent2 = FSequent(List(est, Qss), List(Qtt))
+      val sequent1 = FSequent( List( est, Qtt ), List( Qss ) )
+      val sequent2 = FSequent( List( est, Qss ), List( Qtt ) )
 
-      val proof1 = EquationLeftMacroRule(ax1, ax4, eq, ax4.root.antecedent.head, Qtt)
-      val proof2 = EquationLeftMacroRule(ax1, ax5, eq, ax5.root.antecedent.head, Qss)
-      val proof3 = EquationRightMacroRule(ax1, ax4, eq, ax4.root.succedent.head, Qtt)
-      val proof4 = EquationRightMacroRule(ax1, ax5, eq, ax5.root.succedent.head, Qss)
+      val proof1 = EquationLeftMacroRule( ax1, ax4, eq, ax4.root.antecedent.head, Qtt )
+      val proof2 = EquationLeftMacroRule( ax1, ax5, eq, ax5.root.antecedent.head, Qss )
+      val proof3 = EquationRightMacroRule( ax1, ax4, eq, ax4.root.succedent.head, Qtt )
+      val proof4 = EquationRightMacroRule( ax1, ax5, eq, ax5.root.succedent.head, Qss )
 
-      proof1.root.toFSequent must beEqualTo(sequent1)
-      proof2.root.toFSequent must beEqualTo(sequent2)
-      proof3.root.toFSequent must beEqualTo(sequent2)
-      proof4.root.toFSequent must beEqualTo(sequent1)
+      proof1.root.toFSequent must beEqualTo( sequent1 )
+      proof2.root.toFSequent must beEqualTo( sequent2 )
+      proof3.root.toFSequent must beEqualTo( sequent2 )
+      proof4.root.toFSequent must beEqualTo( sequent1 )
 
     }
   }
-/*
+  /*
 
   "Unary equality rules" should {
     val (s, t) = (HOLConst("s", Ti), HOLConst("t", Ti))

--- a/src/test/scala/at/logic/calculi/lk/lkSpecs.scala
+++ b/src/test/scala/at/logic/calculi/lk/lkSpecs.scala
@@ -2,13 +2,13 @@ package at.logic.calculi.lk.base
 
 import org.specs2.matcher._
 
-case class beSyntacticMultisetEqual(s: Sequent) extends Matcher[Sequent]() {
-  def apply[S <: Sequent](o: Expectable[S]) =
-    result(s.syntacticMultisetEquals(o.value), "successful syntactic multisetEquals", s.toString + " not syntactic multisetEquals " + o.value, o)
+case class beSyntacticMultisetEqual( s: Sequent ) extends Matcher[Sequent]() {
+  def apply[S <: Sequent]( o: Expectable[S] ) =
+    result( s.syntacticMultisetEquals( o.value ), "successful syntactic multisetEquals", s.toString + " not syntactic multisetEquals " + o.value, o )
 }
 
-case class beSyntacticFSequentEqual(s: FSequent) extends Matcher[FSequent]() {
-  def apply[S <: FSequent](o: Expectable[S]) =
-    result(s.multiSetEquals(o.value), "successful syntactic multisetEquals", s.toString + " not the same multiset as fsequent " + o.value, o)
+case class beSyntacticFSequentEqual( s: FSequent ) extends Matcher[FSequent]() {
+  def apply[S <: FSequent]( o: Expectable[S] ) =
+    result( s.multiSetEquals( o.value ), "successful syntactic multisetEquals", s.toString + " not the same multiset as fsequent " + o.value, o )
 }
 

--- a/src/test/scala/at/logic/calculi/lksk/LKskTest.scala
+++ b/src/test/scala/at/logic/calculi/lksk/LKskTest.scala
@@ -12,36 +12,35 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
 import at.logic.calculi.lk.base.FSequent
-import at.logic.calculi.lk.{OrLeftRule, Axiom => LKAxiom, _}
+import at.logic.calculi.lk.{ OrLeftRule, Axiom => LKAxiom, _ }
 import TypeSynonyms._
 import at.logic.calculi.occurrences.FOFactory
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LKskTest extends SpecificationWithJUnit {
-  val c1 = HOLVar("a", Ti->To)
-  val v1 = HOLVar("x", Ti)
-  val f1 = Atom(c1,v1::Nil)
-  val c2 = HOLVar("b", Ti->To)
-  val v2 = HOLVar("c", Ti)
-  val f2 = Atom(c1,v1::Nil)
-  val f3 = Atom(HOLVar("e", To))
-  val ax = Axiom.createDefault(new FSequent(f1::Nil, f1::Nil), Tuple2((EmptyLabel() + f2)::Nil, EmptyLabel()::Nil ))
+  val c1 = HOLVar( "a", Ti -> To )
+  val v1 = HOLVar( "x", Ti )
+  val f1 = Atom( c1, v1 :: Nil )
+  val c2 = HOLVar( "b", Ti -> To )
+  val v2 = HOLVar( "c", Ti )
+  val f2 = Atom( c1, v1 :: Nil )
+  val f3 = Atom( HOLVar( "e", To ) )
+  val ax = Axiom.createDefault( new FSequent( f1 :: Nil, f1 :: Nil ), Tuple2( ( EmptyLabel() + f2 ) :: Nil, EmptyLabel() :: Nil ) )
   val a1 = ax._1 // Axiom return a pair of the proof and a mapping and we want only the proof here
-  val a2 = (Axiom.createDefault(new FSequent(f1::Nil, f1::Nil), Tuple2((EmptyLabel() + f2)::Nil, (EmptyLabel() + f3)::Nil) ) )._1
-
+  val a2 = ( Axiom.createDefault( new FSequent( f1 :: Nil, f1 :: Nil ), Tuple2( ( EmptyLabel() + f2 ) :: Nil, ( EmptyLabel() + f3 ) :: Nil ) ) )._1
 
   "The factories/extractors for LKsk" should {
     "work for Axioms" in {
       "- Formula occurrences have correct formulas" in {
-        a1.root.antecedent.head must beLike {case o : LabelledFormulaOccurrence => ok }
-        a1.root.antecedent.head.factory must beLike {case o : FOFactory => ok }
-        a1 must beLike {case Axiom(o) => o.antecedent.toArray.apply(0).formula == f1 && o.succedent.toArray.apply(0).formula == f1 must_== true}
+        a1.root.antecedent.head must beLike { case o: LabelledFormulaOccurrence => ok }
+        a1.root.antecedent.head.factory must beLike { case o: FOFactory => ok }
+        a1 must beLike { case Axiom( o ) => o.antecedent.toArray.apply( 0 ).formula == f1 && o.succedent.toArray.apply( 0 ).formula == f1 must_== true }
       }
     }
     "work for OrLeftRule" in {
-      val a = OrLeftRule(a1, a2, f1, f2)
-      a.prin.head.factory must beLike {case o : FOFactory => ok }
-      a.prin.head must beLike {case o : LabelledFormulaOccurrence => ok }
+      val a = OrLeftRule( a1, a2, f1, f2 )
+      a.prin.head.factory must beLike { case o: FOFactory => ok }
+      a.prin.head must beLike { case o: LabelledFormulaOccurrence => ok }
     }
   }
 }

--- a/src/test/scala/at/logic/calculi/resolution/RalResolutionTest.scala
+++ b/src/test/scala/at/logic/calculi/resolution/RalResolutionTest.scala
@@ -2,9 +2,9 @@ package at.logic.calculi.resolution.ral
 
 import at.logic.calculi.lk.base.FSequent
 import at.logic.calculi.lksk.LabelledSequent
-import at.logic.calculi.lksk.TypeSynonyms.{Label, EmptyLabel}
+import at.logic.calculi.lksk.TypeSynonyms.{ Label, EmptyLabel }
 import at.logic.language.hol._
-import at.logic.language.lambda.types.{Ti, To}
+import at.logic.language.lambda.types.{ Ti, To }
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
@@ -12,42 +12,42 @@ import org.specs2.runner.JUnitRunner
 /**
  * Created by marty on 9/10/14.
  */
-@RunWith(classOf[JUnitRunner])
-class RalResolutionTest extends SpecificationWithJUnit{
+@RunWith( classOf[JUnitRunner] )
+class RalResolutionTest extends SpecificationWithJUnit {
   "Ral resolution" should {
     "work on simple proofs" in {
-      val x = HOLVar("X", To)
-      val p = Atom(HOLConst("P", To), Nil)
-      val exx = ExVar(x,x.asInstanceOf[HOLFormula])
-      val root = FSequent(Nil,List(exx))
-      val labels : (List[Label],List[Label]) = (List[Label](),List[Label](EmptyLabel()))
+      val x = HOLVar( "X", To )
+      val p = Atom( HOLConst( "P", To ), Nil )
+      val exx = ExVar( x, x.asInstanceOf[HOLFormula] )
+      val root = FSequent( Nil, List( exx ) )
+      val labels: ( List[Label], List[Label] ) = ( List[Label](), List[Label]( EmptyLabel() ) )
 
-      val i1 = InitialSequent(root, labels)
-      val i2 = ForallT(i1, i1.root.l_succedent(0), x)
-      val i3 = Sub(i2, Substitution(x, And(p, Neg(p))))
-      val i4 = AndT1(i3, i3.root.l_succedent(0))
-      val i5 = AndT2(i3, i3.root.l_succedent(0))
-      val i6 = NegT(i5, i5.root.l_succedent(0))
-      val i7 = Cut(i4,i6,List(i4.root.l_succedent(0)), List(i6.root.l_antecedent(0)))
+      val i1 = InitialSequent( root, labels )
+      val i2 = ForallT( i1, i1.root.l_succedent( 0 ), x )
+      val i3 = Sub( i2, Substitution( x, And( p, Neg( p ) ) ) )
+      val i4 = AndT1( i3, i3.root.l_succedent( 0 ) )
+      val i5 = AndT2( i3, i3.root.l_succedent( 0 ) )
+      val i6 = NegT( i5, i5.root.l_succedent( 0 ) )
+      val i7 = Cut( i4, i6, List( i4.root.l_succedent( 0 ) ), List( i6.root.l_antecedent( 0 ) ) )
 
-      i7.root.toFSequent must_== (FSequent(Nil,Nil))
+      i7.root.toFSequent must_== ( FSequent( Nil, Nil ) )
       ok
     }
 
     "work on non-idempotent substitutions" in {
-      val x = HOLVar("x", Ti)
-      val fx = Function(HOLConst("f", Ti -> Ti), x::Nil)
-      val px = Atom(HOLConst("P", Ti->To), List(x))
-      val pfx = Atom(HOLConst("P", Ti->To), List(fx))
+      val x = HOLVar( "x", Ti )
+      val fx = Function( HOLConst( "f", Ti -> Ti ), x :: Nil )
+      val px = Atom( HOLConst( "P", Ti -> To ), List( x ) )
+      val pfx = Atom( HOLConst( "P", Ti -> To ), List( fx ) )
 
-      val sub = Substitution(x, fx)
+      val sub = Substitution( x, fx )
 
-      val root = FSequent(Nil,List(px))
-      val labels : (List[Label],List[Label]) = (List[Label](),List[Label](EmptyLabel()))
+      val root = FSequent( Nil, List( px ) )
+      val labels: ( List[Label], List[Label] ) = ( List[Label](), List[Label]( EmptyLabel() ) )
 
-      val i1 = InitialSequent(root, labels)
-      val i2 = Sub(i1,sub)
-      i2.root.succedent(0).formula must_== (pfx)
+      val i1 = InitialSequent( root, labels )
+      val i2 = Sub( i1, sub )
+      i2.root.succedent( 0 ).formula must_== ( pfx )
       ok
     }
   }

--- a/src/test/scala/at/logic/calculi/resolution/ResolutionTest.scala
+++ b/src/test/scala/at/logic/calculi/resolution/ResolutionTest.scala
@@ -12,61 +12,61 @@ import org.specs2.runner.JUnitRunner
 import at.logic.calculi.resolution.robinson._
 import at.logic.calculi.occurrences._
 import at.logic.language.fol._
-import at.logic.language.hol.{Atom => HOLAtom, Function => HOLFunction, AllVar => HOLAllVar, Or => HOLOr, Neg => HOLNeg, Substitution => HOLSubstitution, HOLConst, HOLVar}
+import at.logic.language.hol.{ Atom => HOLAtom, Function => HOLFunction, AllVar => HOLAllVar, Or => HOLOr, Neg => HOLNeg, Substitution => HOLSubstitution, HOLConst, HOLVar }
 import at.logic.language.lambda.types._
 import at.logic.calculi.lk.base._
 
 import at.logic.language.hol.skolemSymbols.SkolemSymbolFactory
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ResolutionTest extends SpecificationWithJUnit {
-  
+
   "Paramodulation rule in Robinson Resolution" should {
     "be created correctly" in {
-      val cl1 = InitialClause(Nil, Atom("=", Function("+", FOLVar("x")::FOLVar("x")::Nil)::FOLVar("x")::Nil)::Nil)
-      val cl2 = InitialClause(Nil, Atom("=", Function("+", FOLVar("y")::FOLVar("y")::Nil)::FOLVar("y")::Nil)::Nil)
-      val param = Paramodulation(cl1, cl2, cl1.root.succedent(0), cl2.root.succedent(0), Atom("=", FOLVar("y")::FOLVar("y")::Nil), Substitution(List((FOLVar("x"), FOLVar("y")))))
-      val sq =  Seq(Atom("=", FOLVar("y")::FOLVar("y")::Nil))
-      
-      param.root.positive.map(_.formula) must beEqualTo (sq)
+      val cl1 = InitialClause( Nil, Atom( "=", Function( "+", FOLVar( "x" ) :: FOLVar( "x" ) :: Nil ) :: FOLVar( "x" ) :: Nil ) :: Nil )
+      val cl2 = InitialClause( Nil, Atom( "=", Function( "+", FOLVar( "y" ) :: FOLVar( "y" ) :: Nil ) :: FOLVar( "y" ) :: Nil ) :: Nil )
+      val param = Paramodulation( cl1, cl2, cl1.root.succedent( 0 ), cl2.root.succedent( 0 ), Atom( "=", FOLVar( "y" ) :: FOLVar( "y" ) :: Nil ), Substitution( List( ( FOLVar( "x" ), FOLVar( "y" ) ) ) ) )
+      val sq = Seq( Atom( "=", FOLVar( "y" ) :: FOLVar( "y" ) :: Nil ) )
+
+      param.root.positive.map( _.formula ) must beEqualTo( sq )
     }
 
     "be created correctly -- this test relies on the fact that sub is applied to the inferred formula" in {
-      val cl1 = InitialClause(Nil, Atom("=", Function("+", FOLVar("x")::FOLVar("x")::Nil)::FOLVar("x")::Nil)::Nil)
-      val cl2 = InitialClause(Nil, Atom("=", Function("+", FOLVar("y")::FOLVar("y")::Nil)::FOLVar("y")::Nil)::Nil)
-      val param = Paramodulation(cl1, cl2, cl1.root.succedent(0), cl2.root.succedent(0), Atom("=", FOLVar("y")::FOLVar("x")::Nil), Substitution(List((FOLVar("x"), FOLVar("y")))))
-      val sq =  Seq(Atom("=", FOLVar("y")::FOLVar("y")::Nil))
+      val cl1 = InitialClause( Nil, Atom( "=", Function( "+", FOLVar( "x" ) :: FOLVar( "x" ) :: Nil ) :: FOLVar( "x" ) :: Nil ) :: Nil )
+      val cl2 = InitialClause( Nil, Atom( "=", Function( "+", FOLVar( "y" ) :: FOLVar( "y" ) :: Nil ) :: FOLVar( "y" ) :: Nil ) :: Nil )
+      val param = Paramodulation( cl1, cl2, cl1.root.succedent( 0 ), cl2.root.succedent( 0 ), Atom( "=", FOLVar( "y" ) :: FOLVar( "x" ) :: Nil ), Substitution( List( ( FOLVar( "x" ), FOLVar( "y" ) ) ) ) )
+      val sq = Seq( Atom( "=", FOLVar( "y" ) :: FOLVar( "y" ) :: Nil ) )
 
-      param.root.positive.map(_.formula) must beEqualTo (sq)
+      param.root.positive.map( _.formula ) must beEqualTo( sq )
     }
 
     "correctly keep the context of demodulated formulas " in {
       val P = "P"
-      val List(a,b,c,d,e,f) = List("a","b","c","d","e","f") map (x => FOLConst(x).asInstanceOf[FOLTerm])
-      val List(e1,e2,e3,p,q) = List(Equation(a,b), Equation(c,d), Equation(e,f), Atom(P,a::Nil), Atom(P,b::Nil)  )
-      val p1 = InitialClause(Nil, List(e1, e2 ))
-      val p2 = InitialClause(Nil, List(e3, p))
-      val p3 = Paramodulation(p1,p2, p1.root.succedent(0), p2.root.succedent(1), q, Substitution())
-      val expected_root = FSequent(Nil, List(e2,e3,q))
+      val List( a, b, c, d, e, f ) = List( "a", "b", "c", "d", "e", "f" ) map ( x => FOLConst( x ).asInstanceOf[FOLTerm] )
+      val List( e1, e2, e3, p, q ) = List( Equation( a, b ), Equation( c, d ), Equation( e, f ), Atom( P, a :: Nil ), Atom( P, b :: Nil ) )
+      val p1 = InitialClause( Nil, List( e1, e2 ) )
+      val p2 = InitialClause( Nil, List( e3, p ) )
+      val p3 = Paramodulation( p1, p2, p1.root.succedent( 0 ), p2.root.succedent( 1 ), q, Substitution() )
+      val expected_root = FSequent( Nil, List( e2, e3, q ) )
 
-      p3.root.toFSequent must beSyntacticFSequentEqual(expected_root)
+      p3.root.toFSequent must beSyntacticFSequentEqual( expected_root )
 
     }
   }
   "extrator on Resolution rule" should {
     "work properly" in {
-      val x = FOLVar("x")
-      val fa = Function("f", List(FOLConst("a")))
-      val Pfa = Atom("P", List(fa))
-      val Px = Atom("P", List(x))
-      val cl1 = InitialClause(List(), List(Px))
-      val cl2 = InitialClause(List(Pfa), List())
-      val res = Resolution(cl1, cl2, cl1.root.succedent(0), cl2.root.antecedent(0), Substitution(List((x,fa))))
-      res must beLike { case Resolution(_,_,_,_,_,_) => ok }
+      val x = FOLVar( "x" )
+      val fa = Function( "f", List( FOLConst( "a" ) ) )
+      val Pfa = Atom( "P", List( fa ) )
+      val Px = Atom( "P", List( x ) )
+      val cl1 = InitialClause( List(), List( Px ) )
+      val cl2 = InitialClause( List( Pfa ), List() )
+      val res = Resolution( cl1, cl2, cl1.root.succedent( 0 ), cl2.root.antecedent( 0 ), Substitution( List( ( x, fa ) ) ) )
+      res must beLike { case Resolution( _, _, _, _, _, _ ) => ok }
     }
   }
 
-/* using deprecated data structure. Please update.
+  /* using deprecated data structure. Please update.
   "Andrews Resolution" should {
     "refute 'not (A or not A)'" in {
       val a = HOLAtom(HOLConst("p", To))

--- a/src/test/scala/at/logic/calculi/slk/SLKTest.scala
+++ b/src/test/scala/at/logic/calculi/slk/SLKTest.scala
@@ -16,69 +16,69 @@ import at.logic.calculi.lk.Axiom
 import at.logic.calculi.occurrences._
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SLKTest extends SpecificationWithJUnit {
   implicit val factory = defaultFormulaOccurrenceFactory
 
   "The calculus SLK" should {
-    
+
     "work for a simple proof" in {
-      val i = IntVar("i")
-      val pi = IndexedPredicate("p", i::Nil)
-      val p0 = IndexedPredicate("p", IntZero()::Nil)
-      val f = BigAnd(i, pi, IntZero(), IntZero())
-      val ax = Axiom(p0 +: Seq.empty[SchemaFormula], Seq.empty[SchemaFormula])
-      val proof = AndEquivalenceRule3(ax, ax.root.antecedent.head, f)
-      proof.root.toFSequent must beEqualTo (FSequent( f +: Seq.empty[SchemaFormula], Seq.empty[SchemaFormula]))
+      val i = IntVar( "i" )
+      val pi = IndexedPredicate( "p", i :: Nil )
+      val p0 = IndexedPredicate( "p", IntZero() :: Nil )
+      val f = BigAnd( i, pi, IntZero(), IntZero() )
+      val ax = Axiom( p0 +: Seq.empty[SchemaFormula], Seq.empty[SchemaFormula] )
+      val proof = AndEquivalenceRule3( ax, ax.root.antecedent.head, f )
+      proof.root.toFSequent must beEqualTo( FSequent( f +: Seq.empty[SchemaFormula], Seq.empty[SchemaFormula] ) )
     }
 
     "work for AndEquivalenceRule1" in {
-      val i = IntVar("i")
-      val n = IntVar("n")
-      val ai = IndexedPredicate("A", i::Nil)
-      val a_sn = IndexedPredicate("A", Succ(n)::Nil)
-      val and_1_n_ai = BigAnd(i, ai,Succ(IntZero()), n)
-      val and_1_sn_ai = BigAnd(i, ai,Succ(IntZero()), Succ(n))
-      val ax = Axiom(And(and_1_n_ai, a_sn) +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula])
-      val proof = AndEquivalenceRule1(ax, ax.root.antecedent.head, and_1_sn_ai)
-      proof.root.toFSequent must beEqualTo (FSequent( and_1_sn_ai +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula]))
+      val i = IntVar( "i" )
+      val n = IntVar( "n" )
+      val ai = IndexedPredicate( "A", i :: Nil )
+      val a_sn = IndexedPredicate( "A", Succ( n ) :: Nil )
+      val and_1_n_ai = BigAnd( i, ai, Succ( IntZero() ), n )
+      val and_1_sn_ai = BigAnd( i, ai, Succ( IntZero() ), Succ( n ) )
+      val ax = Axiom( And( and_1_n_ai, a_sn ) +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula] )
+      val proof = AndEquivalenceRule1( ax, ax.root.antecedent.head, and_1_sn_ai )
+      proof.root.toFSequent must beEqualTo( FSequent( and_1_sn_ai +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula] ) )
 
     }
-    
+
     "work for OrEquivalenceRule1" in {
-      val i = IntVar("i")
-      val n = IntVar("n")
-      val ai = IndexedPredicate("A", i::Nil)
-      val a_sn = IndexedPredicate("A", Succ(n)::Nil)
-      val or_1_n_ai = BigOr(i, ai, Succ(IntZero()), n)
-      val or_1_sn_ai = BigOr(i, ai, Succ(IntZero()), Succ(n))
-      val ax = Axiom(Or(or_1_n_ai, a_sn) +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula] )
-      val proof = OrEquivalenceRule1(ax, ax.root.antecedent.head, or_1_sn_ai)
-      proof.root.toFSequent must beEqualTo (FSequent( or_1_sn_ai +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula]))
+      val i = IntVar( "i" )
+      val n = IntVar( "n" )
+      val ai = IndexedPredicate( "A", i :: Nil )
+      val a_sn = IndexedPredicate( "A", Succ( n ) :: Nil )
+      val or_1_n_ai = BigOr( i, ai, Succ( IntZero() ), n )
+      val or_1_sn_ai = BigOr( i, ai, Succ( IntZero() ), Succ( n ) )
+      val ax = Axiom( Or( or_1_n_ai, a_sn ) +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula] )
+      val proof = OrEquivalenceRule1( ax, ax.root.antecedent.head, or_1_sn_ai )
+      proof.root.toFSequent must beEqualTo( FSequent( or_1_sn_ai +: Seq.empty[SchemaFormula], a_sn +: Seq.empty[SchemaFormula] ) )
 
     }
-    
-    "work for sCutRule" in {
-      def f = SchemaConst("f", Ti->Ti)
-      def h = SchemaConst("h", ->(Tindex , ->(Ti, Ti)))
-      def g = SchemaConst("g", ->(Tindex , ->(Ti, Ti)))
-      val k = IntVar("k")
-      val x = SchemaVar("x", Ti)
-      val base2 = x
-      val step2 = foTerm("f",  sTerm(g, Succ(k), x::Nil)::Nil)
-      val base1 = sTerm(g, IntZero(), x::Nil)
-      val step1 = sTerm(g, Succ(k), x::Nil)
-      dbTRS.clear
-      dbTRS.add(g, Tuple2(base1, base2), Tuple2(step1, step2))
-      val term1 = sTerm(g, Succ(Succ(k)), x::Nil)
-      val term2 = foTerm("f",  sTerm(g, Succ(k), x::Nil)::Nil)
-      val f1 = Atom(SchemaConst("P", term1.exptype -> To), term1::Nil)
-      val f2 = Atom(SchemaConst("P", term2.exptype -> To), term2::Nil)
 
-      val ax1  = Axiom(f1::Nil, f1::Nil)
-      val ax2  = Axiom(f2::Nil, f2::Nil)
-      val cut = sCutRule(ax1, ax2, f1)
-      
+    "work for sCutRule" in {
+      def f = SchemaConst( "f", Ti -> Ti )
+      def h = SchemaConst( "h", ->( Tindex, ->( Ti, Ti ) ) )
+      def g = SchemaConst( "g", ->( Tindex, ->( Ti, Ti ) ) )
+      val k = IntVar( "k" )
+      val x = SchemaVar( "x", Ti )
+      val base2 = x
+      val step2 = foTerm( "f", sTerm( g, Succ( k ), x :: Nil ) :: Nil )
+      val base1 = sTerm( g, IntZero(), x :: Nil )
+      val step1 = sTerm( g, Succ( k ), x :: Nil )
+      dbTRS.clear
+      dbTRS.add( g, Tuple2( base1, base2 ), Tuple2( step1, step2 ) )
+      val term1 = sTerm( g, Succ( Succ( k ) ), x :: Nil )
+      val term2 = foTerm( "f", sTerm( g, Succ( k ), x :: Nil ) :: Nil )
+      val f1 = Atom( SchemaConst( "P", term1.exptype -> To ), term1 :: Nil )
+      val f2 = Atom( SchemaConst( "P", term2.exptype -> To ), term2 :: Nil )
+
+      val ax1 = Axiom( f1 :: Nil, f1 :: Nil )
+      val ax2 = Axiom( f2 :: Nil, f2 :: Nil )
+      val cut = sCutRule( ax1, ax2, f1 )
+
       Success()
     }
     /*
@@ -95,7 +95,7 @@ class SLKTest extends SpecificationWithJUnit {
         }
       }
     } */
-  /*  // the following test fails because the position occurrences
+    /*  // the following test fails because the position occurrences
       // do not distinguish left/right side of the sequent, only
       // the position inside the antecedent/succedent!
 

--- a/src/test/scala/at/logic/integration_tests/CutIntroTest.scala
+++ b/src/test/scala/at/logic/integration_tests/CutIntroTest.scala
@@ -17,47 +17,45 @@ import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import scala.collection.immutable.HashSet
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class CutIntroTest extends SpecificationWithJUnit {
-  private def LinearExampleTermset( n : Int ) : List[FOLTerm] =
+  private def LinearExampleTermset( n: Int ): List[FOLTerm] =
     if ( n == 0 )
       List[FOLTerm]()
     else
-      Utils.numeral( n - 1 ) :: LinearExampleTermset( n - 1)
+      Utils.numeral( n - 1 ) :: LinearExampleTermset( n - 1 )
 
   // returns LKProof with end-sequent  P(s^k(0)), \ALL x . P(x) -> P(s(x)) :- P(s^n(0))
-  private def LinearExampleProof( k : Int, n : Int ) : LKProof = {
+  private def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"
     val c = "0"
     val p = "P"
 
     val x = FOLVar( "x" )
-    val ass = AllVar( x, Imp( Atom( p, x::Nil ), Atom( p, Function( s, x::Nil )::Nil ) ) )
+    val ass = AllVar( x, Imp( Atom( p, x :: Nil ), Atom( p, Function( s, x :: Nil ) :: Nil ) ) )
     if ( k == n ) // leaf proof
     {
-      val a = Atom( p,  Utils.numeral( n )::Nil )
-      WeakeningLeftRule( Axiom( a::Nil, a::Nil ), ass )
-    }
-    else
-    {
-      val p1 = Atom( p, Utils.numeral( k )::Nil )
-      val p2 = Atom( p, Utils.numeral( k + 1 )::Nil )
+      val a = Atom( p, Utils.numeral( n ) :: Nil )
+      WeakeningLeftRule( Axiom( a :: Nil, a :: Nil ), ass )
+    } else {
+      val p1 = Atom( p, Utils.numeral( k ) :: Nil )
+      val p2 = Atom( p, Utils.numeral( k + 1 ) :: Nil )
       val aux = Imp( p1, p2 )
-      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1::Nil, p1::Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
+      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1 :: Nil, p1 :: Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
     }
   }
 
   "CutIntroduction" should {
     "extract and decompose the termset of the linear example proof (n = 4)" in {
-      if (!(new MiniSATProver).isInstalled()) skipped("MiniSAT is not installed")
+      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
       val proof = LinearExampleProof( 0, 4 )
 
-      val termset = TermsExtraction (proof)
-      val set = termset.set.foldRight (List[FOLTerm]()) ( (t, acc) => termset.getTermTuple (t) ++ acc)
+      val termset = TermsExtraction( proof )
+      val set = termset.set.foldRight( List[FOLTerm]() )( ( t, acc ) => termset.getTermTuple( t ) ++ acc )
 
-      CutIntroduction.one_cut_one_quantifier (proof, false)
+      CutIntroduction.one_cut_one_quantifier( proof, false )
 
-      set must contain (exactly ( LinearExampleTermset( 4 ):_* ))
+      set must contain( exactly( LinearExampleTermset( 4 ): _* ) )
     }
   }
 }

--- a/src/test/scala/at/logic/integration_tests/LNPProofTest.scala
+++ b/src/test/scala/at/logic/integration_tests/LNPProofTest.scala
@@ -15,43 +15,43 @@ import at.logic.transformations.ceres.struct.StructCreators
 import at.logic.transformations.skolemization.lksk.LKtoLKskc
 
 import java.util.zip.GZIPInputStream
-import java.io.{FileReader, FileInputStream, InputStreamReader}
+import java.io.{ FileReader, FileInputStream, InputStreamReader }
 import java.io.File.separator
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import org.specs2.execute.Success
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LNPProofTest extends SpecificationWithJUnit {
 
   def sequentToString( s: Sequent ) = {
     var ret = ""
-    s.antecedent.foreach( formula => ret += formula.toString + ", ")
+    s.antecedent.foreach( formula => ret += formula.toString + ", " )
     ret += " :- "
-    s.succedent.foreach( formula => ret += formula.toString + ", ")
+    s.succedent.foreach( formula => ret += formula.toString + ", " )
     ret
   }
 
   def printStats( p: LKProof ) = {
     val stats = getStatistics( p )
-    print("unary: " + stats.unary + "\n")
-    print("binary: " + stats.binary + "\n")
-    print("cuts: " + stats.cuts + "\n")
+    print( "unary: " + stats.unary + "\n" )
+    print( "binary: " + stats.binary + "\n" )
+    print( "cuts: " + stats.cuts + "\n" )
   }
 
   sequential
   "The system" should {
     "parse correctly the LNP proof" in {
-      val proofs = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("lnp.xml"))) with XMLProofDatabaseParser).getProofDatabase().proofs
-      proofs.size must beEqualTo(1)
+      val proofs = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "lnp.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase().proofs
+      proofs.size must beEqualTo( 1 )
       val proof = proofs.head._2
       //printStats( proof )
 
       val proof_sk = LKtoLKskc( proof )
       val s = StructCreators.extract( proof_sk )
 
-      val cs = StandardClauseSet.transformStructToClauseSet( s ) map (_.toFSequent)
+      val cs = StandardClauseSet.transformStructToClauseSet( s ) map ( _.toFSequent )
       val dcs = deleteTautologies( cs )
       //Console.println("dcs size: " + dcs.size)
       val css = dcs.distinct
@@ -61,10 +61,9 @@ class LNPProofTest extends SpecificationWithJUnit {
       //(new FileWriter("target" + separator + "lnp-cs.tex") with SequentsListLatexExporter
       //  with HOLTermArithmeticalExporter).exportSequentList(cssv.sortWith((x,y) => x.toString < y.toString), List()).close
       saveXML( List(),
-              List(("cs", cs), ("dcs", dcs), ("css", (css)) 
-              //("cssv", (cssv))
-              ),
-              "target" + separator + "lnp-cs.xml" )
+        List( ( "cs", cs ), ( "dcs", dcs ), ( "css", ( css ) ) //("cssv", (cssv))
+        ),
+        "target" + separator + "lnp-cs.xml" )
       // specs2 require a least one Result, see org.specs2.specification.Example 
       Success()
     }

--- a/src/test/scala/at/logic/integration_tests/LatticeTest.scala
+++ b/src/test/scala/at/logic/integration_tests/LatticeTest.scala
@@ -1,6 +1,6 @@
-/** 
- * Description: 
-**/
+/**
+ * Description:
+ */
 package at.logic.integration_tests
 
 import at.logic.algorithms.lk._
@@ -20,44 +20,43 @@ import at.logic.transformations.skolemization.lksk.LKtoLKskc
 import at.logic.transformations.skolemization.skolemize
 
 import java.io.File.separator
-import java.io.{IOException, FileReader, FileInputStream, InputStreamReader}
+import java.io.{ IOException, FileReader, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LatticeTest extends SpecificationWithJUnit {
   val box = List()
-  def checkForProverOrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
-
+  def checkForProverOrSkip = Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
   def sequentToString( s: Sequent ) = {
     var ret = ""
-    s.antecedent.foreach( formula => ret += formula.toString + ", ")
+    s.antecedent.foreach( formula => ret += formula.toString + ", " )
     ret += " :- "
-    s.succedent.foreach( formula => ret += formula.toString + ", ")
+    s.succedent.foreach( formula => ret += formula.toString + ", " )
     ret
   }
 
   def printStats( p: LKProof ) = {
     val stats = getStatistics( p )
-    print("unary: " + stats.unary + "\n")
-    print("binary: " + stats.binary + "\n")
-    print("cuts: " + stats.cuts + "\n")
+    print( "unary: " + stats.unary + "\n" )
+    print( "binary: " + stats.binary + "\n" )
+    print( "cuts: " + stats.cuts + "\n" )
   }
 
   sequential
   "The system" should {
     "parse, transform to LKsk, and extract the clause set for the lattice proof" in {
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("lattice.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "lattice.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
       //printStats( proof )
 
       val proof_sk = LKtoLKskc( proof )
       val s = StructCreators.extract( proof_sk )
-/*
+      /*
       val cs = StandardClauseSet.transformStructToClauseSet( s )
       val dcs = deleteTautologies( cs )
       val css = setNormalize( dcs )
@@ -71,48 +70,45 @@ class LatticeTest extends SpecificationWithJUnit {
     "parse and skolemize the lattice proof" in {
       checkForProverOrSkip
 
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("lattice.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "lattice.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       val proof_sk = skolemize( proof )
       val s = StructCreators.extract( proof_sk )
 
-      val prf = deleteTautologies(proofProfile(s, proof_sk).map( _.toFSequent ))
+      val prf = deleteTautologies( proofProfile( s, proof_sk ).map( _.toFSequent ) )
 
       val tptp_prf = TPTPFOLExporter.tptp_problem( prf )
-      val writer_prf = new java.io.FileWriter("target" + separator + "lattice-prf.tptp")
+      val writer_prf = new java.io.FileWriter( "target" + separator + "lattice-prf.tptp" )
       writer_prf.write( tptp_prf )
       writer_prf.flush
 
-
-
       val cs = deleteTautologies( StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent ) )
       val tptp = TPTPFOLExporter.tptp_problem( cs )
-      val writer = new java.io.FileWriter("target" + separator + "lattice-cs.tptp")
+      val writer = new java.io.FileWriter( "target" + separator + "lattice-cs.tptp" )
       writer.write( tptp )
       writer.flush
 
-      val prf_cs_intersect = prf.filter(seq => cs.contains(seq))
-
+      val prf_cs_intersect = prf.filter( seq => cs.contains( seq ) )
 
       // refute it with prover9
       Prover9.refute( prf ) match {
-        case None => "" must beEqualTo("refutation of proof profile failed")
-        case Some(_) => true must beEqualTo(true)
+        case None      => "" must beEqualTo( "refutation of proof profile failed" )
+        case Some( _ ) => true must beEqualTo( true )
       }
       Prover9.refute( cs ) match {
-        case None => "" must beEqualTo("refutation of struct cs in tptp format failed")
-        case Some(_) => true must beEqualTo(true)
+        case None      => "" must beEqualTo( "refutation of struct cs in tptp format failed" )
+        case Some( _ ) => true must beEqualTo( true )
       }
 
       val projs = Projections( proof_sk )
       val path = "target" + separator + "lattice-sk.xml"
-      saveXML( Tuple2("lattice-sk", proof_sk) ::
+      saveXML( Tuple2( "lattice-sk", proof_sk ) ::
         projs.toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
         // projs.map( p => p._1 ).toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
-        Tuple2("cs", cs)::Tuple2("prf",prf)::Tuple2("cs_prf_intersection", prf_cs_intersect)::Nil, path )
-      (new java.io.File( path ) ).exists() must beEqualTo( true )
+        Tuple2( "cs", cs ) :: Tuple2( "prf", prf ) :: Tuple2( "cs_prf_intersection", prf_cs_intersect ) :: Nil, path )
+      ( new java.io.File( path ) ).exists() must beEqualTo( true )
     }
   }
 }

--- a/src/test/scala/at/logic/integration_tests/MiscTest.scala
+++ b/src/test/scala/at/logic/integration_tests/MiscTest.scala
@@ -7,13 +7,13 @@ import at.logic.algorithms.lk._
 import at.logic.algorithms.lk.statistics._
 import at.logic.algorithms.resolution._
 import at.logic.algorithms.rewriting.DefinitionElimination
-import at.logic.calculi.expansionTrees.{toDeep => ETtoDeep,toShallow => ETtoShallow}
+import at.logic.calculi.expansionTrees.{ toDeep => ETtoDeep, toShallow => ETtoShallow }
 import at.logic.calculi.lk._
 import at.logic.calculi.lk.base._
 import at.logic.calculi.occurrences._
 import at.logic.language.fol._
 import at.logic.language.hol.logicSymbols._
-import at.logic.language.hol.{And => AndHOL, Imp => ImpHOL, Or => OrHOL}
+import at.logic.language.hol.{ And => AndHOL, Imp => ImpHOL, Or => OrHOL }
 import at.logic.language.lambda.symbols._
 import at.logic.language.lambda.types._
 import at.logic.parsing.calculus.xml.saveXML
@@ -22,7 +22,7 @@ import at.logic.parsing.language.xml.XMLParser._
 import at.logic.parsing.readers.XMLReaders._
 import at.logic.parsing.veriT.VeriTParser
 import at.logic.provers.minisat.MiniSATProver
-import at.logic.provers.prover9.{Prover9, Prover9Prover}
+import at.logic.provers.prover9.{ Prover9, Prover9Prover }
 import at.logic.provers.veriT.VeriTProver
 import at.logic.transformations.ReductiveCutElim
 import at.logic.transformations.ceres.clauseSets.StandardClauseSet
@@ -35,7 +35,7 @@ import at.logic.transformations.skolemization.lksk.LKtoLKskc
 
 import java.util.zip.GZIPInputStream
 import java.io.File.separator
-import java.io.{FileReader, FileInputStream, InputStreamReader}
+import java.io.{ FileReader, FileInputStream, InputStreamReader }
 import at.logic.calculi.occurrences._
 import at.logic.utils.testing.ClasspathFileCopier
 import org.junit.runner.RunWith
@@ -43,28 +43,26 @@ import org.specs2.execute.Success
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
   // returns LKProof with end-sequent  P(s^k(0)), \ALL x . P(x) -> P(s(x)) :- P(s^n(0))
-  private def LinearExampleProof( k : Int, n : Int ) : LKProof = {
+  private def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"
     val c = "0"
     val p = "P"
 
-    val x = FOLVar("x")
-    val ass = AllVar( x, Imp( Atom( p, x::Nil ), Atom( p, Function( s, x::Nil )::Nil ) ) )
+    val x = FOLVar( "x" )
+    val ass = AllVar( x, Imp( Atom( p, x :: Nil ), Atom( p, Function( s, x :: Nil ) :: Nil ) ) )
     if ( k == n ) // leaf proof
     {
-      val a = Atom( p,  Utils.numeral( n )::Nil )
-      WeakeningLeftRule( Axiom( a::Nil, a::Nil ), ass )
-    }
-    else
-    {
-      val p1 = Atom( p, Utils.numeral( k )::Nil )
-      val p2 = Atom( p, Utils.numeral( k + 1 )::Nil )
+      val a = Atom( p, Utils.numeral( n ) :: Nil )
+      WeakeningLeftRule( Axiom( a :: Nil, a :: Nil ), ass )
+    } else {
+      val p1 = Atom( p, Utils.numeral( k ) :: Nil )
+      val p2 = Atom( p, Utils.numeral( k + 1 ) :: Nil )
       val aux = Imp( p1, p2 )
-      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1::Nil, p1::Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
+      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1 :: Nil, p1 :: Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
     }
   }
 
@@ -87,119 +85,119 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
 //    */
 
     "perform cut introduction on an example proof" in {
-      if (!(new MiniSATProver).isInstalled()) skipped("MiniSAT is not installed")
-      val p = LinearExampleProof(0, 7)
-      CutIntroduction.one_cut_one_quantifier(p, false)
+      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
+      val p = LinearExampleProof( 0, 7 )
+      CutIntroduction.one_cut_one_quantifier( p, false )
       Success()
     }
 
     "skolemize a simple proof" in {
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sk2.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sk2.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
       val proof_sk = skolemize( proof )
       Success()
     }
 
     "skolemize a proof with a simple definition" in {
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sk3.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sk3.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
       val proof_sk = skolemize( proof )
       Success()
     }
 
     "skolemize a proof with a complex definition" in {
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sk4.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sk4.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
       val proof_sk = skolemize( proof )
       Success()
     }
 
     "extract projections and clause set from a skolemized proof" in {
-      val proofdb = (new XMLReader(new InputStreamReader(getClass.getClassLoader.getResourceAsStream("test1p.xml"))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "test1p.xml" ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
       val projs = Projections( proof )
       val s = at.logic.transformations.ceres.struct.StructCreators.extract( proof )
       val cs = StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent )
-      val prf = deleteTautologies(proofProfile(s, proof).map( _.toFSequent ))
+      val prf = deleteTautologies( proofProfile( s, proof ).map( _.toFSequent ) )
       val path = "target" + separator + "test1p-out.xml"
       saveXML( //projs.map( p => p._1 ).toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
         projs.toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
-        Tuple2("cs", cs)::Tuple2("prf", prf)::Nil, path )
+        Tuple2( "cs", cs ) :: Tuple2( "prf", prf ) :: Nil, path )
       Success()
     }
 
     "introduce a cut and eliminate it via Gentzen in the LinearExampleProof (n = 4)" in {
-      if (!(new MiniSATProver).isInstalled()) skipped("MiniSAT is not installed")
+      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
 
       val p = LinearExampleProof( 0, 4 )
-      val pi = CutIntroduction.one_cut_one_quantifier(p, false)
-      val pe = ReductiveCutElim.eliminateAllByUppermost(pi, steps = false)
+      val pi = CutIntroduction.one_cut_one_quantifier( p, false )
+      val pe = ReductiveCutElim.eliminateAllByUppermost( pi, steps = false )
 
-      ReductiveCutElim.isCutFree(p)  must beEqualTo( true )
-      ReductiveCutElim.isCutFree(pi) must beEqualTo( false )
-      ReductiveCutElim.isCutFree(pe) must beEqualTo( true )
+      ReductiveCutElim.isCutFree( p ) must beEqualTo( true )
+      ReductiveCutElim.isCutFree( pi ) must beEqualTo( false )
+      ReductiveCutElim.isCutFree( pe ) must beEqualTo( true )
     }
 
     "extract expansion tree from tape proof" in {
-      val tokens = HybridLatexParser.parseFile(tempCopyOfClasspathFile("tape3.llk"))
-      val db = HybridLatexParser.createLKProof(tokens)
+      val tokens = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "tape3.llk" ) )
+      val db = HybridLatexParser.createLKProof( tokens )
       // I have no idea why, but this makes the code get the correct proof
-      val proofs = db.proofs.filter(_._1.toString == "TAPEPROOF")
-      val (_,p)::_ = proofs
-      val elp = AtomicExpansion(DefinitionElimination(db.Definitions,p))
-      val reg = regularize(elp)
-      val lksk_proof = LKtoLKskc(reg)
+      val proofs = db.proofs.filter( _._1.toString == "TAPEPROOF" )
+      val ( _, p ) :: _ = proofs
+      val elp = AtomicExpansion( DefinitionElimination( db.Definitions, p ) )
+      val reg = regularize( elp )
+      val lksk_proof = LKtoLKskc( reg )
       // TODO
-      val et = extractExpansionSequent(reg, false)  // must throwA[IllegalArgumentException] // currently contains problematic definitions
+      val et = extractExpansionSequent( reg, false ) // must throwA[IllegalArgumentException] // currently contains problematic definitions
       ok
     }
 
     "construct proof with expansion sequent extracted from proof 1/2" in {
-      val y = FOLVar("y")
-      val x = FOLVar("x")
-      val Py = Atom("P", y :: Nil)
-      val Px = Atom("P", x :: Nil)
-      val AllxPx = AllVar(x, Px)
+      val y = FOLVar( "y" )
+      val x = FOLVar( "x" )
+      val Py = Atom( "P", y :: Nil )
+      val Px = Atom( "P", x :: Nil )
+      val AllxPx = AllVar( x, Px )
 
       // test with 1 weak & 1 strong
-      val p1 = Axiom(Py :: Nil, Py :: Nil)
-      val p2 = ForallLeftRule(p1, Py, AllxPx, y)
-      val p3 = ForallRightRule(p2, Py, AllxPx, y)
+      val p1 = Axiom( Py :: Nil, Py :: Nil )
+      val p2 = ForallLeftRule( p1, Py, AllxPx, y )
+      val p3 = ForallRightRule( p2, Py, AllxPx, y )
 
-      val etSeq = extractExpansionSequent(p3, false)
+      val etSeq = extractExpansionSequent( p3, false )
 
-      val proof = solve.expansionProofToLKProof(p3.root.toFSequent, etSeq)
+      val proof = solve.expansionProofToLKProof( p3.root.toFSequent, etSeq )
       proof.isDefined must beTrue
     }
 
     "construct proof with expansion sequent extracted from proof 2/2" in {
-      val proof = LinearExampleProof(0, 4)
+      val proof = LinearExampleProof( 0, 4 )
 
-      val proofPrime = solve.expansionProofToLKProof(proof.root.toFSequent, extractExpansionSequent(proof, false))
+      val proofPrime = solve.expansionProofToLKProof( proof.root.toFSequent, extractExpansionSequent( proof, false ) )
       proofPrime.isDefined must beTrue
     }
 
     "load veriT proofs pi and verify the validity of Deep(pi) using MiniSAT" in {
       val minisat = new MiniSATProver()
-      if (!minisat.isInstalled()) skipped("MiniSAT is not installed")
+      if ( !minisat.isInstalled() ) skipped( "MiniSAT is not installed" )
 
-      for (i <- List(0,1,3)) { // Tests 2 and 4 take comparatively long.
-        val p = VeriTParser.getExpansionProof(tempCopyOfClasspathFile(s"test${i}.verit")).get
-        val seq = ETtoDeep(p)
+      for ( i <- List( 0, 1, 3 ) ) { // Tests 2 and 4 take comparatively long.
+        val p = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( s"test${i}.verit" ) ).get
+        val seq = ETtoDeep( p )
 
-        minisat.isValid(seq) must beTrue
+        minisat.isValid( seq ) must beTrue
       }
       ok
     }
 
     "load Prover9 proof without equality reasoning, extract expansion tree E, verify deep formula of E using minisat" in {
       val minisat = new MiniSATProver()
-      if (!minisat.isInstalled()) skipped("MiniSAT is not installed")
-      if (!Prover9.isInstalled()) skipped("Prover9 is not installed")
+      if ( !minisat.isInstalled() ) skipped( "MiniSAT is not installed" )
+      if ( !Prover9.isInstalled() ) skipped( "Prover9 is not installed" )
 
       val testFilePath = tempCopyOfClasspathFile( "PUZ002-1.out" )
 
@@ -215,16 +213,16 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
     "load Prover9 proof with equality reasoning, extract expansion tree E, verify deep formula of E using veriT" in {
       val veriT = new VeriTProver()
-      if (!veriT.isInstalled()) skipped("VeriT is not installed")
-      if (!Prover9.isInstalled()) skipped("Prover9 is not installed")
+      if ( !veriT.isInstalled() ) skipped( "VeriT is not installed" )
+      if ( !Prover9.isInstalled() ) skipped( "Prover9 is not installed" )
 
       val testFilePath = tempCopyOfClasspathFile( "ALG004-1.out" )
 
       val lkProof = Prover9.parse_prover9LK( testFilePath )
-      val expansionSequent = extractExpansionSequent(lkProof, false)
-      val deep = ETtoDeep(expansionSequent)
+      val expansionSequent = extractExpansionSequent( lkProof, false )
+      val deep = ETtoDeep( expansionSequent )
 
-      veriT.isValid(deep) must beTrue
+      veriT.isValid( deep ) must beTrue
     }
   }
 }

--- a/src/test/scala/at/logic/integration_tests/PrimeProofTest.scala
+++ b/src/test/scala/at/logic/integration_tests/PrimeProofTest.scala
@@ -6,7 +6,7 @@ import at.logic.algorithms.lk._
 import at.logic.algorithms.lk.eliminateDefinitions
 import at.logic.algorithms.lk.statistics._
 import at.logic.algorithms.subsumption._
-import at.logic.calculi.expansionTrees.{toDeep, ExpansionSequent}
+import at.logic.calculi.expansionTrees.{ toDeep, ExpansionSequent }
 import at.logic.calculi.lk._
 import at.logic.calculi.lk.base._
 import at.logic.language.fol.FOLFormula
@@ -26,11 +26,10 @@ import at.logic.provers.veriT.VeriTProver
 import at.logic.transformations.ceres.clauseSets.StandardClauseSet
 import at.logic.transformations.ceres.clauseSets.profile._
 import at.logic.transformations.ceres.projections.Projections
-import at.logic.transformations.ceres.struct.{StructCreators, structToExpressionTree}
+import at.logic.transformations.ceres.struct.{ StructCreators, structToExpressionTree }
 import at.logic.transformations.herbrandExtraction.extractExpansionSequent
 import at.logic.transformations.skolemization.lksk.LKtoLKskc
 import at.logic.transformations.skolemization.skolemize
-
 
 /* comment out until atp works again
 import at.logic.provers.atp.Prover
@@ -39,133 +38,132 @@ import at.logic.provers.atp.refinements.UnitRefinement
 */
 
 import java.io.File.separator
-import java.io.{IOException, FileReader, FileInputStream, InputStreamReader}
+import java.io.{ IOException, FileReader, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class PrimeProofTest extends SpecificationWithJUnit {
   val box = List()
-  def checkForProverOrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
+  def checkForProverOrSkip = Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
   def sequentToString( s: Sequent ) = {
     var ret = ""
-    s.antecedent.foreach( formula => ret += formula.toString + ", ")
+    s.antecedent.foreach( formula => ret += formula.toString + ", " )
     ret += " :- "
-    s.succedent.foreach( formula => ret += formula.toString + ", ")
+    s.succedent.foreach( formula => ret += formula.toString + ", " )
     ret
   }
 
   def printStats( p: LKProof ) = {
     val stats = getStatistics( p )
-    print("unary: " + stats.unary + "\n")
-    print("binary: " + stats.binary + "\n")
-    print("cuts: " + stats.cuts + "\n")
+    print( "unary: " + stats.unary + "\n" )
+    print( "binary: " + stats.binary + "\n" )
+    print( "cuts: " + stats.cuts + "\n" )
   }
 
-  def mySort(x: Sequent, y: Sequent) = (x.toString < y.toString) // lexicographically
+  def mySort( x: Sequent, y: Sequent ) = ( x.toString < y.toString ) // lexicographically
 
   "The system" should {
-//    "parse correctly the second-order prime proof" in {
-//      val pdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("prime2.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-//      pdb.proofs.size must beEqualTo(1)
-//      val proof = pdb.proofs.head
-//      printStats( proof )
-//
-//      val proof_sk = LKtoLKskc( proof )
-//      val s = StructCreators.extract( proof_sk )
-//
-//      val csPre : List[Sequent] = StandardClauseSet.transformStructToClauseSet(s) map (_.getSequent)
-//
-//      // we will add three axioms: 0 < p(x), 1 < p(x), x = x
-//      val seq1 = Sequent(Nil, Atom(ConstantStringSymbol("<"), HOLConst(ConstantStringSymbol("0"), Ti())::Function(ConstantStringSymbol("p"), HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::Nil)::Nil)
-//      val seq2 = Sequent(Nil, Atom(ConstantStringSymbol("<"), HOLConst(ConstantStringSymbol("1"), Ti())::Function(ConstantStringSymbol("p"), HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::Nil)::Nil)
-//      val seq3 = Sequent(Nil, Atom(ConstantStringSymbol("="), HOLVar(VariableStringSymbol("x"), Ti())::(HOLVar(VariableStringSymbol("x"), Ti())::Nil))::Nil)
-//      val seq4 = Sequent(Nil, Atom(ConstantStringSymbol("="), Function(ConstantStringSymbol("+"), HOLConst(ConstantStringSymbol("0"), Ti())::HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::HOLVar(VariableStringSymbol("x"), Ti())::Nil)::Nil)
-//
-//      val holcs : List[Sequent] = pdb.axioms ::: List[Sequent](seq1,seq2,seq3,seq4) ::: csPre
-//
-//      // maps original types and definitions of abstractions
-//      val sectionsPre = ("Types", getTypeInformation(holcs).toList.sortWith((x,y) => x.toString < y.toString))::Nil
-//
-//      // convert to fol and obtain map of definitons
-//      val imap = Map[at.logic.language.lambda.typedLambdaCalculus.LambdaExpression, at.logic.language.hol.logicSymbols.ConstantStringSymbol]()
-//      val iid = new {var idd = 0; def nextId = {idd = idd+1; idd}}
-//      val cs = holcs.map(x => Sequent(
-//          x.antecedent.map(y => reduceHolToFol(y.asInstanceOf[HOLExpression],imap,iid).asInstanceOf[FOLFormula]),
-//          x.succedent.map(y => reduceHolToFol(y.asInstanceOf[HOLExpression],imap,iid).asInstanceOf[FOLFormula])
-//      ))
-//      val sections = ("Definitions", imap.toList.map(x => (x._1, FOLConst(x._2))))::sectionsPre
-//
-//      val dcs = deleteTautologies( cs )
-//      Console.println("dcs size: " + dcs.size)
-//      val css = dcs.distinct
-//      Console.println("css size: " + css.size)
-//
-//      val cssUnit = simpleUnitResolutionNormalization(css)
-//      Console.println("cssUnit size: " + cssUnit.size)
-//
-//      val scss = subsumedClausesRemoval(cssUnit)
-//      Console.println("scss size: " + scss.size)
-//
-//      val cssv = sequentNormalize(scss)
-//      Console.println("cssv size: " + cssv.size)
-//
-// /*     // apply unit resolution and subsumption on the resulted clause set
-//      val pb = new at.logic.utils.ds.PublishingBuffer[Clause]
-//      pb.insertAll(0,cssv.map(x => at.logic.calculi.resolution.base.Clause(x.antecedent.asInstanceOf[List[HOLFormula]], x.succedent.asInstanceOf[List[HOLFormula]])))
-//      val ref = new at.logic.provers.atp.refinements.UnitRefinement(pb)
-//      val subsumMng = new at.logic.algorithms.subsumption.managers.SimpleManager(pb.asInstanceOf[at.logic.utils.ds.PublishingBuffer[at.logic.calculi.lk.base.Sequent]],
-//        new at.logic.algorithms.subsumption.StillmanSubsumptionAlgorithm{val matchAlg = at.logic.algorithms.matching.fol.FOLMatchingAlgorithm})
-//        AutomatedFOLStream(-1, new at.logic.provers.atp.refinements.UnitRefinement(pb), subsumMng)
-//      val res = new Prover{}.refute(AutomatedFOLStream(-1, new at.logic.provers.atp.refinements.UnitRefinement(pb), subsumMng))
-//      Console.println("has a refutation? " + (!res.isEmpty))
-//      val newUnitSet = pb.toList
-//      Console.println("newUnitSet size: " + newUnitSet.size)
-//      val newUnitSetSubsum = subsumedClausesRemoval(newUnitSet)
-//      Console.println("newUnitSetSubsum size: " + newUnitSetSubsum.size)
-//*/
-//      // done for preserving order
-//      val neg = cssv.filter(x => x.succedent.isEmpty)
-//      val mix = cssv.filter(x => !x.succedent.isEmpty && !x.antecedent.isEmpty)
-//      val pos = cssv.filter(x => x.antecedent.isEmpty)
-///*
-//      // done for preserving order
-//      val neg2 = newUnitSetSubsum.filter(x => x.succedent.isEmpty)
-//      val mix2 = newUnitSetSubsum.filter(x => !x.succedent.isEmpty && !x.antecedent.isEmpty)
-//      val pos2 = newUnitSetSubsum.filter(x => x.antecedent.isEmpty)
-//*/
-//      val subsum = sequentNormalize(cssUnit).diff(cssv)
-//      Console.println("subsum size: " + subsum.size)
-//      (new FileWriter("target" + separator + "prime2-cs-subsumed.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
-//        .exportSequentList(subsum, sections).close
-//      (new FileWriter("target" + separator + "prime2-cs.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
-//        .exportSequentList(neg.sortWith(mySort) ++ mix.sortWith(mySort) ++ pos.sortWith(mySort), sections).close
-// /*     (new FileWriter("target" + separator + "prime2-cs-unit.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
-//        .exportSequentList(neg2.sort(mySort) ++ mix2.sort(mySort) ++ pos2.sort(mySort), sections).close*/
-//      //saveXML( Tuple2("cs", cs)::Tuple2("dcs", dcs)::Tuple2("css", (css.toList))::Tuple2("cssv", cssv.toList)::Nil, "target" + separator + "prime2-cs.xml" )
-//      //saveXML( Tuple2("cs", cs)::Tuple2("dcs", dcs)::Tuple2("css", (css.toList))::Tuple2("cssv", cssv.toList)::Nil, "target" + separator + "prime2-cs.xml" )
-//    }
+    //    "parse correctly the second-order prime proof" in {
+    //      val pdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("prime2.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
+    //      pdb.proofs.size must beEqualTo(1)
+    //      val proof = pdb.proofs.head
+    //      printStats( proof )
+    //
+    //      val proof_sk = LKtoLKskc( proof )
+    //      val s = StructCreators.extract( proof_sk )
+    //
+    //      val csPre : List[Sequent] = StandardClauseSet.transformStructToClauseSet(s) map (_.getSequent)
+    //
+    //      // we will add three axioms: 0 < p(x), 1 < p(x), x = x
+    //      val seq1 = Sequent(Nil, Atom(ConstantStringSymbol("<"), HOLConst(ConstantStringSymbol("0"), Ti())::Function(ConstantStringSymbol("p"), HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::Nil)::Nil)
+    //      val seq2 = Sequent(Nil, Atom(ConstantStringSymbol("<"), HOLConst(ConstantStringSymbol("1"), Ti())::Function(ConstantStringSymbol("p"), HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::Nil)::Nil)
+    //      val seq3 = Sequent(Nil, Atom(ConstantStringSymbol("="), HOLVar(VariableStringSymbol("x"), Ti())::(HOLVar(VariableStringSymbol("x"), Ti())::Nil))::Nil)
+    //      val seq4 = Sequent(Nil, Atom(ConstantStringSymbol("="), Function(ConstantStringSymbol("+"), HOLConst(ConstantStringSymbol("0"), Ti())::HOLVar(VariableStringSymbol("x"), Ti())::Nil, Ti())::HOLVar(VariableStringSymbol("x"), Ti())::Nil)::Nil)
+    //
+    //      val holcs : List[Sequent] = pdb.axioms ::: List[Sequent](seq1,seq2,seq3,seq4) ::: csPre
+    //
+    //      // maps original types and definitions of abstractions
+    //      val sectionsPre = ("Types", getTypeInformation(holcs).toList.sortWith((x,y) => x.toString < y.toString))::Nil
+    //
+    //      // convert to fol and obtain map of definitons
+    //      val imap = Map[at.logic.language.lambda.typedLambdaCalculus.LambdaExpression, at.logic.language.hol.logicSymbols.ConstantStringSymbol]()
+    //      val iid = new {var idd = 0; def nextId = {idd = idd+1; idd}}
+    //      val cs = holcs.map(x => Sequent(
+    //          x.antecedent.map(y => reduceHolToFol(y.asInstanceOf[HOLExpression],imap,iid).asInstanceOf[FOLFormula]),
+    //          x.succedent.map(y => reduceHolToFol(y.asInstanceOf[HOLExpression],imap,iid).asInstanceOf[FOLFormula])
+    //      ))
+    //      val sections = ("Definitions", imap.toList.map(x => (x._1, FOLConst(x._2))))::sectionsPre
+    //
+    //      val dcs = deleteTautologies( cs )
+    //      Console.println("dcs size: " + dcs.size)
+    //      val css = dcs.distinct
+    //      Console.println("css size: " + css.size)
+    //
+    //      val cssUnit = simpleUnitResolutionNormalization(css)
+    //      Console.println("cssUnit size: " + cssUnit.size)
+    //
+    //      val scss = subsumedClausesRemoval(cssUnit)
+    //      Console.println("scss size: " + scss.size)
+    //
+    //      val cssv = sequentNormalize(scss)
+    //      Console.println("cssv size: " + cssv.size)
+    //
+    // /*     // apply unit resolution and subsumption on the resulted clause set
+    //      val pb = new at.logic.utils.ds.PublishingBuffer[Clause]
+    //      pb.insertAll(0,cssv.map(x => at.logic.calculi.resolution.base.Clause(x.antecedent.asInstanceOf[List[HOLFormula]], x.succedent.asInstanceOf[List[HOLFormula]])))
+    //      val ref = new at.logic.provers.atp.refinements.UnitRefinement(pb)
+    //      val subsumMng = new at.logic.algorithms.subsumption.managers.SimpleManager(pb.asInstanceOf[at.logic.utils.ds.PublishingBuffer[at.logic.calculi.lk.base.Sequent]],
+    //        new at.logic.algorithms.subsumption.StillmanSubsumptionAlgorithm{val matchAlg = at.logic.algorithms.matching.fol.FOLMatchingAlgorithm})
+    //        AutomatedFOLStream(-1, new at.logic.provers.atp.refinements.UnitRefinement(pb), subsumMng)
+    //      val res = new Prover{}.refute(AutomatedFOLStream(-1, new at.logic.provers.atp.refinements.UnitRefinement(pb), subsumMng))
+    //      Console.println("has a refutation? " + (!res.isEmpty))
+    //      val newUnitSet = pb.toList
+    //      Console.println("newUnitSet size: " + newUnitSet.size)
+    //      val newUnitSetSubsum = subsumedClausesRemoval(newUnitSet)
+    //      Console.println("newUnitSetSubsum size: " + newUnitSetSubsum.size)
+    //*/
+    //      // done for preserving order
+    //      val neg = cssv.filter(x => x.succedent.isEmpty)
+    //      val mix = cssv.filter(x => !x.succedent.isEmpty && !x.antecedent.isEmpty)
+    //      val pos = cssv.filter(x => x.antecedent.isEmpty)
+    ///*
+    //      // done for preserving order
+    //      val neg2 = newUnitSetSubsum.filter(x => x.succedent.isEmpty)
+    //      val mix2 = newUnitSetSubsum.filter(x => !x.succedent.isEmpty && !x.antecedent.isEmpty)
+    //      val pos2 = newUnitSetSubsum.filter(x => x.antecedent.isEmpty)
+    //*/
+    //      val subsum = sequentNormalize(cssUnit).diff(cssv)
+    //      Console.println("subsum size: " + subsum.size)
+    //      (new FileWriter("target" + separator + "prime2-cs-subsumed.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
+    //        .exportSequentList(subsum, sections).close
+    //      (new FileWriter("target" + separator + "prime2-cs.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
+    //        .exportSequentList(neg.sortWith(mySort) ++ mix.sortWith(mySort) ++ pos.sortWith(mySort), sections).close
+    // /*     (new FileWriter("target" + separator + "prime2-cs-unit.tex") with SequentsListLatexExporter with HOLTermArithmeticalExporter)
+    //        .exportSequentList(neg2.sort(mySort) ++ mix2.sort(mySort) ++ pos2.sort(mySort), sections).close*/
+    //      //saveXML( Tuple2("cs", cs)::Tuple2("dcs", dcs)::Tuple2("css", (css.toList))::Tuple2("cssv", cssv.toList)::Nil, "target" + separator + "prime2-cs.xml" )
+    //      //saveXML( Tuple2("cs", cs)::Tuple2("dcs", dcs)::Tuple2("css", (css.toList))::Tuple2("cssv", cssv.toList)::Nil, "target" + separator + "prime2-cs.xml" )
+    //    }
 
-
-    def prime1(n: Int, refute: Boolean) = {
+    def prime1( n: Int, refute: Boolean ) = {
       checkForProverOrSkip
 
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("prime1-" + n + ".xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "prime1-" + n + ".xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       val veriT = new VeriTProver()
 
-      if (false) { // run this code as soon as issue 260 is fixed:
-        if (veriT.isInstalled()) {
+      if ( false ) { // run this code as soon as issue 260 is fixed:
+        if ( veriT.isInstalled() ) {
           // test expansion tree extraction by verifying that the deep formula is a tautology
-          val definitionFreeProof = eliminateDefinitions(proof) // can't extract ETs in the presence of definitions currently
-          val etSeq = extractExpansionSequent(definitionFreeProof, false)
-          val fSequent = toDeep(etSeq)
-          veriT.isValid(fSequent) must beTrue
+          val definitionFreeProof = eliminateDefinitions( proof ) // can't extract ETs in the presence of definitions currently
+          val etSeq = extractExpansionSequent( definitionFreeProof, false )
+          val fSequent = toDeep( etSeq )
+          veriT.isValid( fSequent ) must beTrue
         }
       }
 
@@ -176,49 +174,46 @@ class PrimeProofTest extends SpecificationWithJUnit {
       // convert struct DAG to tree
       structToExpressionTree( s )
 
-      val prf = deleteTautologies(proofProfile(s, proof_sk) map (_.toFSequent))
+      val prf = deleteTautologies( proofProfile( s, proof_sk ) map ( _.toFSequent ) )
 
       val tptp_prf = TPTPFOLExporter.tptp_problem( prf )
-      val writer_prf = new java.io.FileWriter("target" + separator + "prime1-" + n + "-prf.tptp")
+      val writer_prf = new java.io.FileWriter( "target" + separator + "prime1-" + n + "-prf.tptp" )
       writer_prf.write( tptp_prf )
       writer_prf.flush
 
-
-
-      val cs = deleteTautologies( StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent) )
+      val cs = deleteTautologies( StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent ) )
       val tptp = TPTPFOLExporter.tptp_problem( cs )
-      val writer = new java.io.FileWriter("target" + separator + "prime1-" + n + "-cs.tptp")
+      val writer = new java.io.FileWriter( "target" + separator + "prime1-" + n + "-cs.tptp" )
       writer.write( tptp )
       writer.flush
       val projs = Projections( proof_sk )
       val path = "target" + separator + "prime1-" + n + "-sk.xml"
 
-      val prf_cs_intersect = prf.filter(seq => cs.contains(seq))
+      val prf_cs_intersect = prf.filter( seq => cs.contains( seq ) )
 
-      if (refute) {
+      if ( refute ) {
         Prover9.refute( prf ) match {
-          case None => "" must beEqualTo("refutation of proof profile failed")
-          case Some(_) => true must beEqualTo(true)
+          case None      => "" must beEqualTo( "refutation of proof profile failed" )
+          case Some( _ ) => true must beEqualTo( true )
         }
         Prover9.refute( cs ) match {
-          case None => "" must beEqualTo("refutation of struct cs in tptp format failed")
-          case Some(_) => true must beEqualTo(true)
+          case None      => "" must beEqualTo( "refutation of struct cs in tptp format failed" )
+          case Some( _ ) => true must beEqualTo( true )
         }
       }
 
-      saveXML( Tuple2("prime1-" + n + "-sk", proof_sk) ::
+      saveXML( Tuple2( "prime1-" + n + "-sk", proof_sk ) ::
         projs.toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
         //projs.map( p => p._1 ).toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
-        Tuple2("cs", cs)::Tuple2("prf",prf)::Tuple2("cs_prf_intersection", prf_cs_intersect)::Nil, path )
-      (new java.io.File( path ) ).exists() must beEqualTo( true )
+        Tuple2( "cs", cs ) :: Tuple2( "prf", prf ) :: Tuple2( "cs_prf_intersection", prf_cs_intersect ) :: Nil, path )
+      ( new java.io.File( path ) ).exists() must beEqualTo( true )
     }
 
-
-    def euclid(n: Int) = {
+    def euclid( n: Int ) = {
       checkForProverOrSkip
 
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("euclid-" + n + ".xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "euclid-" + n + ".xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       //val proof_sk = skolemize( regularize( proof )._1 )
@@ -228,46 +223,43 @@ class PrimeProofTest extends SpecificationWithJUnit {
       // convert struct DAG to tree
       structToExpressionTree( s )
 
-      val prf = deleteTautologies(proofProfile(s, proof_sk).map( _.toFSequent ))
+      val prf = deleteTautologies( proofProfile( s, proof_sk ).map( _.toFSequent ) )
 
       val tptp_prf = TPTPFOLExporter.tptp_problem( prf )
-      val writer_prf = new java.io.FileWriter("target" + separator + "euclid-" + n + "-prf.tptp")
+      val writer_prf = new java.io.FileWriter( "target" + separator + "euclid-" + n + "-prf.tptp" )
       writer_prf.write( tptp_prf )
       writer_prf.flush
 
-
-
       val cs = deleteTautologies( StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent ) )
       val tptp = TPTPFOLExporter.tptp_problem( cs )
-      val writer = new java.io.FileWriter("target" + separator + "euclid-" + n + "-cs.tptp")
+      val writer = new java.io.FileWriter( "target" + separator + "euclid-" + n + "-cs.tptp" )
       writer.write( tptp )
       writer.flush
       val projs = Projections( proof_sk )
       val path = "target" + separator + "euclid-" + n + "-sk.xml"
 
-      val prf_cs_intersect = prf.filter(seq => cs.contains(seq))
-
+      val prf_cs_intersect = prf.filter( seq => cs.contains( seq ) )
 
       //Prover9.refute( cs ) must beEqualTo( true )
       //Prover9.refute( prf ) must beEqualTo( true )
 
-      saveXML( Tuple2("euclid-" + n + "-sk", proof_sk) ::
+      saveXML( Tuple2( "euclid-" + n + "-sk", proof_sk ) ::
         projs.toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
         //projs.map( p => p._1 ).toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
-        Tuple2("cs", cs)::Tuple2("prf",prf)::Tuple2("cs_prf_intersection", prf_cs_intersect)::Nil, path )
-      (new java.io.File( path ) ).exists() must beEqualTo( true )
+        Tuple2( "cs", cs ) :: Tuple2( "prf", prf ) :: Tuple2( "cs_prf_intersection", prf_cs_intersect ) :: Nil, path )
+      ( new java.io.File( path ) ).exists() must beEqualTo( true )
     }
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=0" in euclid(0)
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=0" in euclid( 0 )
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=1" in euclid(1)
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=1" in euclid( 1 )
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=2" in euclid(2)
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof (Euclid's proof), n=2" in euclid( 2 )
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=0" in prime1(0, true)
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=0" in prime1( 0, true )
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=1" in prime1(1, false)
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=1" in prime1( 1, false )
 
-    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=2" in prime1(2, false)
-     }
+    "parse, skolemize, and export the clause set in TPTP of the first-order prime proof, n=2" in prime1( 2, false )
+  }
 }

--- a/src/test/scala/at/logic/integration_tests/TapeTest.scala
+++ b/src/test/scala/at/logic/integration_tests/TapeTest.scala
@@ -1,9 +1,8 @@
 package at.logic.integration_tests
 
 import at.logic.language.hol._
-import at.logic.calculi.resolution.{Clause, ResolutionProof}
+import at.logic.calculi.resolution.{ Clause, ResolutionProof }
 import at.logic.calculi.lk._
-
 
 import at.logic.algorithms.fol.hol2fol._
 import at.logic.algorithms.lk._
@@ -23,7 +22,7 @@ import at.logic.transformations.ceres.clauseSets.StandardClauseSet
 import at.logic.transformations.ceres.clauseSets.profile.proofProfile
 import at.logic.transformations.ceres.projections.Projections
 import at.logic.transformations.ceres.struct.StructCreators
-import at.logic.transformations.ceres.{CERES, CERESR2LK}
+import at.logic.transformations.ceres.{ CERES, CERESR2LK }
 
 import at.logic.transformations.skolemization.lksk.LKtoLKskc
 import at.logic.transformations.skolemization.skolemize
@@ -33,23 +32,23 @@ import at.logic.algorithms.rewriting.DefinitionElimination
 import at.logic.algorithms.resolution.RobinsonToLK
 
 import java.io.File.separator
-import java.io.{IOException, FileInputStream, InputStreamReader}
+import java.io.{ IOException, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
 
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class TapeTest extends SpecificationWithJUnit {
   val box = List()
-  def checkForProverOrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
+  def checkForProverOrSkip = Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
   sequential
   "The system" should {
     "parse correctly the tape proof" in {
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("tape-in.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       val proof_sk = LKtoLKskc( proof )
@@ -63,57 +62,56 @@ class TapeTest extends SpecificationWithJUnit {
       */
       ok
     }
-    
+
     "parse, skolemize and extract the profile of the tape proof" in {
       checkForProverOrSkip
 
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("tape-in.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       val proof_sk = skolemize( proof )
       val s = StructCreators.extract( proof_sk )
 
-      val prf = deleteTautologies(proofProfile(s, proof_sk).map( _.toFSequent ))
+      val prf = deleteTautologies( proofProfile( s, proof_sk ).map( _.toFSequent ) )
 
       val tptp_prf = TPTPFOLExporter.tptp_problem( prf )
-      val writer_prf = new java.io.FileWriter("target" + separator + "tape-prf.tptp")
+      val writer_prf = new java.io.FileWriter( "target" + separator + "tape-prf.tptp" )
       writer_prf.write( tptp_prf )
       writer_prf.flush
 
       val cs = deleteTautologies( StandardClauseSet.transformStructToClauseSet( s ).map( _.toFSequent ) )
       val tptp = TPTPFOLExporter.tptp_problem( cs )
-      val writer = new java.io.FileWriter("target" + separator + "tape-cs.tptp")
+      val writer = new java.io.FileWriter( "target" + separator + "tape-cs.tptp" )
       writer.write( tptp )
       writer.flush
       val projs = Projections( proof_sk )
       val path = "target" + separator + "tape-sk.xml"
 
-      val prf_cs_intersect = prf.filter(seq => cs.contains(seq))
+      val prf_cs_intersect = prf.filter( seq => cs.contains( seq ) )
 
       Prover9.refute( prf ) match {
-        case None => "" must beEqualTo("refutation of proof profile failed")
-        case Some(_) => true must beEqualTo(true)
+        case None      => "" must beEqualTo( "refutation of proof profile failed" )
+        case Some( _ ) => true must beEqualTo( true )
       }
       Prover9.refute( cs ) match {
-        case None => "" must beEqualTo("refutation of struct cs in tptp format failed")
-        case Some(_) => true must beEqualTo(true)
+        case None      => "" must beEqualTo( "refutation of struct cs in tptp format failed" )
+        case Some( _ ) => true must beEqualTo( true )
       }
 
-
-      saveXML( Tuple2("tape-sk", proof_sk) ::
+      saveXML( Tuple2( "tape-sk", proof_sk ) ::
         projs.toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
         //projs.map( p => p._1 ).toList.zipWithIndex.map( p => Tuple2( "\\psi_{" + p._2 + "}", p._1 ) ),
-        Tuple2("cs", cs)::Tuple2("prf",prf)::Tuple2("cs_prf_intersection", prf_cs_intersect)::Nil, path )
-      (new java.io.File( path ) ).exists() must beEqualTo( true )
+        Tuple2( "cs", cs ) :: Tuple2( "prf", prf ) :: Tuple2( "cs_prf_intersection", prf_cs_intersect ) :: Nil, path )
+      ( new java.io.File( path ) ).exists() must beEqualTo( true )
     }
-   
+
     "apply prover9 to the tape proof clause set" in {
       checkForProverOrSkip
-      skipped("Infinite loop??")
+      skipped( "Infinite loop??" )
 
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("tape-in.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      proofdb.proofs.size must beEqualTo(1)
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      proofdb.proofs.size must beEqualTo( 1 )
       val proof = proofdb.proofs.head._2
 
       val proof_sk = LKtoLKskc( proof )
@@ -122,60 +120,58 @@ class TapeTest extends SpecificationWithJUnit {
 
       object MyProver extends Prover[Clause]
 
-      def getRefutation(ls: Iterable[FSequent]): Boolean = MyProver.refute(Stream(SetTargetClause(FSequent(List(),List())), Prover9InitCommand(ls), SetStreamCommand())).next must beLike {
-        case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals (FSequent(List(),List())) => ok
+      def getRefutation( ls: Iterable[FSequent] ): Boolean = MyProver.refute( Stream( SetTargetClause( FSequent( List(), List() ) ), Prover9InitCommand( ls ), SetStreamCommand() ) ).next must beLike {
+        case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals ( FSequent( List(), List() ) ) => ok
         case _ => ko
       }
 
-      getRefutation(cs.map(_.toFSequent)) must beTrue
+      getRefutation( cs.map( _.toFSequent ) ) must beTrue
     }
 
     "create an acnf of the tape proof via ground proof" in {
       checkForProverOrSkip
       //get the proof
-      val pdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("tape-in.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      val elp = AtomicExpansion(DefinitionElimination(pdb.Definitions, regularize(pdb.proof("the-proof"))))
-      val (foltape,_) = map_proof(elp, convertHolToFol.apply)
-
+      val pdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      val elp = AtomicExpansion( DefinitionElimination( pdb.Definitions, regularize( pdb.proof( "the-proof" ) ) ) )
+      val ( foltape, _ ) = map_proof( elp, convertHolToFol.apply )
 
       //get the refutation of the clause set, refute it
-      val tapecl = StandardClauseSet.transformStructToClauseSet(StructCreators.extract(foltape))
-      val Some(taperp) = Prover9.refute(tapecl.map(_.toFSequent))
-      val lkref = RobinsonToLK(taperp)
+      val tapecl = StandardClauseSet.transformStructToClauseSet( StructCreators.extract( foltape ) )
+      val Some( taperp ) = Prover9.refute( tapecl.map( _.toFSequent ) )
+      val lkref = RobinsonToLK( taperp )
 
       //get projections etc
-      val tapeproj = Projections(foltape)
-      val refproj = CERES.refProjection(foltape.root.toFSequent)
+      val tapeproj = Projections( foltape )
+      val refproj = CERES.refProjection( foltape.root.toFSequent )
 
-      val acnf = CERES(foltape.root.toFSequent, tapeproj + refproj, lkref)
+      val acnf = CERES( foltape.root.toFSequent, tapeproj + refproj, lkref )
 
       //the acnf must not contain any quantified cuts
-      acnf.nodes.collect({case c@CutRule(_,_,_,aux,_) if containsQuantifier(aux.formula) => c}) must beEmpty
-      acnf.root.toFSequent must beSyntacticFSequentEqual(foltape.root.toFSequent)
+      acnf.nodes.collect( { case c @ CutRule( _, _, _, aux, _ ) if containsQuantifier( aux.formula ) => c } ) must beEmpty
+      acnf.root.toFSequent must beSyntacticFSequentEqual( foltape.root.toFSequent )
 
     }
 
     "create an acnf of the tape proof via robinson2lk" in {
       checkForProverOrSkip
       //get the proof
-      val pdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("tape-in.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
-      val elp = AtomicExpansion(DefinitionElimination(pdb.Definitions, regularize(pdb.proof("the-proof"))))
-      val (foltape,_) = map_proof(elp, convertHolToFol.apply)
-
+      val pdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
+      val elp = AtomicExpansion( DefinitionElimination( pdb.Definitions, regularize( pdb.proof( "the-proof" ) ) ) )
+      val ( foltape, _ ) = map_proof( elp, convertHolToFol.apply )
 
       //get the refutation of the clause set, refute it
-      val tapecl = StandardClauseSet.transformStructToClauseSet(StructCreators.extract(foltape))
-      val Some(taperp) = Prover9.refute(tapecl.map(_.toFSequent))
+      val tapecl = StandardClauseSet.transformStructToClauseSet( StructCreators.extract( foltape ) )
+      val Some( taperp ) = Prover9.refute( tapecl.map( _.toFSequent ) )
 
       //get projections etc
-      val tapeproj = Projections(foltape)
-      val refproj = CERES.refProjection(foltape.root.toFSequent)
+      val tapeproj = Projections( foltape )
+      val refproj = CERES.refProjection( foltape.root.toFSequent )
 
-      val acnf = CERESR2LK(foltape.root.toFSequent, tapeproj + refproj, taperp)
+      val acnf = CERESR2LK( foltape.root.toFSequent, tapeproj + refproj, taperp )
 
       //the acnf must not contain any quantified cuts
-      acnf.nodes.collect({case c@CutRule(_,_,_,aux,_) if containsQuantifier(aux.formula) => c}) must beEmpty
-      acnf.root.toFSequent must beSyntacticFSequentEqual(foltape.root.toFSequent)
+      acnf.nodes.collect( { case c @ CutRule( _, _, _, aux, _ ) if containsQuantifier( aux.formula ) => c } ) must beEmpty
+      acnf.root.toFSequent must beSyntacticFSequentEqual( foltape.root.toFSequent )
 
     }
 

--- a/src/test/scala/at/logic/integration_tests/TreeGrammarDecompositionTest.scala
+++ b/src/test/scala/at/logic/integration_tests/TreeGrammarDecompositionTest.scala
@@ -5,100 +5,95 @@ import at.logic.calculi.lk._
 import at.logic.calculi.lk.base.LKProof
 import at.logic.language.fol._
 import at.logic.transformations.herbrandExtraction.extractExpansionSequent
-import at.logic.provers.maxsat.{MaxSAT, MaxSATSolver}
+import at.logic.provers.maxsat.{ MaxSAT, MaxSATSolver }
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.mutable.SpecificationWithJUnit
-
 
 /**
  * Created by spoerk on 09.10.14.
  */
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
 
-  private def LinearExampleProof(k: Int, n: Int): LKProof = {
+  private def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"
     val c = "0"
     val p = "P"
 
-    val x = FOLVar("x")
-    val ass = AllVar(x, Imp(Atom(p, x :: Nil), Atom(p, Function(s, x :: Nil) :: Nil)))
-    if (k == n) {// leaf proof {
-      val a = Atom(p, Utils.numeral(n) :: Nil)
-      WeakeningLeftRule(Axiom(a :: Nil, a :: Nil), ass)
-    }
-    else {
-      val p1 = Atom(p, Utils.numeral(k) :: Nil)
-      val p2 = Atom(p, Utils.numeral(k + 1) :: Nil)
-      val aux = Imp(p1, p2)
-      ContractionLeftRule(ForallLeftRule(ImpLeftRule(Axiom(p1 :: Nil, p1 :: Nil), LinearExampleProof(k + 1, n), p1, p2), aux, ass, Utils.numeral(k)), ass)
+    val x = FOLVar( "x" )
+    val ass = AllVar( x, Imp( Atom( p, x :: Nil ), Atom( p, Function( s, x :: Nil ) :: Nil ) ) )
+    if ( k == n ) { // leaf proof {
+      val a = Atom( p, Utils.numeral( n ) :: Nil )
+      WeakeningLeftRule( Axiom( a :: Nil, a :: Nil ), ass )
+    } else {
+      val p1 = Atom( p, Utils.numeral( k ) :: Nil )
+      val p2 = Atom( p, Utils.numeral( k + 1 ) :: Nil )
+      val aux = Imp( p1, p2 )
+      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1 :: Nil, p1 :: Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
     }
   }
 
-  private def toTerms(p: LKProof): List[FOLTerm] = {
-    val testtree = extractExpansionSequent(p, false)
-    val testterms = TermsExtraction(testtree)
+  private def toTerms( p: LKProof ): List[FOLTerm] = {
+    val testtree = extractExpansionSequent( p, false )
+    val testterms = TermsExtraction( testtree )
     val testlanguage = testterms.set
     testlanguage
   }
 
-  private def reconstructLanguage(grammar: Grammar): List[FOLTerm] = {
-    if (grammar.size > 0) {
-      val substitutions = grammar.slist.foldRight(List[Set[Substitution]]())((stuple, acc) => {
+  private def reconstructLanguage( grammar: Grammar ): List[FOLTerm] = {
+    if ( grammar.size > 0 ) {
+      val substitutions = grammar.slist.foldRight( List[Set[Substitution]]() )( ( stuple, acc ) => {
         val evs = stuple._1
-        val substitutionSet = stuple._2.map(termVector => Substitution(evs.zip(termVector)))
+        val substitutionSet = stuple._2.map( termVector => Substitution( evs.zip( termVector ) ) )
         substitutionSet :: acc
-      })
+      } )
       //println("Substitutions: \n" + substitutions)
       // substitute everything
-      substitutions.foldLeft(grammar.u)((u, subs) => {
-        u.map(uterm => subs.map(sub => sub(uterm)).toList.distinct).toList.flatten.distinct
-      })
-    }
-    else {
+      substitutions.foldLeft( grammar.u )( ( u, subs ) => {
+        u.map( uterm => subs.map( sub => sub( uterm ) ).toList.distinct ).toList.flatten.distinct
+      } )
+    } else {
       Nil
     }
   }
 
   "TreeGrammarDecomposition" should {
     "extract and decompose the termset of the linear example proof of 8 (n = 1)" in {
-      if (!(new MaxSAT(MaxSATSolver.QMaxSAT)).isInstalled()) skipped("MaxSAT is not installed")
-      
-      val proof = LinearExampleProof(0, 8)
-      val proofLanguage = toTerms(proof)
+      if ( !( new MaxSAT( MaxSATSolver.QMaxSAT ) ).isInstalled() ) skipped( "MaxSAT is not installed" )
 
-      val grammar = TreeGrammarDecomposition(proofLanguage, 1, MCSMethod.MaxSAT)
+      val proof = LinearExampleProof( 0, 8 )
+      val proofLanguage = toTerms( proof )
+
+      val grammar = TreeGrammarDecomposition( proofLanguage, 1, MCSMethod.MaxSAT )
 
       // check size
       grammar.get.slist.size shouldEqual 1
 
       // check validity
-      val grammarLanguage = reconstructLanguage(grammar.get)
+      val grammarLanguage = reconstructLanguage( grammar.get )
 
       proofLanguage diff grammarLanguage must beEmpty
     }
 
     "extract and decompose the termset of the linear example proof of 18 (n = 2)" in {
-      if (!(new MaxSAT(MaxSATSolver.QMaxSAT)).isInstalled()) skipped("MaxSAT is not installed")
-      skipped("this takes too long")
-      val proof = LinearExampleProof(0, 18)
-      val proofLanguage = toTerms(proof)
+      if ( !( new MaxSAT( MaxSATSolver.QMaxSAT ) ).isInstalled() ) skipped( "MaxSAT is not installed" )
+      skipped( "this takes too long" )
+      val proof = LinearExampleProof( 0, 18 )
+      val proofLanguage = toTerms( proof )
 
-      val grammar = TreeGrammarDecomposition(proofLanguage, 2, MCSMethod.MaxSAT)
+      val grammar = TreeGrammarDecomposition( proofLanguage, 2, MCSMethod.MaxSAT )
 
       // check size
       grammar.get.slist.size shouldEqual 2
 
       // check validity
-      val grammarLanguage = reconstructLanguage(grammar.get)
+      val grammarLanguage = reconstructLanguage( grammar.get )
 
       proofLanguage diff grammarLanguage must beEmpty
     }
 
-
   }
 }
-
 

--- a/src/test/scala/at/logic/integration_tests/nTapeTest.scala
+++ b/src/test/scala/at/logic/integration_tests/nTapeTest.scala
@@ -1,19 +1,19 @@
 package at.logic.integration_tests
 
-import java.io.{ IOException}
+import java.io.{ IOException }
 
-import at.logic.algorithms.fol.hol2fol.{undoHol2Fol, replaceAbstractions, reduceHolToFol}
+import at.logic.algorithms.fol.hol2fol.{ undoHol2Fol, replaceAbstractions, reduceHolToFol }
 import at.logic.algorithms.fol.recreateWithFactory
 import at.logic.algorithms.hlk.HybridLatexParser
-import at.logic.algorithms.lk.{AtomicExpansion, regularize}
+import at.logic.algorithms.lk.{ AtomicExpansion, regularize }
 import at.logic.algorithms.llk.HybridLatexExporter
 import at.logic.algorithms.resolution.RobinsonToRal
 import at.logic.algorithms.rewriting.DefinitionElimination
 import at.logic.calculi.lk.base.LKProof
 import at.logic.calculi.lksk.sequentToLabelledSequent
-import at.logic.language.fol.{FOLVar, FOLFormula, FOLExpression}
+import at.logic.language.fol.{ FOLVar, FOLFormula, FOLExpression }
 import at.logic.language.hol._
-import at.logic.language.lambda.symbols.{StringSymbol, SymbolA}
+import at.logic.language.lambda.symbols.{ StringSymbol, SymbolA }
 
 import at.logic.provers.prover9._
 import at.logic.transformations.ceres.clauseSets.AlternativeStandardClauseSet
@@ -24,110 +24,106 @@ import at.logic.transformations.ceres.ceres_omega
 import at.logic.transformations.herbrandExtraction.lksk.extractLKSKExpansionSequent
 import at.logic.transformations.skolemization.lksk.LKtoLKskc
 import at.logic.utils.testing.ClasspathFileCopier
-import at.logic.calculi.expansionTrees.{And => ETAnd, Imp => ETImp, Or => ETOr, Neg => ETNEg, WeakQuantifier, StrongQuantifier, SkolemQuantifier, ExpansionTree, toDeep, ExpansionSequent}
+import at.logic.calculi.expansionTrees.{ And => ETAnd, Imp => ETImp, Or => ETOr, Neg => ETNEg, WeakQuantifier, StrongQuantifier, SkolemQuantifier, ExpansionTree, toDeep, ExpansionSequent }
 
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class nTapeTest extends SpecificationWithJUnit with ClasspathFileCopier {
   val box = List()
-  def checkForProverOrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
+  def checkForProverOrSkip = Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
-  def show(s:String) = println("+++++++++ "+s+" ++++++++++")
+  def show( s: String ) = println( "+++++++++ " + s + " ++++++++++" )
 
-  def f(e:HOLExpression) : String = HybridLatexExporter.getFormulaString(e, true, false)
+  def f( e: HOLExpression ): String = HybridLatexExporter.getFormulaString( e, true, false )
 
   //sequential //skolemization is not thread safe - it shouldnt't make problems here, but in case there are issues, please uncomment
 
-  class Robinson2RalAndUndoHOL2Fol(sig_vars : Map[String, List[HOLVar]],
-                                   sig_consts : Map[String, List[HOLConst]],
-                                   cmap : replaceAbstractions.ConstantsMap) extends RobinsonToRal {
-    val absmap = Map[String, HOLExpression]() ++ (cmap.toList.map(x => (x._2.toString, x._1)))
+  class Robinson2RalAndUndoHOL2Fol( sig_vars: Map[String, List[HOLVar]],
+                                    sig_consts: Map[String, List[HOLConst]],
+                                    cmap: replaceAbstractions.ConstantsMap ) extends RobinsonToRal {
+    val absmap = Map[String, HOLExpression]() ++ ( cmap.toList.map( x => ( x._2.toString, x._1 ) ) )
     val cache = Map[HOLExpression, HOLExpression]()
 
-    override def convert_formula(e:HOLFormula) : HOLFormula = {
+    override def convert_formula( e: HOLFormula ): HOLFormula = {
       //require(e.isInstanceOf[FOLFormula], "Expecting prover 9 formula "+e+" to be from the FOL layer, but it is not.")
 
       BetaReduction.betaNormalize(
-        recreateWithFactory( undoHol2Fol.backtranslate(e, sig_vars, sig_consts, absmap)(HOLFactory), HOLFactory).asInstanceOf[HOLFormula]
-      )
+        recreateWithFactory( undoHol2Fol.backtranslate( e, sig_vars, sig_consts, absmap )( HOLFactory ), HOLFactory ).asInstanceOf[HOLFormula] )
     }
 
-    override def convert_substitution(s:Substitution) : Substitution = {
-      val mapping = s.map.toList.map(x =>
+    override def convert_substitution( s: Substitution ): Substitution = {
+      val mapping = s.map.toList.map( x =>
         (
-          BetaReduction.betaNormalize(recreateWithFactory(undoHol2Fol.backtranslate(x._1.asInstanceOf[HOLExpression], sig_vars, sig_consts, absmap, None)(HOLFactory), HOLFactory).asInstanceOf[HOLExpression]).asInstanceOf[HOLVar],
-          BetaReduction.betaNormalize(recreateWithFactory(undoHol2Fol.backtranslate(x._2.asInstanceOf[HOLExpression], sig_vars, sig_consts, absmap, None)(HOLFactory), HOLFactory).asInstanceOf[HOLExpression])
-          )
-      )
+          BetaReduction.betaNormalize( recreateWithFactory( undoHol2Fol.backtranslate( x._1.asInstanceOf[HOLExpression], sig_vars, sig_consts, absmap, None )( HOLFactory ), HOLFactory ).asInstanceOf[HOLExpression] ).asInstanceOf[HOLVar],
+          BetaReduction.betaNormalize( recreateWithFactory( undoHol2Fol.backtranslate( x._2.asInstanceOf[HOLExpression], sig_vars, sig_consts, absmap, None )( HOLFactory ), HOLFactory ).asInstanceOf[HOLExpression] ) ) )
 
-      Substitution(mapping)
+      Substitution( mapping )
     }
   }
 
   object Robinson2RalAndUndoHOL2Fol {
-    def apply(sig_vars : Map[String, List[HOLVar]],
-              sig_consts : Map[String, List[HOLConst]],
-              cmap : replaceAbstractions.ConstantsMap) =
-      new Robinson2RalAndUndoHOL2Fol(sig_vars, sig_consts, cmap)
+    def apply( sig_vars: Map[String, List[HOLVar]],
+               sig_consts: Map[String, List[HOLConst]],
+               cmap: replaceAbstractions.ConstantsMap ) =
+      new Robinson2RalAndUndoHOL2Fol( sig_vars, sig_consts, cmap )
   }
 
-  def decompose(et : ExpansionTree) : List[ExpansionTree] = et match {
-    case ETAnd(x,y) => decompose(x) ++ decompose(y);
-    case _ => List(et)
+  def decompose( et: ExpansionTree ): List[ExpansionTree] = et match {
+    case ETAnd( x, y ) => decompose( x ) ++ decompose( y );
+    case _             => List( et )
   }
 
-  def printStatistics(et : ExpansionSequent) = {
-    val indet = decompose((et.antecedent(3)))(2)
-    val List(ind1, ind2) : List[ExpansionTree] = indet match {
-      case WeakQuantifier(_, List(
-      (inst1, et1),
-      (inst2, et2)
-      ))
-      =>
-        List(inst1,inst2)
+  def printStatistics( et: ExpansionSequent ) = {
+    val indet = decompose( ( et.antecedent( 3 ) ) )( 2 )
+    val List( ind1, ind2 ): List[ExpansionTree] = indet match {
+      case WeakQuantifier( _, List(
+        ( inst1, et1 ),
+        ( inst2, et2 )
+        ) ) =>
+        List( inst1, inst2 )
     }
 
-    val (ind1base, ind1step) = ind1 match {
-      case ETImp(ETAnd(
-      WeakQuantifier(_, List((_,base))),
-      SkolemQuantifier(_,_,
-                      ETImp(_, WeakQuantifier(f, List((inst,step))))
-                      )
-      ) ,_ ) =>
-        (base, step)
+    val ( ind1base, ind1step ) = ind1 match {
+      case ETImp( ETAnd(
+        WeakQuantifier( _, List( ( _, base ) ) ),
+        SkolemQuantifier( _, _,
+          ETImp( _, WeakQuantifier( f, List( ( inst, step ) ) ) )
+          )
+        ), _ ) =>
+        ( base, step )
     }
 
-    val (ind2base,ind2step) = ind2 match {
-      case ETImp(ETAnd(
-        WeakQuantifier(_, List((_,base))),
-        SkolemQuantifier(_,_,
-               ETImp(_,WeakQuantifier(f, List((inst,step))))
-        )) ,_ ) =>
-        (base, step)
+    val ( ind2base, ind2step ) = ind2 match {
+      case ETImp( ETAnd(
+        WeakQuantifier( _, List( ( _, base ) ) ),
+        SkolemQuantifier( _, _,
+          ETImp( _, WeakQuantifier( f, List( ( inst, step ) ) ) )
+          ) ), _ ) =>
+        ( base, step )
     }
 
-    (ind1base, ind1step, ind2base, ind2step) match {
-      case (HOLAbs(xb,sb), HOLAbs(xs,ss), HOLAbs(yb,tb), HOLAbs(ys,ts)) =>
+    ( ind1base, ind1step, ind2base, ind2step ) match {
+      case ( HOLAbs( xb, sb ), HOLAbs( xs, ss ), HOLAbs( yb, tb ), HOLAbs( ys, ts ) ) =>
         val map = Map[HOLExpression, StringSymbol]()
-        val counter = new {private var state = 0; def nextId = { state = state +1; state}}
+        val counter = new { private var state = 0; def nextId = { state = state + 1; state } }
 
-        val (map1, sb1) = replaceAbstractions(sb, map, counter)
-        val (map2, ss1) = replaceAbstractions(ss, map1, counter)
-        val (map3, tb1) = replaceAbstractions(tb, map2, counter)
-        val (map4, ts1) = replaceAbstractions(ts, map3, counter)
+        val ( map1, sb1 ) = replaceAbstractions( sb, map, counter )
+        val ( map2, ss1 ) = replaceAbstractions( ss, map1, counter )
+        val ( map3, tb1 ) = replaceAbstractions( tb, map2, counter )
+        val ( map4, ts1 ) = replaceAbstractions( ts, map3, counter )
 
-        println("base 1 simplified: "+ f(HOLAbs(xb,sb1)))
-        println("base 2 simplified: "+ f(HOLAbs(yb,tb1)))
-        println("step 1 simplified: "+ f(HOLAbs(xs,ss1)))
-        println("step 2 simplified: "+ f(HOLAbs(ys,ts1)))
+        println( "base 1 simplified: " + f( HOLAbs( xb, sb1 ) ) )
+        println( "base 2 simplified: " + f( HOLAbs( yb, tb1 ) ) )
+        println( "step 1 simplified: " + f( HOLAbs( xs, ss1 ) ) )
+        println( "step 2 simplified: " + f( HOLAbs( ys, ts1 ) ) )
 
-        println("With shortcuts:")
-        for ((term, sym) <- map4) {
-          println("Symbol: "+sym)
-          println("Term:   "+f(term))
+        println( "With shortcuts:" )
+        for ( ( term, sym ) <- map4 ) {
+          println( "Symbol: " + sym )
+          println( "Term:   " + f( term ) )
         }
     }
 
@@ -139,53 +135,52 @@ class nTapeTest extends SpecificationWithJUnit with ClasspathFileCopier {
     "do cut-elimination on the 2 copies tape proof (tape3.llk)" in {
       //skipped("works but takes a bit time")
       checkForProverOrSkip
-      show("Loading file")
-      val tokens = HybridLatexParser.parseFile(tempCopyOfClasspathFile("tape3.llk"))
-      val pdb = HybridLatexParser.createLKProof(tokens)
-      show("Eliminating definitions, expanding tautological axioms")
-      val elp = AtomicExpansion(DefinitionElimination(pdb.Definitions, regularize(pdb.proof("TAPEPROOF"))))
-      show("Skolemizing")
-      val selp = LKtoLKskc(elp)
+      show( "Loading file" )
+      val tokens = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "tape3.llk" ) )
+      val pdb = HybridLatexParser.createLKProof( tokens )
+      show( "Eliminating definitions, expanding tautological axioms" )
+      val elp = AtomicExpansion( DefinitionElimination( pdb.Definitions, regularize( pdb.proof( "TAPEPROOF" ) ) ) )
+      show( "Skolemizing" )
+      val selp = LKtoLKskc( elp )
 
-      show("Extracting struct")
-      val struct = StructCreators.extract(selp, x => containsQuantifier(x) || freeHOVariables(x).nonEmpty)
-      show("Computing projections")
-      val proj = Projections(selp, x => containsQuantifier(x) || freeHOVariables(x).nonEmpty)
+      show( "Extracting struct" )
+      val struct = StructCreators.extract( selp, x => containsQuantifier( x ) || freeHOVariables( x ).nonEmpty )
+      show( "Computing projections" )
+      val proj = Projections( selp, x => containsQuantifier( x ) || freeHOVariables( x ).nonEmpty )
 
-      show("Computing clause set")
-      val cl = AlternativeStandardClauseSet(struct)
-      show("Exporting to prover 9")
-      val (cmap, folcl_) = replaceAbstractions(cl.toList)
-      println("Calculated cmap: ")
-      cmap.map(x => println(x._1+" := "+x._2))
+      show( "Computing clause set" )
+      val cl = AlternativeStandardClauseSet( struct )
+      show( "Exporting to prover 9" )
+      val ( cmap, folcl_ ) = replaceAbstractions( cl.toList )
+      println( "Calculated cmap: " )
+      cmap.map( x => println( x._1 + " := " + x._2 ) )
 
-      val folcl = reduceHolToFol(folcl_)
-      folcl.map(println(_))
+      val folcl = reduceHolToFol( folcl_ )
+      folcl.map( println( _ ) )
 
-      show("Refuting clause set")
-      Prover9.refute(folcl) match {
+      show( "Refuting clause set" )
+      Prover9.refute( folcl ) match {
         case None =>
-          ko("could not refute clause set")
-        case Some(rp) =>
-          show("Getting formulas")
-          val proofformulas = selp.nodes.flatMap(_.asInstanceOf[LKProof].root.toFSequent.formulas  ).toList.distinct
+          ko( "could not refute clause set" )
+        case Some( rp ) =>
+          show( "Getting formulas" )
+          val proofformulas = selp.nodes.flatMap( _.asInstanceOf[LKProof].root.toFSequent.formulas ).toList.distinct
 
-          show("Extracting signature from "+proofformulas.size+ " formulas")
-          val (sigc, sigv) = undoHol2Fol.getSignature( proofformulas )
+          show( "Extracting signature from " + proofformulas.size + " formulas" )
+          val ( sigc, sigv ) = undoHol2Fol.getSignature( proofformulas )
 
-          show("Converting to Ral")
+          show( "Converting to Ral" )
 
-          val myconverter = Robinson2RalAndUndoHOL2Fol(sigv.map(x => (x._1, x._2.toList)), sigc.map(x => (x._1, x._2.toList)), cmap)
-          val ralp = myconverter(rp)
-          show("Creating acnf")
-          val (acnf, endclause) = ceres_omega(proj, ralp, sequentToLabelledSequent(selp.root), struct)
+          val myconverter = Robinson2RalAndUndoHOL2Fol( sigv.map( x => ( x._1, x._2.toList ) ), sigc.map( x => ( x._1, x._2.toList ) ), cmap )
+          val ralp = myconverter( rp )
+          show( "Creating acnf" )
+          val ( acnf, endclause ) = ceres_omega( proj, ralp, sequentToLabelledSequent( selp.root ), struct )
 
-          show("Compute expansion tree")
-          val et = extractLKSKExpansionSequent(acnf, false)
-          show(" HOORAY! ")
+          show( "Compute expansion tree" )
+          val et = extractLKSKExpansionSequent( acnf, false )
+          show( " HOORAY! " )
 
-
-          printStatistics(et)
+          printStatistics( et )
 
           ok
       }
@@ -194,52 +189,52 @@ class nTapeTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
     "do cut-elimination on the 2 copies tape proof (tape3.llk)" in {
       checkForProverOrSkip
-      show("Loading file")
-      val tokens = HybridLatexParser.parseFile(tempCopyOfClasspathFile("tape3ex.llk"))
-      val pdb = HybridLatexParser.createLKProof(tokens)
-      show("Eliminating definitions, expanding tautological axioms")
-      val elp = AtomicExpansion(DefinitionElimination(pdb.Definitions, regularize(pdb.proof("TAPEPROOF"))))
-      show("Skolemizing")
-      val selp = LKtoLKskc(elp)
+      show( "Loading file" )
+      val tokens = HybridLatexParser.parseFile( tempCopyOfClasspathFile( "tape3ex.llk" ) )
+      val pdb = HybridLatexParser.createLKProof( tokens )
+      show( "Eliminating definitions, expanding tautological axioms" )
+      val elp = AtomicExpansion( DefinitionElimination( pdb.Definitions, regularize( pdb.proof( "TAPEPROOF" ) ) ) )
+      show( "Skolemizing" )
+      val selp = LKtoLKskc( elp )
 
-      show("Extracting struct")
-      val struct = StructCreators.extract(selp, x => containsQuantifier(x) || freeHOVariables(x).nonEmpty)
-      show("Computing projections")
-      val proj = Projections(selp, x => containsQuantifier(x) || freeHOVariables(x).nonEmpty)
+      show( "Extracting struct" )
+      val struct = StructCreators.extract( selp, x => containsQuantifier( x ) || freeHOVariables( x ).nonEmpty )
+      show( "Computing projections" )
+      val proj = Projections( selp, x => containsQuantifier( x ) || freeHOVariables( x ).nonEmpty )
 
-      show("Computing clause set")
-      val cl = AlternativeStandardClauseSet(struct)
-      show("Exporting to prover 9")
-      val (cmap, folcl_) = replaceAbstractions(cl.toList)
-      println("Calculated cmap: ")
-      cmap.map(x => println(x._1+" := "+x._2))
+      show( "Computing clause set" )
+      val cl = AlternativeStandardClauseSet( struct )
+      show( "Exporting to prover 9" )
+      val ( cmap, folcl_ ) = replaceAbstractions( cl.toList )
+      println( "Calculated cmap: " )
+      cmap.map( x => println( x._1 + " := " + x._2 ) )
 
-      val folcl = reduceHolToFol(folcl_)
-      folcl.map(println(_))
+      val folcl = reduceHolToFol( folcl_ )
+      folcl.map( println( _ ) )
 
-      show("Refuting clause set")
-      Prover9.refute(folcl) match {
+      show( "Refuting clause set" )
+      Prover9.refute( folcl ) match {
         case None =>
-          ko("could not refute clause set")
-        case Some(rp) =>
-          show("Getting formulas")
-          val proofformulas = selp.nodes.flatMap(_.asInstanceOf[LKProof].root.toFSequent.formulas  ).toList.distinct
+          ko( "could not refute clause set" )
+        case Some( rp ) =>
+          show( "Getting formulas" )
+          val proofformulas = selp.nodes.flatMap( _.asInstanceOf[LKProof].root.toFSequent.formulas ).toList.distinct
 
-          show("Extracting signature from "+proofformulas.size+ " formulas")
-          val (sigc, sigv) = undoHol2Fol.getSignature( proofformulas )
+          show( "Extracting signature from " + proofformulas.size + " formulas" )
+          val ( sigc, sigv ) = undoHol2Fol.getSignature( proofformulas )
 
-          show("Converting to Ral")
+          show( "Converting to Ral" )
 
-          val myconverter = Robinson2RalAndUndoHOL2Fol(sigv.map(x => (x._1, x._2.toList)), sigc.map(x => (x._1, x._2.toList)), cmap)
-          val ralp = myconverter(rp)
-          show("Creating acnf")
-          val (acnf, endclause) = ceres_omega(proj, ralp, sequentToLabelledSequent(selp.root), struct)
+          val myconverter = Robinson2RalAndUndoHOL2Fol( sigv.map( x => ( x._1, x._2.toList ) ), sigc.map( x => ( x._1, x._2.toList ) ), cmap )
+          val ralp = myconverter( rp )
+          show( "Creating acnf" )
+          val ( acnf, endclause ) = ceres_omega( proj, ralp, sequentToLabelledSequent( selp.root ), struct )
 
-          show("Compute expansion tree")
-          val et = extractLKSKExpansionSequent(acnf, false)
-          show(" HOORAY! ")
+          show( "Compute expansion tree" )
+          val et = extractLKSKExpansionSequent( acnf, false )
+          show( " HOORAY! " )
 
-          printStatistics(et)
+          printStatistics( et )
 
           ok
       }

--- a/src/test/scala/at/logic/language/fol/FirstOrderLogicTest.scala
+++ b/src/test/scala/at/logic/language/fol/FirstOrderLogicTest.scala
@@ -10,228 +10,227 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.lambda.types._
 import at.logic.language.hol
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class FirstOrderLogicTest extends SpecificationWithJUnit {
   "FirstOrderLogic" should {
     "construct correctly an atom formula P(x,f(y),c)" in {
-      val List( p, x,y,f,c ) = List("P","x","y","f","c")
-      val Pc = FOLLambdaConst(p, (Ti -> (Ti -> (Ti -> To))) )
-      Atom( p, FOLVar(x)::Function(f,FOLVar(y)::Nil)::FOLConst(c)::Nil ) must beLike {
-        case FOLApp( FOLApp( FOLApp( Pc, FOLVar(x) ), FOLApp( fc, FOLVar(y) ) ), FOLConst(c) ) => ok
+      val List( p, x, y, f, c ) = List( "P", "x", "y", "f", "c" )
+      val Pc = FOLLambdaConst( p, ( Ti -> ( Ti -> ( Ti -> To ) ) ) )
+      Atom( p, FOLVar( x ) :: Function( f, FOLVar( y ) :: Nil ) :: FOLConst( c ) :: Nil ) must beLike {
+        case FOLApp( FOLApp( FOLApp( Pc, FOLVar( x ) ), FOLApp( fc, FOLVar( y ) ) ), FOLConst( c ) ) => ok
       }
     }
     "construct correctly an atom using the factory" in {
-      val var1 = FOLVar("x1")
-      val const1 = FOLConst("c1")
-      val var2 = FOLVar("x2")
-      val args = var1::var2::const1::Nil
-      val atom1 = Atom("A", args)
-      val var3 = Atom("X3")
-      val and1 = And(atom1, var3)
+      val var1 = FOLVar( "x1" )
+      val const1 = FOLConst( "c1" )
+      val var2 = FOLVar( "x2" )
+      val args = var1 :: var2 :: const1 :: Nil
+      val atom1 = Atom( "A", args )
+      val var3 = Atom( "X3" )
+      val and1 = And( atom1, var3 )
       true
     }
     "construct correctly a forall using the factory" in {
-      val var1 = FOLVar("x1")
-      val const1 = FOLConst("c1")
-      val var2 = FOLVar("x2")
-      val args = var1::var2::const1::Nil
-      val atom1 = Atom("A",args)
-      val all1 = AllVar(var1, atom1)
+      val var1 = FOLVar( "x1" )
+      val const1 = FOLConst( "c1" )
+      val var2 = FOLVar( "x2" )
+      val args = var1 :: var2 :: const1 :: Nil
+      val atom1 = Atom( "A", args )
+      val all1 = AllVar( var1, atom1 )
       true
     }
 
     "alpha equality as default provides that ∀x.∀x.P(x) is equal to ∀y.∀y.P(y)" in {
-      val x = FOLVar("x")
-      val y = FOLVar("y")
+      val x = FOLVar( "x" )
+      val y = FOLVar( "y" )
       val p = "P"
-      val px = Atom(p,List(x))
-      val py = Atom(p,List(y))
-      val allall_px = AllVar(x, AllVar(x, px))
-      val allall_py = AllVar(y, AllVar(y, py))
+      val px = Atom( p, List( x ) )
+      val py = Atom( p, List( y ) )
+      val allall_px = AllVar( x, AllVar( x, px ) )
+      val allall_py = AllVar( y, AllVar( y, py ) )
 
-      allall_px must beEqualTo (allall_py)
+      allall_px must beEqualTo( allall_py )
     }
   }
 
   "First Order Formula matching" should {
     "not allow P and P match as an Atom " in {
       val ps = "P"
-      val f = And(Atom(ps), Atom(ps))
+      val f = And( Atom( ps ), Atom( ps ) )
 
       f must beLike {
-        case Atom(_,_) => ko
-        case AllVar(_,_) => ko
-        case ExVar(_,_) => ko
-        case Or(_,_) => ko
-        case Imp(_,_) => ko
-        case And(_,_) => ok
-        case _ => ko
+        case Atom( _, _ )   => ko
+        case AllVar( _, _ ) => ko
+        case ExVar( _, _ )  => ko
+        case Or( _, _ )     => ko
+        case Imp( _, _ )    => ko
+        case And( _, _ )    => ok
+        case _              => ko
       }
     }
     "match Equation with Atom" in {
-      val a = FOLConst("a").asInstanceOf[FOLTerm]
-      val b = FOLConst("b").asInstanceOf[FOLTerm]
-      val eq = Equation(a, b)
+      val a = FOLConst( "a" ).asInstanceOf[FOLTerm]
+      val b = FOLConst( "b" ).asInstanceOf[FOLTerm]
+      val eq = Equation( a, b )
 
       eq must beLike {
-        case Atom(_,_) => ok
-        case _ => ko
+        case Atom( _, _ ) => ok
+        case _            => ko
       }
     }
   }
 
   "First order formulas matching against higher order contructors" should {
     "work for propositional logical operators" in {
-      val List(x,y) = List("x","y") map (FOLVar(_))
+      val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )
       val p = "P"
-      val pab = Atom(p, List(x,y))
+      val pab = Atom( p, List( x, y ) )
 
-      And(pab,pab) match {
-        case hol.And(a,b) =>
-          a mustEqual(pab)
-          b mustEqual(pab)
-        case _ => ko("FOL Conjunction did not match against HOL Conjunction!")
+      And( pab, pab ) match {
+        case hol.And( a, b ) =>
+          a mustEqual ( pab )
+          b mustEqual ( pab )
+        case _ => ko( "FOL Conjunction did not match against HOL Conjunction!" )
       }
 
-      Or(pab,pab) match {
-        case hol.Or(a,b) =>
-          a mustEqual(pab)
-          b mustEqual(pab)
-        case _ => ko("FOL Disjunction did not match against HOL Conjunction!")
+      Or( pab, pab ) match {
+        case hol.Or( a, b ) =>
+          a mustEqual ( pab )
+          b mustEqual ( pab )
+        case _ => ko( "FOL Disjunction did not match against HOL Conjunction!" )
       }
 
-      Neg(pab) match {
-        case hol.Neg(a) =>
-          a mustEqual(pab)
-        case _ => ko("FOL Negation did not match against HOL Conjunction!")
+      Neg( pab ) match {
+        case hol.Neg( a ) =>
+          a mustEqual ( pab )
+        case _ => ko( "FOL Negation did not match against HOL Conjunction!" )
       }
     }
 
     "work for quantifiers" in {
-      val List(a,b) = List("a","b") map (FOLConst(_))
-      val List(x,y) = List("x","y") map (FOLVar(_))
+      val List( a, b ) = List( "a", "b" ) map ( FOLConst( _ ) )
+      val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )
       val p = "P"
-      val pab = Atom(p, List(a,b))
+      val pab = Atom( p, List( a, b ) )
 
-      AllVar(x,pab) match {
-        case hol.AllVar(v,f) =>
-          v mustEqual(x)
-          f mustEqual(pab)
-        case _ => ko("FOL AllVar did not match against HOL Conjunction!")
+      AllVar( x, pab ) match {
+        case hol.AllVar( v, f ) =>
+          v mustEqual ( x )
+          f mustEqual ( pab )
+        case _ => ko( "FOL AllVar did not match against HOL Conjunction!" )
       }
 
-      ExVar(x,pab) match {
-        case hol.ExVar(v,f) =>
-          v mustEqual(x)
-          f mustEqual(pab)
-        case _ => ko("FOL ExVar did not match against HOL Conjunction!")
+      ExVar( x, pab ) match {
+        case hol.ExVar( v, f ) =>
+          v mustEqual ( x )
+          f mustEqual ( pab )
+        case _ => ko( "FOL ExVar did not match against HOL Conjunction!" )
       }
     }
 
     "work well together with the hol layer" in {
-      val a1 = Atom("P",List(FOLConst("a")))
-      val a2 = Atom("Q",List(FOLVar("x")))
-      val neg = hol.Neg(a1)
-      val conj = hol.And(a1,a2)
-      val or = hol.Or(a1,a2)
-      val imp = hol.Imp(a1,a2)
-      val (t1,t2) = (FOLConst("a"), FOLVar("x"))
-      val eq = hol.Equation(t1,t2)
-      val all = hol.AllVar(t2, a2)
-      val ex = hol.ExVar(t2, a2)
+      val a1 = Atom( "P", List( FOLConst( "a" ) ) )
+      val a2 = Atom( "Q", List( FOLVar( "x" ) ) )
+      val neg = hol.Neg( a1 )
+      val conj = hol.And( a1, a2 )
+      val or = hol.Or( a1, a2 )
+      val imp = hol.Imp( a1, a2 )
+      val ( t1, t2 ) = ( FOLConst( "a" ), FOLVar( "x" ) )
+      val eq = hol.Equation( t1, t2 )
+      val all = hol.AllVar( t2, a2 )
+      val ex = hol.ExVar( t2, a2 )
       neg match {
-        case Neg(b1) =>
+        case Neg( b1 ) =>
           a1 must_== b1
-        case _ => ko("HOL created negation did not match against fol conjunction!")
+        case _ => ko( "HOL created negation did not match against fol conjunction!" )
       }
       conj match {
-        case And(b1,b2) =>
+        case And( b1, b2 ) =>
           a1 must_== b1
           a2 must_== b2
-        case _ => ko("HOL created conjunction did not match against fol conjunction!")
+        case _ => ko( "HOL created conjunction did not match against fol conjunction!" )
       }
       or match {
-        case Or(b1,b2) =>
+        case Or( b1, b2 ) =>
           a1 must_== b1
           a2 must_== b2
-        case _ => ko("HOL created disjunction did not match against fol conjunction!")
+        case _ => ko( "HOL created disjunction did not match against fol conjunction!" )
       }
       imp match {
-        case Imp(b1,b2) =>
+        case Imp( b1, b2 ) =>
           a1 must_== b1
           a2 must_== b2
-        case _ => ko("HOL created implication did not match against fol conjunction!")
+        case _ => ko( "HOL created implication did not match against fol conjunction!" )
       }
       eq match {
-        case Equation(b1,b2) =>
+        case Equation( b1, b2 ) =>
           t1 must_== b1
           t2 must_== b2
-        case _ => ko("HOL created equation did not match against fol conjunction!")
+        case _ => ko( "HOL created equation did not match against fol conjunction!" )
       }
       all match {
-        case AllVar(b1,b2) =>
+        case AllVar( b1, b2 ) =>
           t2 must_== b1
           a2 must_== b2
-        case _ => ko("HOL created universal quantification did not match against fol conjunction!")
+        case _ => ko( "HOL created universal quantification did not match against fol conjunction!" )
       }
       ex match {
-        case ExVar(b1,b2) =>
+        case ExVar( b1, b2 ) =>
           t2 must_== b1
           a2 must_== b2
-        case _ => ko("HOL created existential quantification did not match against fol conjunction!")
+        case _ => ko( "HOL created existential quantification did not match against fol conjunction!" )
       }
 
     }
 
     "work well together with the hol layer" in {
-      val a1 = Atom("P",List(FOLConst("a")))
-      val a2 = Atom("Q",List(FOLVar("x")))
-      val neg = Neg(a1)
-      val conj = And(a1,a2)
-      val or = Or(a1,a2)
-      val imp = Imp(a1,a2)
-      val (t1,t2) = (FOLConst("a"), FOLVar("x"))
-      val eq = Equation(t1,t2)
-      val all = AllVar(t2, a2)
-      val ex = ExVar(t2, a2)
+      val a1 = Atom( "P", List( FOLConst( "a" ) ) )
+      val a2 = Atom( "Q", List( FOLVar( "x" ) ) )
+      val neg = Neg( a1 )
+      val conj = And( a1, a2 )
+      val or = Or( a1, a2 )
+      val imp = Imp( a1, a2 )
+      val ( t1, t2 ) = ( FOLConst( "a" ), FOLVar( "x" ) )
+      val eq = Equation( t1, t2 )
+      val all = AllVar( t2, a2 )
+      val ex = ExVar( t2, a2 )
       neg match {
-        case hol.Neg(b1) =>
+        case hol.Neg( b1 ) =>
           ok
-        case _ => ko("HOL created negation did not match against fol conjunction!")
+        case _ => ko( "HOL created negation did not match against fol conjunction!" )
       }
       conj match {
-        case hol.And(b1,b2) =>
+        case hol.And( b1, b2 ) =>
           ok
-        case _ => ko("HOL created conjunction did not match against fol conjunction!")
+        case _ => ko( "HOL created conjunction did not match against fol conjunction!" )
       }
       or match {
-        case hol.Or(b1,b2) =>
+        case hol.Or( b1, b2 ) =>
           ok
-        case _ => ko("HOL created disjunction did not match against fol conjunction!")
+        case _ => ko( "HOL created disjunction did not match against fol conjunction!" )
       }
       imp match {
-        case hol.Imp(b1,b2) =>
+        case hol.Imp( b1, b2 ) =>
           ok
-        case _ => ko("HOL created implication did not match against fol conjunction!")
+        case _ => ko( "HOL created implication did not match against fol conjunction!" )
       }
       eq match {
-        case hol.Equation(b1,b2) =>
+        case hol.Equation( b1, b2 ) =>
           ok
-        case _ => ko("HOL created equation did not match against fol conjunction!")
+        case _ => ko( "HOL created equation did not match against fol conjunction!" )
       }
       all match {
-        case hol.AllVar(b1,b2) =>
+        case hol.AllVar( b1, b2 ) =>
           ok
-        case _ => ko("HOL created universal quantification did not match against fol conjunction!")
+        case _ => ko( "HOL created universal quantification did not match against fol conjunction!" )
       }
       ex match {
-        case hol.ExVar(b1,b2) =>
+        case hol.ExVar( b1, b2 ) =>
           ok
-        case _ => ko("HOL created existential quantification did not match against fol conjunction!")
+        case _ => ko( "HOL created existential quantification did not match against fol conjunction!" )
       }
       ok
     }
-
 
   }
 

--- a/src/test/scala/at/logic/language/hoare/UtilsTest.scala
+++ b/src/test/scala/at/logic/language/hoare/UtilsTest.scala
@@ -6,55 +6,55 @@ import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import ProgramParser._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class UtilsTest extends SpecificationWithJUnit {
   "LoopFree" should {
     "match loop-free programs" in {
-      LoopFree.unapply(parseProgram("skip")) must beSome
-      LoopFree.unapply(parseProgram("if P() then skip else skip fi")) must beSome
-      LoopFree.unapply(parseProgram("x := a; skip")) must beSome
+      LoopFree.unapply( parseProgram( "skip" ) ) must beSome
+      LoopFree.unapply( parseProgram( "if P() then skip else skip fi" ) ) must beSome
+      LoopFree.unapply( parseProgram( "x := a; skip" ) ) must beSome
     }
 
     "not match for loops" in {
-      LoopFree.unapply(parseProgram("for x < y do skip od")) must beNone
+      LoopFree.unapply( parseProgram( "for x < y do skip od" ) ) must beNone
     }
 
     "not match for loops, even if nested" in {
-      LoopFree.unapply(parseProgram("if P() then for x < y do skip od else skip fi")) must beNone
-      LoopFree.unapply(parseProgram("for x < y do skip od; skip")) must beNone
+      LoopFree.unapply( parseProgram( "if P() then for x < y do skip od else skip fi" ) ) must beNone
+      LoopFree.unapply( parseProgram( "for x < y do skip od; skip" ) ) must beNone
     }
   }
 
   "mapVariableNames" should {
     "rename lhs of assignments" in {
-      mapVariableNames(parseProgram("x := a"), { _ + "_1" }) must beEqualTo(parseProgram("x_1 := a"))
+      mapVariableNames( parseProgram( "x := a" ), { _ + "_1" } ) must beEqualTo( parseProgram( "x_1 := a" ) )
     }
 
     "rename inside expressions" in {
-      mapVariableNames(parseProgram("if P(x,y) then x := f(y) else y := g(x) fi"), { _ + "_1"}) must
-        beEqualTo(parseProgram("if P(x_1,y_1) then x_1 := f(y_1) else y_1 := g(x_1) fi"))
+      mapVariableNames( parseProgram( "if P(x,y) then x := f(y) else y := g(x) fi" ), { _ + "_1" } ) must
+        beEqualTo( parseProgram( "if P(x_1,y_1) then x_1 := f(y_1) else y_1 := g(x_1) fi" ) )
     }
   }
 
   "weakestPrecondition" should {
     "handle ifs" in {
-      weakestPrecondition(parseProgram("if P(x) then x := f(y) else x := f(z) fi"), parseFormula("R(x)")) must
-        beEqualTo(parseFormula("(P(x) -> R(f(y))) & (-P(x) -> R(f(z)))"))
+      weakestPrecondition( parseProgram( "if P(x) then x := f(y) else x := f(z) fi" ), parseFormula( "R(x)" ) ) must
+        beEqualTo( parseFormula( "(P(x) -> R(f(y))) & (-P(x) -> R(f(z)))" ) )
     }
   }
 
   "unrollLoop" should {
     "be loop-free" in {
-      unrollLoop(parseProgram("for y < z do x := x + y od"), 4) must beLike {
-        case LoopFree(_) => ok
-        case _ => ko
+      unrollLoop( parseProgram( "for y < z do x := x + y od" ), 4 ) must beLike {
+        case LoopFree( _ ) => ok
+        case _             => ko
       }
     }
   }
 
   "blocks" should {
     "split sequences" in {
-      Blocks.unapply(parseProgram("x := x; x:= x; x := x")) must beEqualTo(List.fill(3)(parseProgram("x := x")))
+      Blocks.unapply( parseProgram( "x := x; x:= x; x := x" ) ) must beEqualTo( List.fill( 3 )( parseProgram( "x := x" ) ) )
     }
   }
 }

--- a/src/test/scala/at/logic/language/hol/HOLPositionTest.scala
+++ b/src/test/scala/at/logic/language/hol/HOLPositionTest.scala
@@ -8,20 +8,20 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class HOLPositionTest extends SpecificationWithJUnit {
   "HOLPositions" should {
     "be computed correctly" in {
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val f = HOLConst("f", Ti -> Ti)
-      val c = HOLConst("c", Ti)
-      val P = HOLConst("P", Ti -> To)
-      val Px = Atom(P, List(x))
-      val Pfc = Atom(P, List(HOLApp(f, c)))
+      val x = HOLVar( "x", Ti )
+      val y = HOLVar( "y", Ti )
+      val f = HOLConst( "f", Ti -> Ti )
+      val c = HOLConst( "c", Ti )
+      val P = HOLConst( "P", Ti -> To )
+      val Px = Atom( P, List( x ) )
+      val Pfc = Atom( P, List( HOLApp( f, c ) ) )
 
-      getPositions(Px) must beEqualTo(List(HOLPosition(Nil), HOLPosition(1), HOLPosition(2)))
-      replace(Px, HOLPosition(2), HOLApp(f,c)) must beEqualTo(Pfc)
+      getPositions( Px ) must beEqualTo( List( HOLPosition( Nil ), HOLPosition( 1 ), HOLPosition( 2 ) ) )
+      replace( Px, HOLPosition( 2 ), HOLApp( f, c ) ) must beEqualTo( Pfc )
     }
   }
 }

--- a/src/test/scala/at/logic/language/hol/HigherOrderLogicTest.scala
+++ b/src/test/scala/at/logic/language/hol/HigherOrderLogicTest.scala
@@ -14,98 +14,98 @@ import logicSymbols._
 import skolemSymbols._
 import at.logic.language.hol.BetaReduction._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class HigherOrderLogicTest extends SpecificationWithJUnit {
 
   "HigherOrderLogic" should {
-    val c1 = HOLConst("a", Ti->To)
-    val v1 = HOLVar("x", Ti)
-    val a1 = HOLApp(c1, v1)
-    val c2 = HOLVar("a", Ti->(Ti->To))
-    val v21 = HOLVar("x", Ti)
-    val v22 = HOLVar("y", Ti)
-    val a21 = HOLApp(c2, v21)
-    val a22 = HOLApp(a21, v22)
+    val c1 = HOLConst( "a", Ti -> To )
+    val v1 = HOLVar( "x", Ti )
+    val a1 = HOLApp( c1, v1 )
+    val c2 = HOLVar( "a", Ti -> ( Ti -> To ) )
+    val v21 = HOLVar( "x", Ti )
+    val v22 = HOLVar( "y", Ti )
+    val a21 = HOLApp( c2, v21 )
+    val a22 = HOLApp( a21, v22 )
 
     "mix correctly the formula trait (1)" in {
       val result = a1 match {
         case x: HOLFormula => true
-        case _ => false
+        case _             => false
       }
       result must beTrue
     }
     "mix correctly the formula trait (2)" in {
       val result = a22 match {
         case x: HOLFormula => true
-        case _ => false
+        case _             => false
       }
       result must beTrue
     }
     "mix correctly the formula trait (3)" in {
-      val at1 = Atom(HOLVar("P", ->(c2.exptype, ->(a22.exptype, To))), c2::a22::Nil)
+      val at1 = Atom( HOLVar( "P", ->( c2.exptype, ->( a22.exptype, To ) ) ), c2 :: a22 :: Nil )
       // Another way to construct P's type is: FunctionType(To, args.map(a => a.exptype) )
       val result = at1 match {
         case x: HOLFormula => true
-        case _ => false
+        case _             => false
       }
       result must beTrue
     }
     "And connective should return the right And formula" in {
-      val c1 = Atom(HOLConst("a", To))
-      val c2 = Atom(HOLConst("b", To))
-      val result = And(c1, c2) match {
-        case HOLApp(HOLApp(andC, c1), c2) => true
-        case _ => false
+      val c1 = Atom( HOLConst( "a", To ) )
+      val c2 = Atom( HOLConst( "b", To ) )
+      val result = And( c1, c2 ) match {
+        case HOLApp( HOLApp( andC, c1 ), c2 ) => true
+        case _                                => false
       }
       result must beTrue
-      }
+    }
     "Or connective should return the right formula" in {
-      val c1 = Atom(HOLConst("a", To))
-      val c2 = Atom(HOLConst("b", To))
-      val result = Or(c1, c2) match {
-        case HOLApp(HOLApp(orC, c1), c2) => true
-        case _ => false
+      val c1 = Atom( HOLConst( "a", To ) )
+      val c2 = Atom( HOLConst( "b", To ) )
+      val result = Or( c1, c2 ) match {
+        case HOLApp( HOLApp( orC, c1 ), c2 ) => true
+        case _                               => false
       }
       result must beTrue
     }
     "Imp connective should return the right formula" in {
-      val c1 = Atom(HOLVar("a", To))
-      val c2 = Atom(HOLVar("b", To))
-      val result = Imp(c1, c2) match {
-        case HOLApp(HOLApp(impC, c1), c2) => true
-        case _ => false
+      val c1 = Atom( HOLVar( "a", To ) )
+      val c2 = Atom( HOLVar( "b", To ) )
+      val result = Imp( c1, c2 ) match {
+        case HOLApp( HOLApp( impC, c1 ), c2 ) => true
+        case _                                => false
       }
       result must beTrue
     }
     "Neg connective should " in {
       "return the right formula" in {
-        val c1 = Atom(HOLVar("a", To))
-        val result = Neg(c1) match {
-          case HOLApp(negC, c1) => true
-          case _ => false
+        val c1 = Atom( HOLVar( "a", To ) )
+        val result = Neg( c1 ) match {
+          case HOLApp( negC, c1 ) => true
+          case _                  => false
         }
         result must beTrue
       }
       "be extracted correctly" in {
-        val e = HOLApp(HOLConst("g","(i -> i)"), HOLConst("c", "i")::Nil)
+        val e = HOLApp( HOLConst( "g", "(i -> i)" ), HOLConst( "c", "i" ) :: Nil )
         val result = e match {
-          case Neg(_) => false
-          case _ => true
+          case Neg( _ ) => false
+          case _        => true
         }
         result must beTrue
       }
     }
 
     "substitute and normalize correctly when Substitution is applied" in {
-      val x = HOLVar("X", Ti -> To )
-      val f = HOLVar("f", (Ti -> To) -> Ti )
-      val xfx = HOLApp(x, HOLApp( f, x ) )
+      val x = HOLVar( "X", Ti -> To )
+      val f = HOLVar( "f", ( Ti -> To ) -> Ti )
+      val xfx = HOLApp( x, HOLApp( f, x ) )
 
-      val z = HOLVar("z", Ti)
-      val p = HOLVar("P", Ti -> To)
+      val z = HOLVar( "z", Ti )
+      val p = HOLVar( "P", Ti -> To )
       val Pz = HOLApp( p, z )
       val t = HOLAbs( z, Pz )
-      val pft = HOLApp( p, HOLApp( f, t ))
+      val pft = HOLApp( p, HOLApp( f, t ) )
 
       val sigma = Substitution( x, t )
 
@@ -113,15 +113,15 @@ class HigherOrderLogicTest extends SpecificationWithJUnit {
     }
 
     "substitute and normalize correctly when Substitution is applied on the formula level" in {
-      val x = HOLVar("X", Ti -> To )
-      val f = HOLVar("f", (Ti -> To) -> Ti )
-      val xfx = Atom(x, Function( f, x::Nil )::Nil )
+      val x = HOLVar( "X", Ti -> To )
+      val f = HOLVar( "f", ( Ti -> To ) -> Ti )
+      val xfx = Atom( x, Function( f, x :: Nil ) :: Nil )
 
-      val z = HOLVar("z", Ti)
-      val p = HOLVar("P", Ti -> To)
+      val z = HOLVar( "z", Ti )
+      val p = HOLVar( "P", Ti -> To )
       val Pz = HOLApp( p, z )
       val t = HOLAbs( z, Pz )
-      val pft = Atom( p, Function( f, t::Nil )::Nil )
+      val pft = Atom( p, Function( f, t :: Nil ) :: Nil )
 
       val sigma = Substitution( x, t )
       val xfx_sigma = betaNormalize( sigma( xfx ) )
@@ -131,65 +131,65 @@ class HigherOrderLogicTest extends SpecificationWithJUnit {
   }
 
   "Exists quantifier" should {
-    val c1 = HOLConst("a", Ti->To)
-    val v1 = HOLVar("x", Ti)
-    val f1 = Atom(c1,v1::Nil)
+    val c1 = HOLConst( "a", Ti -> To )
+    val v1 = HOLVar( "x", Ti )
+    val f1 = Atom( c1, v1 :: Nil )
     "create a term of the right type" in {
-      (ExVar(v1, f1).exptype) must beEqualTo (To)
+      ( ExVar( v1, f1 ).exptype ) must beEqualTo( To )
     }
   }
 
   "Forall quantifier" should {
-    val c1 = HOLConst("a", Ti->To)
-    val v1 = HOLVar("x", Ti)
-    val f1 = Atom(c1,v1::Nil)
+    val c1 = HOLConst( "a", Ti -> To )
+    val v1 = HOLVar( "x", Ti )
+    val f1 = Atom( c1, v1 :: Nil )
     "create a term of the right type" in {
-      (AllVar(v1, f1).exptype) must beEqualTo (To)
+      ( AllVar( v1, f1 ).exptype ) must beEqualTo( To )
     }
   }
 
   "Atoms" should {
     "be extracted correctly" in {
-      val p = HOLConst("P", To)
+      val p = HOLConst( "P", To )
       val result = p match {
-        case Atom(HOLConst("P", To), Nil) => true
-        case _ => false
+        case Atom( HOLConst( "P", To ), Nil ) => true
+        case _                                => false
       }
       result must beTrue
     }
   }
-  
+
   "Equation" should {
     "be of the right type" in {
-      val c1 = HOLConst("f1", Ti -> Ti)
-      val c2 = HOLConst("f2", Ti -> Ti)
-      val eq = Equation(c1,c2)
-      val HOLApp(HOLApp(t,_), _) = eq
-      t.exptype must beEqualTo ((Ti -> Ti) -> ((Ti -> Ti) -> To))
+      val c1 = HOLConst( "f1", Ti -> Ti )
+      val c2 = HOLConst( "f2", Ti -> Ti )
+      val eq = Equation( c1, c2 )
+      val HOLApp( HOLApp( t, _ ), _ ) = eq
+      t.exptype must beEqualTo( ( Ti -> Ti ) -> ( ( Ti -> Ti ) -> To ) )
     }
   }
 
   "Substitution" should {
     "work correctly on some testcase involving free/bound vars" in {
-      val s0 = HOLConst("s_{0}", Ti -> Ti)
-      val C = HOLConst("C", Ti -> Ti)
-      val T = HOLConst("T", Ti -> Ti)
-      val sCTn = Function(s0, Function( C, Function( T, HOLConst("n", Ti)::Nil)::Nil)::Nil )
-      val u = HOLVar("u", Ti)
-      val v = HOLVar("v", Ti)
-      val P1 = Atom( HOLVar("P", ->(sCTn.exptype, ->(Ti, To))), sCTn::u::Nil)
-      val P2 = Atom( HOLVar("P", ->(sCTn.exptype, ->(Ti, To))), sCTn::v::Nil)
-      val q_form = AllVar(u, ExVar(v, Imp(P1, P2)))
-      
+      val s0 = HOLConst( "s_{0}", Ti -> Ti )
+      val C = HOLConst( "C", Ti -> Ti )
+      val T = HOLConst( "T", Ti -> Ti )
+      val sCTn = Function( s0, Function( C, Function( T, HOLConst( "n", Ti ) :: Nil ) :: Nil ) :: Nil )
+      val u = HOLVar( "u", Ti )
+      val v = HOLVar( "v", Ti )
+      val P1 = Atom( HOLVar( "P", ->( sCTn.exptype, ->( Ti, To ) ) ), sCTn :: u :: Nil )
+      val P2 = Atom( HOLVar( "P", ->( sCTn.exptype, ->( Ti, To ) ) ), sCTn :: v :: Nil )
+      val q_form = AllVar( u, ExVar( v, Imp( P1, P2 ) ) )
+
       q_form match {
-        case AllVar(x, f) => {
-          val a = HOLConst("a", x.exptype)
+        case AllVar( x, f ) => {
+          val a = HOLConst( "a", x.exptype )
           val sub = Substitution( x, a )
-          val P3 = Atom(HOLVar("P", ->(sCTn.exptype, ->(a.exptype, To))), sCTn::a::Nil)
+          val P3 = Atom( HOLVar( "P", ->( sCTn.exptype, ->( a.exptype, To ) ) ), sCTn :: a :: Nil )
           val s = sub( f )
           val result = s match {
-            case ExVar(v, Imp(P3, P2)) => true
-            case _ => false
+            case ExVar( v, Imp( P3, P2 ) ) => true
+            case _                         => false
           }
           result must beTrue
         }
@@ -198,16 +198,16 @@ class HigherOrderLogicTest extends SpecificationWithJUnit {
   }
 
   "SkolemSymbolFactory" should {
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val f = AllVar( x, Atom(HOLVar("P", ->(Ti, To)), x::Nil ) )
-      val s0 = new StringSymbol( "s_{0}" )
-      val s1 = new StringSymbol( "s_{2}" )
-      val s2 = new StringSymbol( "s_{4}" )
-      val s3 = new StringSymbol( "s_{6}" )
+    val x = HOLVar( "x", Ti )
+    val y = HOLVar( "y", Ti )
+    val f = AllVar( x, Atom( HOLVar( "P", ->( Ti, To ) ), x :: Nil ) )
+    val s0 = new StringSymbol( "s_{0}" )
+    val s1 = new StringSymbol( "s_{2}" )
+    val s2 = new StringSymbol( "s_{4}" )
+    val s3 = new StringSymbol( "s_{6}" )
 
-      SkolemSymbolFactory.reset
-      val stream = SkolemSymbolFactory.getSkolemSymbols
+    SkolemSymbolFactory.reset
+    val stream = SkolemSymbolFactory.getSkolemSymbols
 
     "return a correct stream of Skolem symbols" in {
       stream.head must beEqualTo( s0 )
@@ -218,52 +218,53 @@ class HigherOrderLogicTest extends SpecificationWithJUnit {
 
   "Higher Order Formula matching" should {
     "not allow P and P match as an Atom " in {
-      val f = And(Atom(HOLVar("P", To),Nil), Atom(HOLVar("P", To),Nil))
+      val f = And( Atom( HOLVar( "P", To ), Nil ), Atom( HOLVar( "P", To ), Nil ) )
 
       f must beLike {
-        case Atom(_,_) => println("Is an atom"); ko
-        case Function(_,_,_) => ko
-        case AllVar(_,_) => ko
-        case ExVar(_,_) => ko
-        case Or(_,_) => ko
-        case Imp(_,_) => ko
-        case And(_,_) => ok
-        case _ => ko
+        case Atom( _, _ )        =>
+          println( "Is an atom" ); ko
+        case Function( _, _, _ ) => ko
+        case AllVar( _, _ )      => ko
+        case ExVar( _, _ )       => ko
+        case Or( _, _ )          => ko
+        case Imp( _, _ )         => ko
+        case And( _, _ )         => ok
+        case _                   => ko
       }
     }
   }
 
   "Quantifier blocks" should {
-    val x = HOLVar("x", Ti)
-    val y = HOLVar("y", Ti)
-    val z = HOLVar("z", Ti)
+    val x = HOLVar( "x", Ti )
+    val y = HOLVar( "y", Ti )
+    val z = HOLVar( "z", Ti )
 
-    val Pxyz = Atom(HOLConst("P", ->(Ti,->(Ti,(->(Ti,To))))), List(x,y,z))
-    val allP = AllVar(x, AllVar(y, AllVar(z, Pxyz)))
-    val exP = ExVar(x, ExVar(y, ExVar(z, Pxyz)))
+    val Pxyz = Atom( HOLConst( "P", ->( Ti, ->( Ti, ( ->( Ti, To ) ) ) ) ), List( x, y, z ) )
+    val allP = AllVar( x, AllVar( y, AllVar( z, Pxyz ) ) )
+    val exP = ExVar( x, ExVar( y, ExVar( z, Pxyz ) ) )
 
     "Correctly introduce one quantifier" in {
-      AllVarBlock(List(x), Pxyz) must beEqualTo(AllVar(x, Pxyz))
-      ExVarBlock(List(x), Pxyz) must beEqualTo(ExVar(x, Pxyz))
+      AllVarBlock( List( x ), Pxyz ) must beEqualTo( AllVar( x, Pxyz ) )
+      ExVarBlock( List( x ), Pxyz ) must beEqualTo( ExVar( x, Pxyz ) )
     }
 
     "Correctly introduce multiple quantifiers" in {
-      AllVarBlock(List(x,y,z), Pxyz) must beEqualTo(allP)
-      ExVarBlock(List(x,y,z), Pxyz) must beEqualTo(exP)
+      AllVarBlock( List( x, y, z ), Pxyz ) must beEqualTo( allP )
+      ExVarBlock( List( x, y, z ), Pxyz ) must beEqualTo( exP )
     }
 
     "Correctly match quantified formulas" in {
 
       val match1 = allP match {
-        case AllVarBlock(vars, f) =>
-          vars == List(x,y,z)
+        case AllVarBlock( vars, f ) =>
+          vars == List( x, y, z )
           f == Pxyz
         case _ => false
       }
 
       val match2 = exP match {
-        case ExVarBlock(vars, f) =>
-          vars == List(x,y,z)
+        case ExVarBlock( vars, f ) =>
+          vars == List( x, y, z )
           f == Pxyz
         case _ => false
       }
@@ -274,18 +275,18 @@ class HigherOrderLogicTest extends SpecificationWithJUnit {
 
     "Fail to match other formulas" in {
       exP match {
-        case AllVarBlock(_,_) => failure
-        case _ =>
+        case AllVarBlock( _, _ ) => failure
+        case _                   =>
       }
 
       allP match {
-        case ExVarBlock(_,_) => failure
-        case _ =>
+        case ExVarBlock( _, _ ) => failure
+        case _                  =>
       }
 
       Pxyz match {
-        case AllVarBlock(_,_) | ExVarBlock(_,_) => failure
-        case _ =>
+        case AllVarBlock( _, _ ) | ExVarBlock( _, _ ) => failure
+        case _                                        =>
       }
 
       success

--- a/src/test/scala/at/logic/language/hol/ReplacementsTest.scala
+++ b/src/test/scala/at/logic/language/hol/ReplacementsTest.scala
@@ -12,19 +12,19 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ReplacementsTest extends SpecificationWithJUnit {
   "Replacements" should {
     "work correctly on" in {
       "Atoms" in {
-        val a = HOLConst("a", Ti)
-        val b = HOLConst("b", Ti)
-        val P = HOLConst("P", Ti -> To)
-        val atom1 = Atom(P, a::Nil)
-        val atom2 = Atom(P, b::Nil)
-        val pos = List(1)
-        val rep = Replacement(pos, b)
-        (rep.apply(atom1)) must beEqualTo (atom2)
+        val a = HOLConst( "a", Ti )
+        val b = HOLConst( "b", Ti )
+        val P = HOLConst( "P", Ti -> To )
+        val atom1 = Atom( P, a :: Nil )
+        val atom2 = Atom( P, b :: Nil )
+        val pos = List( 1 )
+        val rep = Replacement( pos, b )
+        ( rep.apply( atom1 ) ) must beEqualTo( atom2 )
       }
     }
   }

--- a/src/test/scala/at/logic/language/lambda/BetaReductionTest.scala
+++ b/src/test/scala/at/logic/language/lambda/BetaReductionTest.scala
@@ -16,173 +16,173 @@ import StrategyOuterInner._
 import StrategyLeftRight._
 import ImplicitStandardStrategy._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class BetaReductionTest extends SpecificationWithJUnit {
 
-  val v = Var("v", Ti); 
-  val x = Var("x", Ti); 
-  val y = Var("y", Ti);
-  val f = Var("f", Ti -> Ti); 
-  val g = Var("g", Ti -> Ti)
-  val f2 = Var("f2", Ti -> Ti); 
-  val g2 = Var("g2", Ti -> Ti)
+  val v = Var( "v", Ti );
+  val x = Var( "x", Ti );
+  val y = Var( "y", Ti );
+  val f = Var( "f", Ti -> Ti );
+  val g = Var( "g", Ti -> Ti )
+  val f2 = Var( "f2", Ti -> Ti );
+  val g2 = Var( "g2", Ti -> Ti )
 
   "BetaReduction" should {
     "betaReduce a simple redex" in {
-        val e = App(Abs(x, App(f, x)),v)
-        ( betaReduce(e)(Outermost, Leftmost) ) must beEqualTo ( App(f, v) )
+      val e = App( Abs( x, App( f, x ) ), v )
+      ( betaReduce( e )( Outermost, Leftmost ) ) must beEqualTo( App( f, v ) )
     }
     "betaReduce correctly with outermost strategy" in {
-        val e = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        ( betaReduce(e)(Outermost, Leftmost) ) must beEqualTo ( App(Abs(x, App(f, x)),y) )
+      val e = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      ( betaReduce( e )( Outermost, Leftmost ) ) must beEqualTo( App( Abs( x, App( f, x ) ), y ) )
     }
     "betaReduce correctly with innermost strategy" in {
-        val e = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        ( betaReduce(e)(Innermost, Leftmost) ) must beEqualTo ( App(Abs(v, App(f, v)),y) )
+      val e = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      ( betaReduce( e )( Innermost, Leftmost ) ) must beEqualTo( App( Abs( v, App( f, v ) ), y ) )
     }
     "betaReduce correctly with leftmost strategy" in {
-        val er = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        val el = Abs(v, App(Abs(x, App(f, x)),v))
-        val e = App(el,er)
-        ( betaReduce(e)(Innermost, Leftmost) ) must beEqualTo ( App(Abs(v, App(f, v)),er) )
+      val er = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      val el = Abs( v, App( Abs( x, App( f, x ) ), v ) )
+      val e = App( el, er )
+      ( betaReduce( e )( Innermost, Leftmost ) ) must beEqualTo( App( Abs( v, App( f, v ) ), er ) )
     }
     "betaReduce correctly with rightmost strategy" in {
-        val er = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        val el = Abs(v, App(Abs(x, App(f, x)),v))
-        val e = App(el,er)
-        ( betaReduce(e)(Innermost, Rightmost) ) must beEqualTo ( App(el,App(Abs(v, App(f, v)),y)) )
+      val er = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      val el = Abs( v, App( Abs( x, App( f, x ) ), v ) )
+      val e = App( el, er )
+      ( betaReduce( e )( Innermost, Rightmost ) ) must beEqualTo( App( el, App( Abs( v, App( f, v ) ), y ) ) )
     }
     "betaNormalize correctly with outermost strategy" in {
       "- 1" in {
-          val er = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-          val el = Abs(v, App(Abs(x, App(f, x)),v))
-          val e = App(el,er)
-          ( betaNormalize(e)(Outermost) ) must beEqualTo ( App(f,App(f,y)) )
+        val er = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+        val el = Abs( v, App( Abs( x, App( f, x ) ), v ) )
+        val e = App( el, er )
+        ( betaNormalize( e )( Outermost ) ) must beEqualTo( App( f, App( f, y ) ) )
       }
       "- 2" in {
-          val e = App(App(Abs(g, Abs(y, App(g,y))), f), v)
-          ( betaNormalize(e)(Outermost) ) must beEqualTo ( App(f,v) )
+        val e = App( App( Abs( g, Abs( y, App( g, y ) ) ), f ), v )
+        ( betaNormalize( e )( Outermost ) ) must beEqualTo( App( f, v ) )
       }
       "- 3" in {
-          val e = App(App(App(Abs(g2, Abs(g, Abs(y, App(g2,App(g,y))))), f2), f), v)
-          ( betaNormalize(e)(Outermost) ) must beEqualTo ( App(f2,App(f,v)) )
+        val e = App( App( App( Abs( g2, Abs( g, Abs( y, App( g2, App( g, y ) ) ) ) ), f2 ), f ), v )
+        ( betaNormalize( e )( Outermost ) ) must beEqualTo( App( f2, App( f, v ) ) )
       }
     }
     "betaNormalize correctly with innermost strategy" in {
-        val er = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        val el = Abs(v, App(Abs(x, App(f, x)),v))
-        val e = App(el,er)
-        ( betaNormalize(e)(Innermost) ) must beEqualTo ( App(f,App(f,y)) )
+      val er = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      val el = Abs( v, App( Abs( x, App( f, x ) ), v ) )
+      val e = App( el, er )
+      ( betaNormalize( e )( Innermost ) ) must beEqualTo( App( f, App( f, y ) ) )
     }
     "betaNormalize correctly with implicit standard strategy" in {
-        val er = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        val el = Abs(v, App(Abs(x, App(f, x)),v))
-        val e = App(el,er)
-        ( betaNormalize(e) ) must beEqualTo ( App(f,App(f,y)) )
+      val er = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      val el = Abs( v, App( Abs( x, App( f, x ) ), v ) )
+      val e = App( el, er )
+      ( betaNormalize( e ) ) must beEqualTo( App( f, App( f, y ) ) )
     }
     "betaReduce correctly with implicit standard strategy" in {
-        val e = App(Abs(v, App(Abs(x, App(f, x)),v)),y)
-        ( betaReduce(e) ) must beEqualTo ( App(Abs(x, App(f, x)),y) )
+      val e = App( Abs( v, App( Abs( x, App( f, x ) ), v ) ), y )
+      ( betaReduce( e ) ) must beEqualTo( App( Abs( x, App( f, x ) ), y ) )
     }
     "betaReduce correctly the terms" in {
       "- 1" in {
-        val term1 = App(Abs(Var("x",Ti->Ti),Abs(Var("y",Ti),App(Var("x",Ti->Ti),Var("y",Ti)))),Abs(Var("z",Ti),Var("z",Ti)))
-        val term2 = Abs(Var("y",Ti),App(Abs(Var("z",Ti),Var("z",Ti)),Var("y",Ti)))
-        (betaReduce(term1)(Outermost, Leftmost)) must beEqualTo (term2)
+        val term1 = App( Abs( Var( "x", Ti -> Ti ), Abs( Var( "y", Ti ), App( Var( "x", Ti -> Ti ), Var( "y", Ti ) ) ) ), Abs( Var( "z", Ti ), Var( "z", Ti ) ) )
+        val term2 = Abs( Var( "y", Ti ), App( Abs( Var( "z", Ti ), Var( "z", Ti ) ), Var( "y", Ti ) ) )
+        ( betaReduce( term1 )( Outermost, Leftmost ) ) must beEqualTo( term2 )
       }
       "- 2" in {
-        val term1 = App(Abs(Var("x",Ti->Ti),Abs(Var("x",Ti),App(Var("x",Ti->Ti),Var("x",Ti)))),Abs(Var("x",Ti),Var("x",Ti)))
-        val term2 = Abs(Var("y",Ti),App(Abs(Var("z",Ti),Var("z",Ti)),Var("y",Ti)))
-        (betaReduce(term1)(Outermost, Leftmost)) must beEqualTo (term2)
+        val term1 = App( Abs( Var( "x", Ti -> Ti ), Abs( Var( "x", Ti ), App( Var( "x", Ti -> Ti ), Var( "x", Ti ) ) ) ), Abs( Var( "x", Ti ), Var( "x", Ti ) ) )
+        val term2 = Abs( Var( "y", Ti ), App( Abs( Var( "z", Ti ), Var( "z", Ti ) ), Var( "y", Ti ) ) )
+        ( betaReduce( term1 )( Outermost, Leftmost ) ) must beEqualTo( term2 )
       }
       "- 3" in {
-        val x1 = Var("x",Ti->Ti)
-        val x2 = Var("y",Ti)
-        val x3 = Var("z",Ti)
-        val x4 = Var("w",Ti)
-        val x5 = Var("v",Ti)
-        val c1 = Var("f", Ti->(Ti->Ti))
-        val t1 = App(c1,App(x1,x2))
-        val t2 = App(t1,App(x1,x3))
-        val t3 = Abs(x4,x4)
-        val term1 = App(Abs(x1::x2::x3::Nil, t2),t3)
-        val term2 = Abs(x2::x3::Nil, App(App(c1,App(t3,x2)),App(t3,x3)))
-        (betaReduce(term1)(Outermost, Leftmost)) must beEqualTo (term2)
+        val x1 = Var( "x", Ti -> Ti )
+        val x2 = Var( "y", Ti )
+        val x3 = Var( "z", Ti )
+        val x4 = Var( "w", Ti )
+        val x5 = Var( "v", Ti )
+        val c1 = Var( "f", Ti -> ( Ti -> Ti ) )
+        val t1 = App( c1, App( x1, x2 ) )
+        val t2 = App( t1, App( x1, x3 ) )
+        val t3 = Abs( x4, x4 )
+        val term1 = App( Abs( x1 :: x2 :: x3 :: Nil, t2 ), t3 )
+        val term2 = Abs( x2 :: x3 :: Nil, App( App( c1, App( t3, x2 ) ), App( t3, x3 ) ) )
+        ( betaReduce( term1 )( Outermost, Leftmost ) ) must beEqualTo( term2 )
       }
       "- 4" in {
-        val e = Abs(x, App(Abs(g, App(g,x)), f))
-        (betaReduce(e)(Outermost, Leftmost)) must beEqualTo (Abs(y, App(f, y)))
+        val e = Abs( x, App( Abs( g, App( g, x ) ), f ) )
+        ( betaReduce( e )( Outermost, Leftmost ) ) must beEqualTo( Abs( y, App( f, y ) ) )
       }
     }
     "betaNormalize correctly with Abs terms built from variables obtained by the Abs extractor" in {
-      val x = Var("x", Ti)
-      val y = Var("", Ti)
-      val p = Var("p", Ti -> To)
+      val x = Var( "x", Ti )
+      val y = Var( "", Ti )
+      val p = Var( "p", Ti -> To )
       val px = App( p, x )
       val py = App( p, y )
-      val xpx = Abs(x, px)
+      val xpx = Abs( x, px )
       val res = xpx match {
-        case Abs(v, t) => App(Abs(v, t), y)
+        case Abs( v, t ) => App( Abs( v, t ), y )
       }
-      betaNormalize( res )(Innermost) must beEqualTo( py )
+      betaNormalize( res )( Innermost ) must beEqualTo( py )
     }
     "betaNormalize correctly including a simple variable renaming" in {
       val x = Var( "x", Ti )
       val z = Var( "z", Ti )
-      val f = Const( "f", Ti->(Ti->Ti) )
-      val M = App( Abs( x::z::Nil, App( f, x::z::Nil )), z )
-      val N = Abs( x, App( f, z::x::Nil ))
+      val f = Const( "f", Ti -> ( Ti -> Ti ) )
+      val M = App( Abs( x :: z :: Nil, App( f, x :: z :: Nil ) ), z )
+      val N = Abs( x, App( f, z :: x :: Nil ) )
       val M_normalized = betaNormalize( M )
 
-      M_normalized must beEqualTo ( N )
+      M_normalized must beEqualTo( N )
     }
     "betaNormalize correctly 1+2=3 using Church numerals" in {
       val x = Var( "x", Ti )
-      val f = Var( "f", Ti->Ti )
+      val f = Var( "f", Ti -> Ti )
       // a church numeral is of type (Ti->Ti)->(Ti->Ti)
-      val m = Var( "m", (Ti->Ti)->(Ti->Ti) )
-      val n = Var( "n", (Ti->Ti)->(Ti->Ti) )
+      val m = Var( "m", ( Ti -> Ti ) -> ( Ti -> Ti ) )
+      val n = Var( "n", ( Ti -> Ti ) -> ( Ti -> Ti ) )
 
-      val one = Abs( f::x::Nil, App( f, x ))
-      val two = Abs( f::x::Nil, App( f, App( f, x )))
-      val three = Abs( f::x::Nil, App( f, App( f, App( f, x ))))
+      val one = Abs( f :: x :: Nil, App( f, x ) )
+      val two = Abs( f :: x :: Nil, App( f, App( f, x ) ) )
+      val three = Abs( f :: x :: Nil, App( f, App( f, App( f, x ) ) ) )
 
-      val add = Abs( m::n::f::x::Nil, App( m, f::App( n, f::x::Nil )::Nil ) )
+      val add = Abs( m :: n :: f :: x :: Nil, App( m, f :: App( n, f :: x :: Nil ) :: Nil ) )
 
-      val result = betaNormalize( App( add, one::two::Nil ))
+      val result = betaNormalize( App( add, one :: two :: Nil ) )
 
-      ( result ) must beEqualTo ( three )
+      ( result ) must beEqualTo( three )
     }
     "betaNormalize correctly 8+3=11 using Church numerals" in {
       val x = Var( "x", Ti )
-      val f = Var( "f", Ti->Ti )
+      val f = Var( "f", Ti -> Ti )
       // a church numeral is of type (Ti->Ti)->(Ti->Ti)
-      val m = Var( "m", (Ti->Ti)->(Ti->Ti) )
-      val n = Var( "n", (Ti->Ti)->(Ti->Ti) )
+      val m = Var( "m", ( Ti -> Ti ) -> ( Ti -> Ti ) )
+      val n = Var( "n", ( Ti -> Ti ) -> ( Ti -> Ti ) )
 
-      val three = Abs( f::x::Nil, App( f, App( f, App( f, x ))))
-      val eight = Abs( f::x::Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x )))))))))
-      val eleven = Abs( f::x::Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x ))))))))))))
+      val three = Abs( f :: x :: Nil, App( f, App( f, App( f, x ) ) ) )
+      val eight = Abs( f :: x :: Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x ) ) ) ) ) ) ) ) )
+      val eleven = Abs( f :: x :: Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x ) ) ) ) ) ) ) ) ) ) ) )
 
-      val add = Abs( m::n::f::x::Nil, App( m, f::App( n, f::x::Nil )::Nil ) )
+      val add = Abs( m :: n :: f :: x :: Nil, App( m, f :: App( n, f :: x :: Nil ) :: Nil ) )
 
-      val result = betaNormalize( App( add, eight::three::Nil ))
+      val result = betaNormalize( App( add, eight :: three :: Nil ) )
 
-      ( result ) must beEqualTo ( eleven )
+      ( result ) must beEqualTo( eleven )
     }
     "betaNormalize correctly 2^3=8 using Church numerals" in {
       val x = Var( "x", Ti )
-      val f = Var( "f", Ti->Ti )
-      val two = Abs( f::x::Nil, App( f, App( f, x )))
-      val eight = Abs( f::x::Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x )))))))))
+      val f = Var( "f", Ti -> Ti )
+      val two = Abs( f :: x :: Nil, App( f, App( f, x ) ) )
+      val eight = Abs( f :: x :: Nil, App( f, App( f, App( f, App( f, App( f, App( f, App( f, App( f, x ) ) ) ) ) ) ) ) )
 
-      val y = Var( "y", Ti->Ti )
-      val g = Var( "g", (Ti->Ti)->(Ti->Ti) )
-      val to_power_three = Abs( g::y::Nil, App( g, App( g, App( g, y ))))
+      val y = Var( "y", Ti -> Ti )
+      val g = Var( "g", ( Ti -> Ti ) -> ( Ti -> Ti ) )
+      val to_power_three = Abs( g :: y :: Nil, App( g, App( g, App( g, y ) ) ) )
 
-      val result = betaNormalize( App( to_power_three, two ))
+      val result = betaNormalize( App( to_power_three, two ) )
 
-      ( result ) must beEqualTo ( eight )
+      ( result ) must beEqualTo( eight )
     }
   }
 }

--- a/src/test/scala/at/logic/language/lambda/LambdaCalculusTest.scala
+++ b/src/test/scala/at/logic/language/lambda/LambdaCalculusTest.scala
@@ -10,146 +10,146 @@ import org.specs2.runner.JUnitRunner
 
 import types._
 import symbols._
-import scala.collection.immutable.{HashSet, HashMap}
+import scala.collection.immutable.{ HashSet, HashMap }
 import scala.math.signum
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LambdaCalculusTest extends SpecificationWithJUnit {
-  
+
   "TypedLambdaCalculus" should {
     "make implicit conversion from String to Name" in {
-      (Var("p",Ti) ) must beEqualTo (Var("p", Ti ))
+      ( Var( "p", Ti ) ) must beEqualTo( Var( "p", Ti ) )
     }
     "create N-ary abstractions (AbsN) correctly" in {
-      val v1 = Var("x",Ti)
-      val v2 = Var("y",Ti)
-      val f = Var("f",Ti -> (Ti -> To))
-      ( Abs(v1::v2::Nil, f) match {
-        case Abs(v1,Abs(v2,f)) => true
-        case _ => false
-        }) must beEqualTo ( true )
+      val v1 = Var( "x", Ti )
+      val v2 = Var( "y", Ti )
+      val f = Var( "f", Ti -> ( Ti -> To ) )
+      ( Abs( v1 :: v2 :: Nil, f ) match {
+        case Abs( v1, Abs( v2, f ) ) => true
+        case _                       => false
+      } ) must beEqualTo( true )
     }
     "create N-ary applications (AppN) correctly" in {
-      val v1 = Var("x",Ti)
-      val v2 = Var("y",Ti)
-      val f = Var("f",Ti -> (Ti -> To))
-      ( App(f, List(v1,v2)) match {
-        case App(App(f, v1), v2) => true
-        case _ => false
-        }) must beEqualTo ( true )
+      val v1 = Var( "x", Ti )
+      val v2 = Var( "y", Ti )
+      val f = Var( "f", Ti -> ( Ti -> To ) )
+      ( App( f, List( v1, v2 ) ) match {
+        case App( App( f, v1 ), v2 ) => true
+        case _                       => false
+      } ) must beEqualTo( true )
     }
   }
-  
+
   "Equality" should {
     "distinguish variables with same name but different type" in {
       val xi = Var( "x", Ti )
-      val xii = Var( "x", Ti->Ti )
+      val xii = Var( "x", Ti -> Ti )
 
-      ( xi ) must not be equalTo ( xii )
-      ( xi.syntaxEquals( xii )) must beEqualTo ( false )
+      ( xi ) must not be equalTo( xii )
+      ( xi.syntaxEquals( xii ) ) must beEqualTo( false )
     }
 
     "distinguish the constant x from the variable x" in {
       val x_const = Const( "x", Ti )
       val x_var = Var( "x", Ti )
 
-      ( x_const ) must not be equalTo ( x_var )
-      ( x_const.syntaxEquals( x_var )) must beEqualTo ( false )
+      ( x_const ) must not be equalTo( x_var )
+      ( x_const.syntaxEquals( x_var ) ) must beEqualTo( false )
     }
 
     "equate variables with same name (but different symbols)" in {
       val v = Var( "v", Ti )
       val v0 = Var( "v0", Ti )
-      val v_renamed = rename(v, List( v ))
+      val v_renamed = rename( v, List( v ) )
 
-      v_renamed must beEqualTo ( v0 )
-      ( v_renamed.syntaxEquals( v0 ) ) must beEqualTo ( true )
+      v_renamed must beEqualTo( v0 )
+      ( v_renamed.syntaxEquals( v0 ) ) must beEqualTo( true )
     }
 
     "work correctly for alpha conversion" in {
-      val a0 = Abs(Var("x", Ti->Ti), App(Var("x",Ti->Ti),Var("y",Ti)))
-      val b0 = Abs(Var("x", Ti->Ti), App(Var("x",Ti->Ti),Var("y",Ti)))
+      val a0 = Abs( Var( "x", Ti -> Ti ), App( Var( "x", Ti -> Ti ), Var( "y", Ti ) ) )
+      val b0 = Abs( Var( "x", Ti -> Ti ), App( Var( "x", Ti -> Ti ), Var( "y", Ti ) ) )
       "- (\\x.xy) = (\\x.xy)" in {
-        (a0) must beEqualTo (b0)
-        ( a0.syntaxEquals(b0) ) must beEqualTo ( true )
+        ( a0 ) must beEqualTo( b0 )
+        ( a0.syntaxEquals( b0 ) ) must beEqualTo( true )
       }
-      val a1 = Abs(Var("y", Ti), App(Var("x",Ti->Ti), Var("y", Ti)))
-      val b1 = Abs(Var("z", Ti), App(Var("x",Ti->Ti), Var("z", Ti)))
+      val a1 = Abs( Var( "y", Ti ), App( Var( "x", Ti -> Ti ), Var( "y", Ti ) ) )
+      val b1 = Abs( Var( "z", Ti ), App( Var( "x", Ti -> Ti ), Var( "z", Ti ) ) )
       "- (\\y.xy) = (\\z.xz)" in {
-        (a1) must beEqualTo (b1)
-        ( a1.syntaxEquals(b1) ) must beEqualTo ( false )
+        ( a1 ) must beEqualTo( b1 )
+        ( a1.syntaxEquals( b1 ) ) must beEqualTo( false )
       }
-      val a2 = Abs(Var("y", Ti), a1)
-      val b2 = Abs(Var("w", Ti), a1)
+      val a2 = Abs( Var( "y", Ti ), a1 )
+      val b2 = Abs( Var( "w", Ti ), a1 )
       "- (\\y.\\y.xy) = (\\w.\\y.xy)" in {
-        (a2) must beEqualTo (b2)
-        ( a2.syntaxEquals(b2) ) must beEqualTo ( false )
+        ( a2 ) must beEqualTo( b2 )
+        ( a2.syntaxEquals( b2 ) ) must beEqualTo( false )
       }
-      val a3 = Abs(Var("y", Ti), App(Abs(Var("y", Ti), Var("x", Ti)), Var("y", Ti)))
-      val b3 = Abs(Var("w", Ti), App(Abs(Var("y", Ti), Var("x", Ti)), Var("w", Ti)))
+      val a3 = Abs( Var( "y", Ti ), App( Abs( Var( "y", Ti ), Var( "x", Ti ) ), Var( "y", Ti ) ) )
+      val b3 = Abs( Var( "w", Ti ), App( Abs( Var( "y", Ti ), Var( "x", Ti ) ), Var( "w", Ti ) ) )
       "- (\\y.(\\y.x)y) = (\\w.(\\y.x)w)" in {
-        (a3) must beEqualTo (b3)
-        ( a3.syntaxEquals(b3) ) must beEqualTo ( false )
+        ( a3 ) must beEqualTo( b3 )
+        ( a3.syntaxEquals( b3 ) ) must beEqualTo( false )
       }
-      val a4 = Abs(Var("y", Ti), App(Abs(Var("y", Ti), Var("x", Ti)), Var("y", Ti)))
-      val b4 = Abs(Var("y", Ti), App(Abs(Var("y", Ti), Var("x", Ti)), Var("w", Ti)))
+      val a4 = Abs( Var( "y", Ti ), App( Abs( Var( "y", Ti ), Var( "x", Ti ) ), Var( "y", Ti ) ) )
+      val b4 = Abs( Var( "y", Ti ), App( Abs( Var( "y", Ti ), Var( "x", Ti ) ), Var( "w", Ti ) ) )
       "- (\\y.(\\y.x)y) != (\\y.(\\y.x)w)" in {
-        (a4) must not be equalTo (b4)
-        ( a4.syntaxEquals(b4) ) must beEqualTo ( false )
+        ( a4 ) must not be equalTo( b4 )
+        ( a4.syntaxEquals( b4 ) ) must beEqualTo( false )
       }
-      val a5 = Abs(Var("y", Ti), App(Abs(Var("y", Ti), Var("y", Ti)), Var("y", Ti)))
-      val b5 = Abs(Var("y", Ti), App(Abs(Var("w", Ti), Var("w", Ti)), Var("y", Ti)))
+      val a5 = Abs( Var( "y", Ti ), App( Abs( Var( "y", Ti ), Var( "y", Ti ) ), Var( "y", Ti ) ) )
+      val b5 = Abs( Var( "y", Ti ), App( Abs( Var( "w", Ti ), Var( "w", Ti ) ), Var( "y", Ti ) ) )
       "- (\\y.(\\y.y)y) = (\\y.(\\w.w)y)" in {
-        (a5) must beEqualTo (b5)
-        ( a5.syntaxEquals(b5) ) must beEqualTo ( false )
+        ( a5 ) must beEqualTo( b5 )
+        ( a5.syntaxEquals( b5 ) ) must beEqualTo( false )
       }
-      val a6 = Abs(Var("y", Ti), App(Abs(Var("y", Ti), Var("y", Ti)), Var("y", Ti)))
-      val b6 = Abs(Var("y", Ti), App(Abs(Var("w", Ti), Var("y", Ti)), Var("x", Ti)))
+      val a6 = Abs( Var( "y", Ti ), App( Abs( Var( "y", Ti ), Var( "y", Ti ) ), Var( "y", Ti ) ) )
+      val b6 = Abs( Var( "y", Ti ), App( Abs( Var( "w", Ti ), Var( "y", Ti ) ), Var( "x", Ti ) ) )
       "- (\\y.(\\y.y)y) != (\\y.(\\w.y)y)" in {
-        (a6) must not be equalTo (b6)
-        ( a6.syntaxEquals(b6) ) must beEqualTo ( false )
+        ( a6 ) must not be equalTo( b6 )
+        ( a6.syntaxEquals( b6 ) ) must beEqualTo( false )
       }
     }
   }
 
   "Hash Codes" should {
     "be equal for alpha equal terms" in {
-      val t1 = App(Const("P", Ti -> To), Var("x", Ti))
-      val t2 = App(Const("P", Ti -> To), Var("y", Ti))
-      val t3 = Abs( Var("x", Ti), t1)
-      val t4 = Abs( Var("y", Ti), t2)
-      val t5 = Abs( Var("x", Ti), t1)
-      val t6 = Abs( Var("y", Ti), t2)
+      val t1 = App( Const( "P", Ti -> To ), Var( "x", Ti ) )
+      val t2 = App( Const( "P", Ti -> To ), Var( "y", Ti ) )
+      val t3 = Abs( Var( "x", Ti ), t1 )
+      val t4 = Abs( Var( "y", Ti ), t2 )
+      val t5 = Abs( Var( "x", Ti ), t1 )
+      val t6 = Abs( Var( "y", Ti ), t2 )
 
-      val l = List(t1,t2,t3,t4,t5,t6)
-      l.forall(x => l.forall(y => {
-        if (x == y)
+      val l = List( t1, t2, t3, t4, t5, t6 )
+      l.forall( x => l.forall( y => {
+        if ( x == y )
           x.hashCode() must_== y.hashCode()
         else
           true
-      }))
+      } ) )
 
-      ok("all tests passed")
+      ok( "all tests passed" )
     }
 
     "make maps and sets properly defined" in {
-      val t1 = App(Const("P", Ti -> To), Var("x", Ti))
-      val t2 = App(Const("P", Ti -> To), Var("y", Ti))
-      val t3 = Abs( Var("x", Ti), t1)
-      val t4 = Abs( Var("y", Ti), t2)
-      val t5 = Abs( Var("x", Ti), t1)
-      val t6 = Abs( Var("y", Ti), t2)
+      val t1 = App( Const( "P", Ti -> To ), Var( "x", Ti ) )
+      val t2 = App( Const( "P", Ti -> To ), Var( "y", Ti ) )
+      val t3 = Abs( Var( "x", Ti ), t1 )
+      val t4 = Abs( Var( "y", Ti ), t2 )
+      val t5 = Abs( Var( "x", Ti ), t1 )
+      val t6 = Abs( Var( "y", Ti ), t2 )
 
       val map = HashMap[LambdaExpression, Int]()
       val set = HashSet[LambdaExpression]()
 
-      val nmap = map + ((t3,1)) + ((t4,2))
-      nmap(t3) must_==(2) //the entry for the alpha equal formula must have been overwritten
-      nmap.size must_==(1) //t3 and t4 are considered equal, so the keyset must not contain both
-      nmap must beEqualTo( Map[LambdaExpression, Int]() + ((t3,1)) + ((t4,2))) //map and hashmap must agree
+      val nmap = map + ( ( t3, 1 ) ) + ( ( t4, 2 ) )
+      nmap( t3 ) must_== ( 2 ) //the entry for the alpha equal formula must have been overwritten
+      nmap.size must_== ( 1 ) //t3 and t4 are considered equal, so the keyset must not contain both
+      nmap must beEqualTo( Map[LambdaExpression, Int]() + ( ( t3, 1 ) ) + ( ( t4, 2 ) ) ) //map and hashmap must agree
 
       val nset = set + t3 + t4
-      nset.size must_==(1) //t3 and t4 are considered equal, so the set must not contain both
+      nset.size must_== ( 1 ) //t3 and t4 are considered equal, so the set must not contain both
       nset must beEqualTo( Set() + t3 + t4 ) //hashset and set must agree
     }
 
@@ -160,68 +160,68 @@ class LambdaCalculusTest extends SpecificationWithJUnit {
       val x = Var( "x", Ti )
       val y = Var( "y", Ti )
       val z = Var( "z", Ti )
-      val blacklist = x::y::z::Nil
+      val blacklist = x :: y :: z :: Nil
       val x_renamed = rename( x, blacklist )
 
-      ( blacklist.contains( x_renamed ) ) must beEqualTo ( false )
+      ( blacklist.contains( x_renamed ) ) must beEqualTo( false )
     }
 
     "produce a new variable different from all in the blacklist (in presence of maliciously chosen variable names)" in {
       val v = Var( "v", Ti )
       val v0 = Var( "v0", Ti )
-      val v_renamed = rename( v, v::v0::Nil )
-   
-      ( v_renamed ) must not be equalTo ( v0 )
-      ( v_renamed.syntaxEquals( v0 ) ) must beEqualTo ( false )
+      val v_renamed = rename( v, v :: v0 :: Nil )
+
+      ( v_renamed ) must not be equalTo( v0 )
+      ( v_renamed.syntaxEquals( v0 ) ) must beEqualTo( false )
     }
   }
 
   "TypedLambdaCalculus" should {
     "extract free variables correctly" in {
-      val x = Var("X", Ti -> To )
-      val y = Var("y", Ti )
-      val z = Var("Z", Ti -> To )
-      val r = Var("R", (Ti -> To) -> (Ti -> ((Ti -> To) -> To)))
-      val a = App(r, x::y::z::Nil)
+      val x = Var( "X", Ti -> To )
+      val y = Var( "y", Ti )
+      val z = Var( "Z", Ti -> To )
+      val r = Var( "R", ( Ti -> To ) -> ( Ti -> ( ( Ti -> To ) -> To ) ) )
+      val a = App( r, x :: y :: z :: Nil )
       val qa = Abs( x, a )
-      val free = freeVariables(qa)
-      free must not (contain( (v: Var) => v.syntaxEquals(x) ))
-      free must (contain( (v: Var) => v.syntaxEquals(y) ))
-      free must (contain( (v: Var) => v.syntaxEquals(z) ))
-      free must (contain( (v: Var) => v.syntaxEquals(r) ))
+      val free = freeVariables( qa )
+      free must not( contain( ( v: Var ) => v.syntaxEquals( x ) ) )
+      free must ( contain( ( v: Var ) => v.syntaxEquals( y ) ) )
+      free must ( contain( ( v: Var ) => v.syntaxEquals( z ) ) )
+      free must ( contain( ( v: Var ) => v.syntaxEquals( r ) ) )
     }
 
     "extract free variables correctly" in {
       val x = Var( "x", Ti -> Ti )
       val z = Var( "z", Ti )
-      val M = App( Abs( x, App( x, z )), x )
+      val M = App( Abs( x, App( x, z ) ), x )
 
-      val fv = freeVariables(M).toSet
+      val fv = freeVariables( M ).toSet
       val fv_correct = Set( x, z )
 
-      fv must be equalTo( fv_correct )
+      fv must be equalTo ( fv_correct )
     }
 
     "extract free variables correctly" in {
       val x = Var( "x", Ti -> Ti )
       val z = Var( "z", Ti )
-      val M = Abs( x, App( Abs( x, App( x, z )), x ))
+      val M = Abs( x, App( Abs( x, App( x, z ) ), x ) )
 
-      val fv = freeVariables(M).toSet
+      val fv = freeVariables( M ).toSet
       val fv_correct = Set( z )
 
-      fv must be equalTo( fv_correct )
+      fv must be equalTo ( fv_correct )
     }
 
     "deal correctly with bound variables in the Abs extractor" in {
-      val x = Var("x", Ti)
-      val p = Var("p", Ti -> To)
-      val px = App(p, x)
-      val xpx = Abs(x, px)
+      val x = Var( "x", Ti )
+      val p = Var( "p", Ti -> To )
+      val px = App( p, x )
+      val xpx = Abs( x, px )
 
       val res = xpx match {
-        case Abs(v, t) => Abs(v, t)
-      } 
+        case Abs( v, t ) => Abs( v, t )
+      }
 
       res must beEqualTo( xpx )
     }

--- a/src/test/scala/at/logic/language/lambda/LambdaPositionTest.scala
+++ b/src/test/scala/at/logic/language/lambda/LambdaPositionTest.scala
@@ -7,29 +7,29 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LambdaPositionTest extends SpecificationWithJUnit {
   "LambdaPositions" should {
     "be computed correctly" in {
-      val x = Var("x", Ti)
-      val f  = Const("f", ->(Ti,Ti))
-      val fx = App(f, x)
-      val exp = Abs(x, fx)
+      val x = Var( "x", Ti )
+      val f = Const( "f", ->( Ti, Ti ) )
+      val fx = App( f, x )
+      val exp = Abs( x, fx )
 
-      getPositions(x).head must beEqualTo(LambdaPosition(Nil))
-      getPositions(exp) must beEqualTo(List(LambdaPosition(Nil), LambdaPosition(1), LambdaPosition(1,1), LambdaPosition(1,2)))
+      getPositions( x ).head must beEqualTo( LambdaPosition( Nil ) )
+      getPositions( exp ) must beEqualTo( List( LambdaPosition( Nil ), LambdaPosition( 1 ), LambdaPosition( 1, 1 ), LambdaPosition( 1, 2 ) ) )
     }
 
     "be replaced correctly" in {
-      val x = Var("x", Ti)
-      val y = Var("y", Ti)
-      val f  = Const("f", ->(Ti,Ti))
-      val fx = App(f, x)
-      val fy = App(f, y)
-      val exp = Abs(x, fx)
-      val expNew = replace(exp, LambdaPosition(1,2), y)
+      val x = Var( "x", Ti )
+      val y = Var( "y", Ti )
+      val f = Const( "f", ->( Ti, Ti ) )
+      val fx = App( f, x )
+      val fy = App( f, y )
+      val exp = Abs( x, fx )
+      val expNew = replace( exp, LambdaPosition( 1, 2 ), y )
 
-      expNew(LambdaPosition(1)) must beEqualTo(fy)
+      expNew( LambdaPosition( 1 ) ) must beEqualTo( fy )
     }
   }
 }

--- a/src/test/scala/at/logic/language/lambda/LongNormalFormTest.scala
+++ b/src/test/scala/at/logic/language/lambda/LongNormalFormTest.scala
@@ -5,45 +5,45 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import symbols._
-import types. {Ti, ->}
+import types.{ Ti, -> }
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class EtaExpansionTest extends SpecificationWithJUnit {
-  val v = Var("v", Ti);
-  val x = Var("x", Ti);
-  val y = Var("y", Ti);
-  val z = Var("z", Ti);
-  val f = Var("f", Ti -> Ti);
-  val g = Var("g", Ti -> Ti)
-  val f2 = Var("f2", Ti -> Ti);
-  val g2 = Var("g2", Ti -> Ti)
-  val g3 = Var("g3", ->(Ti,->(Ti,Ti)))
-  val g4 = Abs(x,g3)
-  val g5 = Abs(x,App(g3,x))
-  val g6 = Var("g6", ->(->(Ti,Ti),->(Ti,Ti)))
+  val v = Var( "v", Ti );
+  val x = Var( "x", Ti );
+  val y = Var( "y", Ti );
+  val z = Var( "z", Ti );
+  val f = Var( "f", Ti -> Ti );
+  val g = Var( "g", Ti -> Ti )
+  val f2 = Var( "f2", Ti -> Ti );
+  val g2 = Var( "g2", Ti -> Ti )
+  val g3 = Var( "g3", ->( Ti, ->( Ti, Ti ) ) )
+  val g4 = Abs( x, g3 )
+  val g5 = Abs( x, App( g3, x ) )
+  val g6 = Var( "g6", ->( ->( Ti, Ti ), ->( Ti, Ti ) ) )
 
   "EtaExpansion" should {
     "expand correctly the lambda expressions f : (i->i) to lambda x. f(x)" in {
-      longNormalForm(f) must beEqualTo (Abs(x,App(f,x)))
+      longNormalForm( f ) must beEqualTo( Abs( x, App( f, x ) ) )
     }
     "expand correctly the lambda expressions g3(x) : (i->i) to lambda y. g3(x,y)" in {
-      longNormalForm(App(g3,x)) must beEqualTo (Abs(y, App(g3, x::y::Nil)))
+      longNormalForm( App( g3, x ) ) must beEqualTo( Abs( y, App( g3, x :: y :: Nil ) ) )
     }
     "expand correctly the lambda expressions g3 : i->(i->i) to lambda x,y. g3(x,y)" in {
-      longNormalForm(g3) must beEqualTo (Abs(x::y::Nil, App(g3,x::y::Nil)))
+      longNormalForm( g3 ) must beEqualTo( Abs( x :: y :: Nil, App( g3, x :: y :: Nil ) ) )
     }
     "expand correctly the lambda expressions g3(g3(x,y)) : i to lambda z. g3(g3(x,y),z)" in {
-      longNormalForm(App(g3, App(g3,x::y::Nil))) must beEqualTo (Abs(z, App(g3, App(g3, x::y::Nil)::z::Nil)))
+      longNormalForm( App( g3, App( g3, x :: y :: Nil ) ) ) must beEqualTo( Abs( z, App( g3, App( g3, x :: y :: Nil ) :: z :: Nil ) ) )
     }
     "expand correctly the lambda expressions g6(f) : (i->i) to eta Abs(#7,App(App(g6, Abs(#8,App(f, #8))), #7))" in {
-      longNormalForm(App(g6,f)) must beEqualTo (Abs(z,App(App(g6, Abs(x,App(f, x))), z)))
+      longNormalForm( App( g6, f ) ) must beEqualTo( Abs( z, App( App( g6, Abs( x, App( f, x ) ) ), z ) ) )
     }
     "expand correctly the lambda expressions g6 : (i->i)->(i->i) to lambda x,y. g6(lambda z. x(z),y)" in {
-      longNormalForm(g6) must beEqualTo (Abs(f::y::Nil, App(g6, Abs(z,App(f,z))::y::Nil)))
+      longNormalForm( g6 ) must beEqualTo( Abs( f :: y :: Nil, App( g6, Abs( z, App( f, z ) ) :: y :: Nil ) ) )
     }
     "expand correctly the lambda expressions f : (i->i) to f2 : (i->i)" in {
-      val v2 = longNormalForm(Abs(x,App(g3,x)))
-      longNormalForm(g3) must beEqualTo (v2)
+      val v2 = longNormalForm( Abs( x, App( g3, x ) ) )
+      longNormalForm( g3 ) must beEqualTo( v2 )
     }
   }
 }

--- a/src/test/scala/at/logic/language/lambda/SubstitutionsTest.scala
+++ b/src/test/scala/at/logic/language/lambda/SubstitutionsTest.scala
@@ -14,86 +14,86 @@ import BetaReduction._
 import ImplicitStandardStrategy._
 import org.specs2.execute.Success
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SubstitutionsTest extends SpecificationWithJUnit {
 
   "Substitutions" should {
     "NOT compose the substitution {f(y)/x} and {g(y)/x}" in {
-      val x = Var("x", Ti);
-      val y = Var("y", Ti);
-      val f = Var("f", Ti -> Ti)
-      val g = Var("g", Ti -> Ti)
-      val e1 = App(f, y)
-      val e2 = App(g, y)
-      val sub1 = Substitution(x,e1)
-      val sub2 = Substitution(x,e2)
+      val x = Var( "x", Ti );
+      val y = Var( "y", Ti );
+      val f = Var( "f", Ti -> Ti )
+      val g = Var( "g", Ti -> Ti )
+      val e1 = App( f, y )
+      val e2 = App( g, y )
+      val sub1 = Substitution( x, e1 )
+      val sub2 = Substitution( x, e2 )
       val sub = sub1 compose sub2
-      sub must beEqualTo (sub2)
+      sub must beEqualTo( sub2 )
     }
     "substitute correctly when Substitution is applied (1)" in {
-      val v = Var("v", Ti); 
-      val x = Var("x", Ti); 
-      val f = Var("f", Ti -> Ti)
-      val e = App(f, x)
-      val sigma = Substitution(v, e)
-      ( e ) must beEqualTo ( sigma( v ) )
+      val v = Var( "v", Ti );
+      val x = Var( "x", Ti );
+      val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      ( e ) must beEqualTo( sigma( v ) )
     }
     "substitute correctly when Substitution is applied (2)" in {
-      val v = Var("v", Ti); val x = Var("x", Ti); val f = Var("f", Ti -> Ti)
-      val e = App(f, x)
-      val sigma = Substitution(v, e)
-      val expression = App(f, v)
-      ( App(f, App(f, x)) ) must beEqualTo ( sigma(expression) )
+      val v = Var( "v", Ti ); val x = Var( "x", Ti ); val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      val expression = App( f, v )
+      ( App( f, App( f, x ) ) ) must beEqualTo( sigma( expression ) )
     }
     "substitute correctly when Substitution is applied (3)" in {
-      val v = Var("v", Ti); val x = Var("x", Ti); val f = Var("f", Ti -> Ti)
-      val y = Var("y", Ti)
-      val e = App(f, x)
-      val sigma = Substitution(v,e)
-      val expression = Abs(y, App(f, v))
-      ( Abs(y,App(f, App(f, x))) ) must beEqualTo ( sigma(expression) )
+      val v = Var( "v", Ti ); val x = Var( "x", Ti ); val f = Var( "f", Ti -> Ti )
+      val y = Var( "y", Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      val expression = Abs( y, App( f, v ) )
+      ( Abs( y, App( f, App( f, x ) ) ) ) must beEqualTo( sigma( expression ) )
     }
     "substitute correctly when SingleSubstitution is applied, renaming bound variables (1)" in {
-        val v = Var("v", Ti); 
-        val x = Var("x", Ti); 
-        val f = Var("f", Ti -> Ti)
-        val e = App(f, x)
-        val sigma = Substitution(v,e)
-        val exp1 = Abs(x, App(f, v))
-        val exp2 = sigma(exp1)
-        val exp3 = Abs(x,App(f, App(f, x)))
-        ( exp2 ) must be_!= ( exp3 )
+      val v = Var( "v", Ti );
+      val x = Var( "x", Ti );
+      val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      val exp1 = Abs( x, App( f, v ) )
+      val exp2 = sigma( exp1 )
+      val exp3 = Abs( x, App( f, App( f, x ) ) )
+      ( exp2 ) must be_!=( exp3 )
     }
     "substitute correctly when SingleSubstitution is applied, renaming bound variables (2)" in {
-        val v = Var("v", Ti); val x = Var("x", Ti); val f = Var("f", Ti -> Ti)
-        val e = App(f, x)
-        val sigma = Substitution(v,e)
-        val exp1 = Abs(f, App(f, v))
-        val exp2 = sigma(exp1)
-        val exp3 = Abs(f,App(f, App(f, x)))
-        ( exp2 ) must be_!= ( exp3 )
+      val v = Var( "v", Ti ); val x = Var( "x", Ti ); val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      val exp1 = Abs( f, App( f, v ) )
+      val exp2 = sigma( exp1 )
+      val exp3 = Abs( f, App( f, App( f, x ) ) )
+      ( exp2 ) must be_!=( exp3 )
     }
     "substitute correctly in presence of variant variables" in {
       val x = Var( "x", Ti )
-      val xprime = rename( x, List( x ))
+      val xprime = rename( x, List( x ) )
       val y = Var( "y", Ti )
       val z = Var( "z", Ti )
-      val f = Var( "f", Ti->(Ti->(Ti->Ti)) )
-      val M = Abs( x, App( f, List( x, y, z )))
-      val sigma = Substitution( List(( y, x ), ( z, xprime )))
+      val f = Var( "f", Ti -> ( Ti -> ( Ti -> Ti ) ) )
+      val M = Abs( x, App( f, List( x, y, z ) ) )
+      val sigma = Substitution( List( ( y, x ), ( z, xprime ) ) )
       val w = Var( "w", Ti )
       val Msigma = sigma( M )
-      val Msigma_correct = Abs( w, App( f, List( w, x, xprime )))
+      val Msigma_correct = Abs( w, App( f, List( w, x, xprime ) ) )
 
-      ( Msigma ) must beEqualTo ( Msigma_correct )
+      ( Msigma ) must beEqualTo( Msigma_correct )
     }
     "substitute and normalize correctly when Substitution is applied" in {
-      val x = Var("X", Ti -> To )
-      val f = Var("f", (Ti -> To) -> Ti )
-      val xfx = App(x, App( f, x ) )
+      val x = Var( "X", Ti -> To )
+      val f = Var( "f", ( Ti -> To ) -> Ti )
+      val xfx = App( x, App( f, x ) )
 
-      val z = Var("z", Ti)
-      val p = Var("P", Ti -> To)
+      val z = Var( "z", Ti )
+      val p = Var( "P", Ti -> To )
       val Pz = App( p, z )
       val t = Abs( z, Pz )
 
@@ -102,83 +102,83 @@ class SubstitutionsTest extends SpecificationWithJUnit {
       betaNormalize( sigma.apply( xfx ) ) must beEqualTo( App( p, App( f, t ) ) )
     }
     "concatenate/compose 2 Substitutions correctly" in {
-      val v = Var("v", Ti); val x = Var("x", Ti); val f = Var("f", Ti -> Ti)
-      val e = App(f, x)
-      val sigma = Substitution(v,e)
-      val sigma1 = sigma::(Substitution())
-      val sigma2 = sigma::sigma::(Substitution())
-      val sigma3 = sigma1::sigma1
-      ( sigma2 ) must beEqualTo ( sigma3 )
+      val v = Var( "v", Ti ); val x = Var( "x", Ti ); val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val sigma = Substitution( v, e )
+      val sigma1 = sigma :: ( Substitution() )
+      val sigma2 = sigma :: sigma :: ( Substitution() )
+      val sigma3 = sigma1 :: sigma1
+      ( sigma2 ) must beEqualTo( sigma3 )
     }
     "substitute correctly when Substitution is applied" in {
-      val v = Var("v", Ti)
-      val x = Var("x", Ti)
-      val f = Var("f", Ti -> Ti)
-      val e = App(f, v)
-      val sigma1 = Substitution(v,x)
-      ( sigma1(e) ) must beEqualTo ( App(f,x) )
+      val v = Var( "v", Ti )
+      val x = Var( "x", Ti )
+      val f = Var( "f", Ti -> Ti )
+      val e = App( f, v )
+      val sigma1 = Substitution( v, x )
+      ( sigma1( e ) ) must beEqualTo( App( f, x ) )
     }
     "not substitute for bound variables in (\\x.fx)x with sub {x |-> gy}" in {
-      val term1 = App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("x",Ti))
-      val sub = Substitution(Var("x",Ti), App(Var("g",Ti->Ti),Var("y",Ti)))
-      val term2 = App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),App(Var("g",Ti->Ti),Var("y",Ti)))
-      (sub(term1)) must beEqualTo (term2)
+      val term1 = App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "x", Ti ) )
+      val sub = Substitution( Var( "x", Ti ), App( Var( "g", Ti -> Ti ), Var( "y", Ti ) ) )
+      val term2 = App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), App( Var( "g", Ti -> Ti ), Var( "y", Ti ) ) )
+      ( sub( term1 ) ) must beEqualTo( term2 )
     }
     "not substitute for bound variables in (\\x.fx)x with sub {x |-> (\\x.fx)c}" in {
       "- 1" in {
-        val term1 = App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("x",Ti))
-        val sub = Substitution(Var("x",Ti), App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("c",Ti)))
-        val term2 = App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("c",Ti)))
-        (sub(term1)) must beEqualTo (term2)
+        val term1 = App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "x", Ti ) )
+        val sub = Substitution( Var( "x", Ti ), App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "c", Ti ) ) )
+        val term2 = App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "c", Ti ) ) )
+        ( sub( term1 ) ) must beEqualTo( term2 )
       }
       "- 2" in {
-        val term1 = App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("x",Ti))
-        val sub = Substitution(Var("x",Ti), App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("c",Ti)))
-        val term2 = App(Abs(Var("z",Ti), App(Var("f",Ti->Ti),Var("z",Ti))),App(Abs(Var("w",Ti), App(Var("f",Ti->Ti),Var("w",Ti))),Var("c",Ti)))
-        (sub(term1)) must beEqualTo (term2)
+        val term1 = App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "x", Ti ) )
+        val sub = Substitution( Var( "x", Ti ), App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "c", Ti ) ) )
+        val term2 = App( Abs( Var( "z", Ti ), App( Var( "f", Ti -> Ti ), Var( "z", Ti ) ) ), App( Abs( Var( "w", Ti ), App( Var( "f", Ti -> Ti ), Var( "w", Ti ) ) ), Var( "c", Ti ) ) )
+        ( sub( term1 ) ) must beEqualTo( term2 )
       }
     }
     "substitute correctly when substituting a term with bound variables into the scope of other bound variables" in {
-      val term1 = Abs(Var("x",Ti), App(Var("F",Ti->Ti),Var("x",Ti)))
-      val sub = Substitution(Var("F",Ti->Ti), Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))))
-      val term2 = Abs(Var("x",Ti), App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("x",Ti)))
-      (sub(term1)) must beEqualTo (term2)
+      val term1 = Abs( Var( "x", Ti ), App( Var( "F", Ti -> Ti ), Var( "x", Ti ) ) )
+      val sub = Substitution( Var( "F", Ti -> Ti ), Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ) )
+      val term2 = Abs( Var( "x", Ti ), App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "x", Ti ) ) )
+      ( sub( term1 ) ) must beEqualTo( term2 )
     }
     "correctly apply a substitution when a bound variable appears both in its domain and its range" in {
-      val x = Var("x", Ti)
-      val y = Var("y", Ti)
-      val z = Var("z", Ti)
-      val u = Var("u", Ti)
-      val f = Var("f", Ti->(Ti->Ti) )
-      val term1 = Abs( y, App( App( f, x ), y ))
-      val sub = Substitution( List(( x, y ), ( y, z )))
-      val term2 = Abs( u, App( App( f, y ), u ))
-      (sub(term1)) must beEqualTo (term2)
+      val x = Var( "x", Ti )
+      val y = Var( "y", Ti )
+      val z = Var( "z", Ti )
+      val u = Var( "u", Ti )
+      val f = Var( "f", Ti -> ( Ti -> Ti ) )
+      val term1 = Abs( y, App( App( f, x ), y ) )
+      val sub = Substitution( List( ( x, y ), ( y, z ) ) )
+      val term2 = Abs( u, App( App( f, y ), u ) )
+      ( sub( term1 ) ) must beEqualTo( term2 )
     }
     "work correctly on subterms of abs (i.e. the variables which were bound there are no longer bound)" in {
-      val term1 = Abs(Var("F",Ti->Ti),Abs(Var("x",Ti), App(Var("F",Ti->Ti),Var("x",Ti))))
-      val sub = Substitution(term1.variable, Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))))
-      val term2 = Abs(Var("x",Ti), App(Abs(Var("x",Ti), App(Var("f",Ti->Ti),Var("x",Ti))),Var("x",Ti)))
-      (sub(term1.term)) must beEqualTo (term2)
+      val term1 = Abs( Var( "F", Ti -> Ti ), Abs( Var( "x", Ti ), App( Var( "F", Ti -> Ti ), Var( "x", Ti ) ) ) )
+      val sub = Substitution( term1.variable, Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ) )
+      val term2 = Abs( Var( "x", Ti ), App( Abs( Var( "x", Ti ), App( Var( "f", Ti -> Ti ), Var( "x", Ti ) ) ), Var( "x", Ti ) ) )
+      ( sub( term1.term ) ) must beEqualTo( term2 )
     }
     "not substitute terms with different types" in {
-      val x = Var("x", Ti)
-      val f = Var("f", Ti -> Ti)
-      val e = App(f, x)
-      val g = Var("g", Ti)
-      val result = try { Substitution(f, g); false } catch {
+      val x = Var( "x", Ti )
+      val f = Var( "f", Ti -> Ti )
+      val e = App( f, x )
+      val g = Var( "g", Ti )
+      val result = try { Substitution( f, g ); false } catch {
         case ex: IllegalArgumentException => true
-        case _ => false
+        case _                            => false
       }
 
       result must beTrue
     }
     "not substitute variables with different types" in {
-      val x = Var("x", Ti -> Ti)
-      val c = Var("c", Ti)
-      val result = try { Substitution(x, c); false } catch {
+      val x = Var( "x", Ti -> Ti )
+      val c = Var( "c", Ti )
+      val result = try { Substitution( x, c ); false } catch {
         case ex: IllegalArgumentException => true
-        case _ => false
+        case _                            => false
       }
 
       result must beTrue

--- a/src/test/scala/at/logic/language/lambda/SymbolsTest.scala
+++ b/src/test/scala/at/logic/language/lambda/SymbolsTest.scala
@@ -13,20 +13,20 @@ import org.specs2.runner.JUnitRunner
 
 import symbols._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SymbolsTest extends SpecificationWithJUnit {
   "Equality between symbols" should {
     "return true if it is the same class and mixed with the same string" in {
-      (VariantSymbol("a")) must beEqualTo (VariantSymbol("a"))
+      ( VariantSymbol( "a" ) ) must beEqualTo( VariantSymbol( "a" ) )
     }
     "return true if they have the same string and number" in {
-      (VariantSymbol("a", 0)) must beEqualTo (VariantSymbol("a", 0))
+      ( VariantSymbol( "a", 0 ) ) must beEqualTo( VariantSymbol( "a", 0 ) )
     }
     "return false if the two are of the same class but different strings" in {
-      (VariantSymbol("a")) must not be equalTo (VariantSymbol("b"))
+      ( VariantSymbol( "a" ) ) must not be equalTo( VariantSymbol( "b" ) )
     }
     "return false if they have the same string but different numbers" in {
-      (VariantSymbol("a", 0)) must not be equalTo (VariantSymbol("a", 1))
+      ( VariantSymbol( "a", 0 ) ) must not be equalTo( VariantSymbol( "a", 1 ) )
     }
   }
 }

--- a/src/test/scala/at/logic/language/lambda/TypesTest.scala
+++ b/src/test/scala/at/logic/language/lambda/TypesTest.scala
@@ -13,55 +13,55 @@ import org.specs2.runner.JUnitRunner
 import scala.util.parsing.combinator._
 import types._
 
-@RunWith(classOf[JUnitRunner])
-class TypesTest  extends SpecificationWithJUnit {
+@RunWith( classOf[JUnitRunner] )
+class TypesTest extends SpecificationWithJUnit {
   "Types" should {
     "produce a binary function type ( i -> (i -> o ) )" in {
-      FunctionType( To, Ti::Ti::Nil ) must beEqualTo ( ->(Ti, ->( Ti, To ) ) )
+      FunctionType( To, Ti :: Ti :: Nil ) must beEqualTo( ->( Ti, ->( Ti, To ) ) )
     }
     val p = new JavaTokenParsers with types.Parsers
     "parse correctly from string (1)" in {
-      ( p.parseAll(p.Type, "i").get ) must beEqualTo ( Ti )
+      ( p.parseAll( p.Type, "i" ).get ) must beEqualTo( Ti )
     }
     "parse correctly from string (2)" in {
-      ( p.parseAll(p.Type, "o").get ) must beEqualTo ( To )
+      ( p.parseAll( p.Type, "o" ).get ) must beEqualTo( To )
     }
     "parse correctly from string (3)" in {
-      ( p.parseAll(p.Type, "(i -> o)").get ) must beEqualTo ( ->(Ti,To) )
+      ( p.parseAll( p.Type, "(i -> o)" ).get ) must beEqualTo( ->( Ti, To ) )
     }
     "parse correctly from string (4)" in {
-      ( p.parseAll(p.Type, "((i -> o) -> o)").get ) must beEqualTo ( ->(->(Ti,To),To) )
+      ( p.parseAll( p.Type, "((i -> o) -> o)" ).get ) must beEqualTo( ->( ->( Ti, To ), To ) )
     }
     "parse correctly from string (5)" in {
-      ( p.parseAll(p.Type, "(i -> (o -> o))").get ) must beEqualTo ( ->(Ti, ->(To,To)) )
+      ( p.parseAll( p.Type, "(i -> (o -> o))" ).get ) must beEqualTo( ->( Ti, ->( To, To ) ) )
     }
     "use correctly the constructor for strings string (1)" in {
-      ( ->("(i -> (o -> o))", To) ) must beEqualTo ( ->(->(Ti, ->(To,To)),To) )
+      ( ->( "(i -> (o -> o))", To ) ) must beEqualTo( ->( ->( Ti, ->( To, To ) ), To ) )
     }
     "extract from string (1)" in {
       ( "(i -> (o -> o))" match {
-        case StringExtractor( ->(Ti, ->(To,To)) ) => true
-        case _ => false
-      } ) must beEqualTo ( true )
+        case StringExtractor( ->( Ti, ->( To, To ) ) ) => true
+        case _                                         => false
+      } ) must beEqualTo( true )
     }
   }
 
   "FunctionType" should {
     "be created/extracted correctly for" in {
       "(i -> (o -> o))" in {
-        FunctionType(To, Ti::To::Nil) must beLike {case FunctionType(To, Ti::To::Nil) => ok}
+        FunctionType( To, Ti :: To :: Nil ) must beLike { case FunctionType( To, Ti :: To :: Nil ) => ok }
       }
       "(i -> ((o -> o) -> i))" in {
-        FunctionType(Ti, Ti::(->(To,To))::Nil) must beLike {case FunctionType(Ti, Ti::(->(To,To))::Nil) => ok}
+        FunctionType( Ti, Ti :: ( ->( To, To ) ) :: Nil ) must beLike { case FunctionType( Ti, Ti :: ( ->( To, To ) ) :: Nil ) => ok }
       }
       "(i)" in {
-        FunctionType(Ti, Nil) must beLike {case FunctionType(Ti, Nil) => ok}
+        FunctionType( Ti, Nil ) must beLike { case FunctionType( Ti, Nil ) => ok }
       }
       "(i -> i -> i -> i -> i -> i -> i -> i -> i -> i -> i -> i -> o)" in {
-        FunctionType(To, Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Nil) must beLike {case FunctionType(To, Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Ti::Nil) => ok}
+        FunctionType( To, Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Nil ) must beLike { case FunctionType( To, Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Ti :: Nil ) => ok }
       }
       "((i -> o) -> ((i -> o) -> (i -> o)))" in {
-        FunctionType(->(Ti, To), (->(Ti, To))::(->(Ti, To))::Nil) must beLike {case FunctionType(To, (->(Ti, To))::(->(Ti, To))::Ti::Nil) => ok}
+        FunctionType( ->( Ti, To ), ( ->( Ti, To ) ) :: ( ->( Ti, To ) ) :: Nil ) must beLike { case FunctionType( To, ( ->( Ti, To ) ) :: ( ->( Ti, To ) ) :: Ti :: Nil ) => ok }
       }
     }
   }

--- a/src/test/scala/at/logic/language/schema/schemaTest.scala
+++ b/src/test/scala/at/logic/language/schema/schemaTest.scala
@@ -6,129 +6,128 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SchemaTest extends SpecificationWithJUnit {
   "Schema" should {
-    val i = IntVar("i")
-    val one = Succ(IntZero())
-    val two = Succ(Succ(IntZero()))
+    val i = IntVar( "i" )
+    val one = Succ( IntZero() )
+    val two = Succ( Succ( IntZero() ) )
     val p = "P"
-    val pi = IndexedPredicate(p, i::Nil)
-    val p1 = IndexedPredicate(p, one::Nil)
-    val p2 = IndexedPredicate(p, two::Nil)
-    val bigAnd = BigAnd(SchemaAbs(i, pi), one, two)
-    val bigOr = BigOr(i, pi, one, two)
-    val and = And(p1, p2)
-    val or = Or(bigAnd, bigOr)
-    val neg = Neg(or)
-    val imp = Imp(neg, and)
+    val pi = IndexedPredicate( p, i :: Nil )
+    val p1 = IndexedPredicate( p, one :: Nil )
+    val p2 = IndexedPredicate( p, two :: Nil )
+    val bigAnd = BigAnd( SchemaAbs( i, pi ), one, two )
+    val bigOr = BigOr( i, pi, one, two )
+    val and = And( p1, p2 )
+    val or = Or( bigAnd, bigOr )
+    val neg = Neg( or )
+    val imp = Imp( neg, and )
 
-    
     "create IndexedPredicate correctly (1)" in {
-      (p1) must beLike {case f: SchemaFormula => ok}
+      ( p1 ) must beLike { case f: SchemaFormula => ok }
     }
     "create IndexedPredicate correctly (2)" in {
-      (pi) must beLike {case f: SchemaFormula => ok}
+      ( pi ) must beLike { case f: SchemaFormula => ok }
     }
     "create SchemaFormula correctly (1)" in {
-      (and) must beLike {case f: SchemaFormula => ok}
+      ( and ) must beLike { case f: SchemaFormula => ok }
     }
     "create SchemaFormula correctly (2)" in {
-      (bigAnd) must beLike {case f: SchemaFormula => ok}
-    }    
+      ( bigAnd ) must beLike { case f: SchemaFormula => ok }
+    }
     "create SchemaFormula correctly (3)" in {
-      (bigOr) must beLike {case f: SchemaFormula => ok}
+      ( bigOr ) must beLike { case f: SchemaFormula => ok }
     }
     "create SchemaFormula correctly (4)" in {
-      (imp) must beLike {case f: SchemaFormula => ok}
+      ( imp ) must beLike { case f: SchemaFormula => ok }
     }
-    
+
     "correctly deal with bound variables in the BigAnd extractor (2)" in {
-      val pi = IndexedPredicate("p", i::Nil)
-      val f = BigAnd(i, pi, IntZero(), IntZero())
+      val pi = IndexedPredicate( "p", i :: Nil )
+      val f = BigAnd( i, pi, IntZero(), IntZero() )
       val res = f match {
-        case BigAnd(v, f, ub, lb) => SchemaAbs(v, f)
+        case BigAnd( v, f, ub, lb ) => SchemaAbs( v, f )
       }
-      res must beEqualTo( SchemaAbs(i, pi) )
+      res must beEqualTo( SchemaAbs( i, pi ) )
     }
-    
+
     "correctly deal with bound variables in the BigAnd extractor (1)" in {
-      val pi = IndexedPredicate("p", i::Nil)
-      val p0 = IndexedPredicate("p", IntZero()::Nil)
-      val f = BigAnd(i, pi, IntZero(), IntZero())
+      val pi = IndexedPredicate( "p", i :: Nil )
+      val p0 = IndexedPredicate( "p", IntZero() :: Nil )
+      val f = BigAnd( i, pi, IntZero(), IntZero() )
       val res = f match {
-        case BigAnd(v, f, ub, lb) => SchemaApp(SchemaAbs(v, f), ub)
+        case BigAnd( v, f, ub, lb ) => SchemaApp( SchemaAbs( v, f ), ub )
       }
       betaNormalize( res ) must beEqualTo( p0 )
     }
-    
+
     "perform the unapply function in BigAnd correctly" in {
-       val iformula = SchemaAbs(i.asInstanceOf[SchemaVar], p1)
-       val bigConj = BigAnd(iformula, one, two)
-       (BigAnd.unapply(bigConj).get._1 must beEqualTo (i)) &&
-       (BigAnd.unapply(bigConj).get._2 must beEqualTo (p1)) &&
-       (BigAnd.unapply(bigConj).get._3 must beEqualTo (one)) &&
-       (BigAnd.unapply(bigConj).get._4 must beEqualTo (two))
-    } 
+      val iformula = SchemaAbs( i.asInstanceOf[SchemaVar], p1 )
+      val bigConj = BigAnd( iformula, one, two )
+      ( BigAnd.unapply( bigConj ).get._1 must beEqualTo( i ) ) &&
+        ( BigAnd.unapply( bigConj ).get._2 must beEqualTo( p1 ) ) &&
+        ( BigAnd.unapply( bigConj ).get._3 must beEqualTo( one ) ) &&
+        ( BigAnd.unapply( bigConj ).get._4 must beEqualTo( two ) )
+    }
 
     "have correct BiggerThan constructor" in {
-      val bt1 = BiggerThan(i, one)
-      val bt2 = BiggerThan(two, one)
-      val bt3 = BiggerThan(one, two)
-      val bt4 = BiggerThan(two, i)
+      val bt1 = BiggerThan( i, one )
+      val bt2 = BiggerThan( two, one )
+      val bt3 = BiggerThan( one, two )
+      val bt4 = BiggerThan( two, i )
       bt1 must beLike {
-        case Atom(BiggerThanC, x::y::Nil) => ok
-        case _ => ko
+        case Atom( BiggerThanC, x :: y :: Nil ) => ok
+        case _                                  => ko
       }
     }
 
     "create a schematic term" in {
-      val fconst = SchemaConst("f", Tindex->Tindex->Tindex)
-      val gconst = SchemaConst("g", Tindex->Tindex)
-      val hconst = SchemaConst("h", Tindex->Tindex)
+      val fconst = SchemaConst( "f", Tindex -> Tindex -> Tindex )
+      val gconst = SchemaConst( "g", Tindex -> Tindex )
+      val hconst = SchemaConst( "h", Tindex -> Tindex )
 
-      def g(t: SchemaExpression): SchemaExpression = {
-        SchemaApp(gconst, t)
+      def g( t: SchemaExpression ): SchemaExpression = {
+        SchemaApp( gconst, t )
       }
 
-      def h(t: SchemaExpression): SchemaExpression = {
-        SchemaApp(hconst, t)
+      def h( t: SchemaExpression ): SchemaExpression = {
+        SchemaApp( hconst, t )
       }
 
-      def f(n: IntegerTerm, v: SchemaExpression): SchemaExpression = {
+      def f( n: IntegerTerm, v: SchemaExpression ): SchemaExpression = {
         n match {
-          case IntZero() => g(n)
-          case _ => g(f(Pred(n), v))
+          case IntZero() => g( n )
+          case _         => g( f( Pred( n ), v ) )
         }
       }
-      
+
       // ?????????????????????
-      true must beEqualTo (true)
+      true must beEqualTo( true )
     }
 
     "unfold a schematic term" in {
-      def f = SchemaConst("f", Ti->Ti)
-      def h = SchemaConst("h", ->(Tindex , ->(Ti, Ti)))
-      def g = SchemaConst("g", ->(Tindex , ->(Ti, Ti)))
-      val k = IntVar("k")
-      val x = foVar("x")
-      val z = indexedFOVar("z", Succ(IntZero()))
-      val z0 = indexedFOVar("z", IntZero())
-      val base1 = sTerm(g, IntZero(), x::Nil)
-      val step1 = sTerm(g, Succ(k), x::Nil)
+      def f = SchemaConst( "f", Ti -> Ti )
+      def h = SchemaConst( "h", ->( Tindex, ->( Ti, Ti ) ) )
+      def g = SchemaConst( "g", ->( Tindex, ->( Ti, Ti ) ) )
+      val k = IntVar( "k" )
+      val x = foVar( "x" )
+      val z = indexedFOVar( "z", Succ( IntZero() ) )
+      val z0 = indexedFOVar( "z", IntZero() )
+      val base1 = sTerm( g, IntZero(), x :: Nil )
+      val step1 = sTerm( g, Succ( k ), x :: Nil )
       val base2 = x
-      val step2 = foTerm("f",  sTerm(g, Succ(k), x::Nil)::Nil)
+      val step2 = foTerm( "f", sTerm( g, Succ( k ), x :: Nil ) :: Nil )
       dbTRS.clear
-      dbTRS.add(g, Tuple2(base1, base2), Tuple2(step1, step2))
-      val term = sTerm(g, Succ(Succ(k)), x::Nil)
-      val term1 = sTerm(g, Succ(IntZero()), z::Nil)
-      val term2 = sTerm(g, IntZero(), z0::Nil)
+      dbTRS.add( g, Tuple2( base1, base2 ), Tuple2( step1, step2 ) )
+      val term = sTerm( g, Succ( Succ( k ) ), x :: Nil )
+      val term1 = sTerm( g, Succ( IntZero() ), z :: Nil )
+      val term2 = sTerm( g, IntZero(), z0 :: Nil )
 
-      val unf = unfoldSTerm(term2)
-      
+      val unf = unfoldSTerm( term2 )
+
       // ?????????????????????
-      true must beEqualTo (true)
-      
+      true must beEqualTo( true )
+
     }
   }
 }

--- a/src/test/scala/at/logic/parsing/calculi/simple/SimpleResolutionParserTest.scala
+++ b/src/test/scala/at/logic/parsing/calculi/simple/SimpleResolutionParserTest.scala
@@ -12,30 +12,29 @@ import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.language.hol._
-import at.logic.language.fol.{FOLVar, FOLConst, Atom => FOLAtom, Function => FOLFunction}
+import at.logic.language.fol.{ FOLVar, FOLConst, Atom => FOLAtom, Function => FOLFunction }
 import at.logic.parsing.readers.StringReader
 import at.logic.calculi.resolution._
 import at.logic.calculi.resolution.robinson._
 import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimpleResolutionParserTest extends SpecificationWithJUnit {
-//  private class MyParser(input: String) extends StringReader(input) with SimpleResolutionParserHOL
-  private class MyParser2(input: String) extends StringReader(input) with SimpleResolutionParserFOL
+  //  private class MyParser(input: String) extends StringReader(input) with SimpleResolutionParserHOL
+  private class MyParser2( input: String ) extends StringReader( input ) with SimpleResolutionParserFOL
 
-  val pa = Atom(HOLConst(StringSymbol("p"), Ti -> To),HOLConst(StringSymbol("a"), Ti)::Nil)
-  val pfx = Atom(HOLConst(StringSymbol("p"), Ti->To),Function(HOLConst(StringSymbol("f"), Ti -> Ti), HOLVar(StringSymbol("x"), Ti)::Nil)::Nil)
-  val px = Atom(HOLConst(StringSymbol("p"), Ti->To), HOLVar(StringSymbol("x"), Ti)::Nil)
-  val pffa = Atom(HOLConst(StringSymbol("p"), Ti -> To),Function(HOLConst(StringSymbol("f"),Ti->Ti),Function(HOLConst(StringSymbol("f"), Ti->Ti), HOLConst(StringSymbol("a"), Ti)::Nil)::Nil)::Nil)
+  val pa = Atom( HOLConst( StringSymbol( "p" ), Ti -> To ), HOLConst( StringSymbol( "a" ), Ti ) :: Nil )
+  val pfx = Atom( HOLConst( StringSymbol( "p" ), Ti -> To ), Function( HOLConst( StringSymbol( "f" ), Ti -> Ti ), HOLVar( StringSymbol( "x" ), Ti ) :: Nil ) :: Nil )
+  val px = Atom( HOLConst( StringSymbol( "p" ), Ti -> To ), HOLVar( StringSymbol( "x" ), Ti ) :: Nil )
+  val pffa = Atom( HOLConst( StringSymbol( "p" ), Ti -> To ), Function( HOLConst( StringSymbol( "f" ), Ti -> Ti ), Function( HOLConst( StringSymbol( "f" ), Ti -> Ti ), HOLConst( StringSymbol( "a" ), Ti ) :: Nil ) :: Nil ) :: Nil )
 
-  val pa_fol = FOLAtom(StringSymbol("P"),FOLConst(StringSymbol("a"))::Nil)
-  val pfx_fol = FOLAtom(StringSymbol("P"),FOLFunction("f", FOLVar(StringSymbol("x"))::Nil)::Nil)
-  val px_fol = FOLAtom(StringSymbol("P"),FOLVar(StringSymbol("x"))::Nil)
-  val pffa_fol = FOLAtom(StringSymbol("P"),FOLFunction("f",FOLFunction("f", FOLConst("a")::Nil)::Nil)::Nil)
+  val pa_fol = FOLAtom( StringSymbol( "P" ), FOLConst( StringSymbol( "a" ) ) :: Nil )
+  val pfx_fol = FOLAtom( StringSymbol( "P" ), FOLFunction( "f", FOLVar( StringSymbol( "x" ) ) :: Nil ) :: Nil )
+  val px_fol = FOLAtom( StringSymbol( "P" ), FOLVar( StringSymbol( "x" ) ) :: Nil )
+  val pffa_fol = FOLAtom( StringSymbol( "P" ), FOLFunction( "f", FOLFunction( "f", FOLConst( "a" ) :: Nil ) :: Nil ) :: Nil )
 
-  def clause_to_lists(cl : Clause) : (Seq[Formula], Seq[Formula]) = (cl.negative map (_.formula), cl.positive map (_.formula))
-
+  def clause_to_lists( cl: Clause ): ( Seq[Formula], Seq[Formula] ) = ( cl.negative map ( _.formula ), cl.positive map ( _.formula ) )
 
   "SimpleResolutionParser" should {
     /*
@@ -62,23 +61,23 @@ class SimpleResolutionParserTest extends SpecificationWithJUnit {
     }
     */
     "return an empty clause when given ." in {
-      (new MyParser2(".").getClauseList) must beEqualTo (Seq(FSequent(Nil,Nil)))
+      ( new MyParser2( "." ).getClauseList ) must beEqualTo( Seq( FSequent( Nil, Nil ) ) )
     }
     "return an empty list when given nothing" in {
-      (new MyParser2("").getClauseList) must beEqualTo (Nil)
+      ( new MyParser2( "" ).getClauseList ) must beEqualTo( Nil )
     }
     "return the correct clause of -p(x). fol" in {
-      (new MyParser2("-P(x).").getClauseList) must beEqualTo (Seq(FSequent(px_fol::Nil,Nil)))
+      ( new MyParser2( "-P(x)." ).getClauseList ) must beEqualTo( Seq( FSequent( px_fol :: Nil, Nil ) ) )
     }
     "return the correct clauses for p(a). -p(x) | p(f(x)). -p(f(f(a))). in fol" in {
-      (new MyParser2("P(a). -P(x) | P(f(x)). -P(f(f(a))).").getClauseList) must beEqualTo (Seq( FSequent(Nil,pa_fol::Nil), FSequent(px_fol::Nil,pfx_fol::Nil), FSequent(pffa_fol::Nil,Nil)))
+      ( new MyParser2( "P(a). -P(x) | P(f(x)). -P(f(f(a)))." ).getClauseList ) must beEqualTo( Seq( FSequent( Nil, pa_fol :: Nil ), FSequent( px_fol :: Nil, pfx_fol :: Nil ), FSequent( pffa_fol :: Nil, Nil ) ) )
     }
     /*
     "return the correct clause for p(x) | -p(x) in hol" in {
       (new MyParser("p(x:i) | -p(x:i).").getClauseList) must beEqualTo (Clause(px::Nil,px::Nil)::Nil)
     }*/
     "return the correct clause for p(x) | -p(x) in fol" in {
-      (new MyParser2("P(x) | -P(x).").getClauseList) must beEqualTo (Seq(FSequent(px_fol::Nil,px_fol::Nil)))
+      ( new MyParser2( "P(x) | -P(x)." ).getClauseList ) must beEqualTo( Seq( FSequent( px_fol :: Nil, px_fol :: Nil ) ) )
     }
 
     /*

--- a/src/test/scala/at/logic/parsing/calculi/xml/LKExporterTest.scala
+++ b/src/test/scala/at/logic/parsing/calculi/xml/LKExporterTest.scala
@@ -18,17 +18,16 @@ import at.logic.parsing.language.xml.HOLTermExporter
 import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.language.lambda.types.To
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LkExporterTest extends SpecificationWithJUnit {
 
+  val exporter = new LKExporter {}
+  // helper to create 0-ary predicate constants
+  def pc( sym: String ) = Atom( HOLConst( StringSymbol( sym ), To ), List() )
 
-  val exporter = new LKExporter{}
-// helper to create 0-ary predicate constants
-  def pc( sym: String ) = Atom( HOLConst(StringSymbol( sym ), To), List() )
-  
   "LKExporter" should {
     "export correctly a sequent A, B :- C, D" in {
-      trim(exporter.exportSequent( FSequent(List("A","B") map (pc), List("C","D") map (pc)))) must beEqualTo (trim(
+      trim( exporter.exportSequent( FSequent( List( "A", "B" ) map ( pc ), List( "C", "D" ) map ( pc ) ) ) ) must beEqualTo( trim(
         <sequent>
           <formulalist>
             <constantatomformula symbol="A"/>
@@ -38,36 +37,34 @@ class LkExporterTest extends SpecificationWithJUnit {
             <constantatomformula symbol="C"/>
             <constantatomformula symbol="D"/>
           </formulalist>
-        </sequent>
-      ))
+        </sequent> ) )
     }
   }
   "export correctly a sequent list {A1, B1 :- C1, D1, A2, B2 :- C2, D2}" in {
-    trim(exporter.exportSequentList( "testlist",List( FSequent(List("A1","B1") map (pc), List("C1","D1") map (pc)),
-                                                     FSequent(List("A2","B2") map (pc), List("C2","D2") map (pc))))) must beEqualTo (trim(
-        <sequentlist symbol="testlist">
-          <sequent>
-            <formulalist>
-              <constantatomformula symbol="A1"/>
-              <constantatomformula symbol="B1"/>
-            </formulalist>
-            <formulalist>
-              <constantatomformula symbol="C1"/>
-              <constantatomformula symbol="D1"/>
-            </formulalist>
-          </sequent>
-          <sequent>
-            <formulalist>
-              <constantatomformula symbol="A2"/>
-              <constantatomformula symbol="B2"/>
-            </formulalist>
-            <formulalist>
-              <constantatomformula symbol="C2"/>
-              <constantatomformula symbol="D2"/>
-            </formulalist>
-          </sequent>
-        </sequentlist>
-      ))
+    trim( exporter.exportSequentList( "testlist", List( FSequent( List( "A1", "B1" ) map ( pc ), List( "C1", "D1" ) map ( pc ) ),
+      FSequent( List( "A2", "B2" ) map ( pc ), List( "C2", "D2" ) map ( pc ) ) ) ) ) must beEqualTo( trim(
+      <sequentlist symbol="testlist">
+        <sequent>
+          <formulalist>
+            <constantatomformula symbol="A1"/>
+            <constantatomformula symbol="B1"/>
+          </formulalist>
+          <formulalist>
+            <constantatomformula symbol="C1"/>
+            <constantatomformula symbol="D1"/>
+          </formulalist>
+        </sequent>
+        <sequent>
+          <formulalist>
+            <constantatomformula symbol="A2"/>
+            <constantatomformula symbol="B2"/>
+          </formulalist>
+          <formulalist>
+            <constantatomformula symbol="C2"/>
+            <constantatomformula symbol="D2"/>
+          </formulalist>
+        </sequent>
+      </sequentlist> ) )
   }
 }
 

--- a/src/test/scala/at/logic/parsing/calculi/xml/SimpleXMLParserTest.scala
+++ b/src/test/scala/at/logic/parsing/calculi/xml/SimpleXMLParserTest.scala
@@ -1,6 +1,6 @@
-/** 
- * Description: 
-**/
+/**
+ * Description:
+ */
 
 package at.logic.parsing.calculi.xml
 
@@ -15,13 +15,34 @@ import at.logic.language.hol._
 import at.logic.calculi.lk._
 import at.logic.calculi.lk.base._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimpleXMLParserTest extends SpecificationWithJUnit {
-    "parse correctly a simple tree" in {
-      // use trivial string parser
-      implicit val Parser : String => String = (x => x)
+  "parse correctly a simple tree" in {
+    // use trivial string parser
+    implicit val Parser: String => String = ( x => x )
 
-      val (name, tree) = (new NodeReader(
+    val ( name, tree ) = ( new NodeReader(
+      <proof symbol="\pi" calculus="LKS">
+        <rule type="or">
+          <conclusion>\/_i=1..n P_i</conclusion>
+          <rule type="axiom">
+            <conclusion>\/_i=2..n P_i \/ P_1</conclusion>
+          </rule>
+        </rule>
+      </proof> ) with SimpleXMLProofParser ).getNamedTree()( Parser )
+    name must beEqualTo( "\\pi" )
+    tree.vertex must beLike {
+      case x: String if x == """\/_i=1..n P_i""" => ok
+      case _                                     => ko
+    }
+  }
+
+  "parse correctly a simple document" in {
+    // use trivial string parser
+    implicit val Parser: String => String = ( x => x )
+
+    val trees = ( new NodeReader(
+      <prooftrees>
         <proof symbol="\pi" calculus="LKS">
           <rule type="or">
             <conclusion>\/_i=1..n P_i</conclusion>
@@ -30,32 +51,13 @@ class SimpleXMLParserTest extends SpecificationWithJUnit {
             </rule>
           </rule>
         </proof>
-      ) with SimpleXMLProofParser).getNamedTree()(Parser)
-      name must beEqualTo("\\pi")
-      tree.vertex must beLike{ case x : String if x == """\/_i=1..n P_i""" => ok
-                               case _ => ko }
+      </prooftrees> ) with SimpleXMLProofParser ).getNamedTrees()( Parser )
+    trees.size must beEqualTo( 1 )
+    val ( name, tree ) = trees.head
+    name must beEqualTo( "\\pi" )
+    tree.vertex must beLike {
+      case x: String if x == """\/_i=1..n P_i""" => ok
+      case _                                     => ko
     }
-
-    "parse correctly a simple document" in {
-      // use trivial string parser
-      implicit val Parser : String => String = (x => x)
-
-      val trees = (new NodeReader(
-        <prooftrees>
-          <proof symbol="\pi" calculus="LKS">
-            <rule type="or">
-              <conclusion>\/_i=1..n P_i</conclusion>
-              <rule type="axiom">
-                <conclusion>\/_i=2..n P_i \/ P_1</conclusion>
-              </rule>
-            </rule>
-          </proof>
-        </prooftrees>
-      ) with SimpleXMLProofParser).getNamedTrees()(Parser)
-      trees.size must beEqualTo(1)
-      val (name, tree) = trees.head
-      name must beEqualTo("\\pi")
-      tree.vertex must beLike{ case x : String if x == """\/_i=1..n P_i""" => ok
-                               case _ => ko }
-    }
+  }
 }

--- a/src/test/scala/at/logic/parsing/hoare/ProgramParserTest.scala
+++ b/src/test/scala/at/logic/parsing/hoare/ProgramParserTest.scala
@@ -7,26 +7,26 @@ import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 import ProgramParser._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ProgramParserTest extends SpecificationWithJUnit {
   "ProgramParser" should {
     "parse an assignment" in {
-      parseProgram("x := f(x)") must beEqualTo(Assign("x", parseTerm("f(x)")))
+      parseProgram( "x := f(x)" ) must beEqualTo( Assign( "x", parseTerm( "f(x)" ) ) )
     }
     "parse a skip" in {
-      parseProgram("skip") must beEqualTo(Skip())
+      parseProgram( "skip" ) must beEqualTo( Skip() )
     }
     "parse an if-then-else" in {
-      parseProgram("if P() then skip else x := a fi") must beEqualTo(
-        IfElse(Atom("P"), Skip(), Assign("x", parseTerm("a"))))
+      parseProgram( "if P() then skip else x := a fi" ) must beEqualTo(
+        IfElse( Atom( "P" ), Skip(), Assign( "x", parseTerm( "a" ) ) ) )
     }
     "parse a sequence" in {
-      parseProgram("x := a; skip") must beEqualTo(Sequence(Assign("x", parseTerm("a")), Skip()))
-      parseProgram("x := a; x := b; x := c") must beEqualTo(
-        Sequence(parseProgram("x := a"), Sequence(parseProgram("x := b"), parseProgram("x := c"))))
+      parseProgram( "x := a; skip" ) must beEqualTo( Sequence( Assign( "x", parseTerm( "a" ) ), Skip() ) )
+      parseProgram( "x := a; x := b; x := c" ) must beEqualTo(
+        Sequence( parseProgram( "x := a" ), Sequence( parseProgram( "x := b" ), parseProgram( "x := c" ) ) ) )
     }
     "parse a for loop" in {
-      parseProgram("for x < y do skip od") must beEqualTo(ForLoop("x", "y", Skip()))
+      parseProgram( "for x < y do skip od" ) must beEqualTo( ForLoop( "x", "y", Skip() ) )
     }
   }
 }

--- a/src/test/scala/at/logic/parsing/ivy/IvyTest.scala
+++ b/src/test/scala/at/logic/parsing/ivy/IvyTest.scala
@@ -7,281 +7,274 @@ import org.specs2.mutable.SpecificationWithJUnit
 import at.logic.parsing.lisp
 import java.io.File.separator
 import util.parsing.input.Reader
-import lisp.{SExpressionParser}
+import lisp.{ SExpressionParser }
 
 /**
  * Test for the Ivy interface.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class IvyTest extends SpecificationWithJUnit with ClasspathFileCopier {
-  def dumpreader[T](r:Reader[T]) = {
+  def dumpreader[T]( r: Reader[T] ) = {
     var reader = r
-    println("=== dumping reader! ===")
-    while (! reader.atEnd) {
-      print(reader.first)
+    println( "=== dumping reader! ===" )
+    while ( !reader.atEnd ) {
+      print( reader.first )
       reader = reader.rest
     }
     println()
   }
 
-  def debug(s:String) = {} //{println("Debug: "+s)}
-
+  def debug( s: String ) = {} //{println("Debug: "+s)}
 
   sequential
   "The Ivy Parser " should {
-       " parse an empty list " in {
-         val parser = new SExpressionParser
-         parser.parse("()") match {
-           case parser.Success(result, rest) =>
-             debug("parsing ok!")
-             "parsing ok!" must beEqualTo("parsing ok!")
-           case parser.NoSuccess(msg, rest) =>
-             debug("parser failed: "+msg+ " at "+rest.pos)
-             "msg: "+msg must beEqualTo("failed")
-         }
-       }
+    " parse an empty list " in {
+      val parser = new SExpressionParser
+      parser.parse( "()" ) match {
+        case parser.Success( result, rest ) =>
+          debug( "parsing ok!" )
+          "parsing ok!" must beEqualTo( "parsing ok!" )
+        case parser.NoSuccess( msg, rest ) =>
+          debug( "parser failed: " + msg + " at " + rest.pos )
+          "msg: " + msg must beEqualTo( "failed" )
+      }
+    }
 
     " not parse an empty list + garbage" in {
       val parser = new SExpressionParser
-      parser.parse("())") match {
-        case parser.Success(result, rest) =>
-          debug("parsing ok!")
-          "parsing ok! "+result must beEqualTo("fail!")
-        case parser.NoSuccess(msg, rest) =>
-          debug("correctly failed!")
-          "parsing failed as expected" must beEqualTo("parsing failed as expected")
+      parser.parse( "())" ) match {
+        case parser.Success( result, rest ) =>
+          debug( "parsing ok!" )
+          "parsing ok! " + result must beEqualTo( "fail!" )
+        case parser.NoSuccess( msg, rest ) =>
+          debug( "correctly failed!" )
+          "parsing failed as expected" must beEqualTo( "parsing failed as expected" )
       }
     }
 
     " parse the atom a1" in {
       val parser = new SExpressionParser
-      parser.parse("a1") match {
-        case parser.Success(result, rest) =>
-          debug("parsing ok!")
-          "parsing ok!" must beEqualTo("parsing ok!")
-        case parser.NoSuccess(msg, rest) =>
-          debug("parser failed: "+msg)
-          "msg: "+msg must beEqualTo("failed")
+      parser.parse( "a1" ) match {
+        case parser.Success( result, rest ) =>
+          debug( "parsing ok!" )
+          "parsing ok!" must beEqualTo( "parsing ok!" )
+        case parser.NoSuccess( msg, rest ) =>
+          debug( "parser failed: " + msg )
+          "msg: " + msg must beEqualTo( "failed" )
       }
     }
 
     " parse the atom a2(space)" in {
       //this test passes because regexpparsers strip whitespace!
       val parser = new SExpressionParser
-      parser.parse("a2    ") match {
-        case parser.Success(result, rest) =>
-          debug("parsing ok!")
-          true must beEqualTo(true)
-        case parser.NoSuccess(msg, rest) =>
-          debug("parsing wrong! "+msg)
-          true must beEqualTo(false)
+      parser.parse( "a2    " ) match {
+        case parser.Success( result, rest ) =>
+          debug( "parsing ok!" )
+          true must beEqualTo( true )
+        case parser.NoSuccess( msg, rest ) =>
+          debug( "parsing wrong! " + msg )
+          true must beEqualTo( false )
       }
     }
 
     """ parse the atom "a b c" """ in {
       //this test passes because regexpparsers strip whitespace!
       val parser = new SExpressionParser
-      parser.parse(""""a b c"""") match {
-        case parser.Success(result, rest) =>
-          debug("parsing ok!")
-          true must beEqualTo(true)
-        case parser.NoSuccess(msg, rest) =>
-          debug("parsing wrong! "+msg)
-          true must beEqualTo(false)
+      parser.parse( """"a b c"""" ) match {
+        case parser.Success( result, rest ) =>
+          debug( "parsing ok!" )
+          true must beEqualTo( true )
+        case parser.NoSuccess( msg, rest ) =>
+          debug( "parsing wrong! " + msg )
+          true must beEqualTo( false )
       }
     }
 
-
     " parse the list (c1 (c2 c2) c) " in {
-        val parser = new SExpressionParser
-      parser.parse("(c1 (c2 c2) c)") match {
-        case parser.Success(result, rest) =>
+      val parser = new SExpressionParser
+      parser.parse( "(c1 (c2 c2) c)" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.List(lisp.Atom("c1")::
-                           lisp.List(lisp.Atom("c2"):: lisp.Atom("c2"):: Nil)::
-                           lisp.Atom("c")::Nil)::Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.List( lisp.Atom( "c1" ) ::
+              lisp.List( lisp.Atom( "c2" ) :: lisp.Atom( "c2" ) :: Nil ) ::
+              lisp.Atom( "c" ) :: Nil ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
               //dumpreader(rest)
-              "matched correct list "+result must beEqualTo("failed")
+              "matched correct list " + result must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
-          "parser returned success "+msg must beEqualTo("failed")
+        case parser.NoSuccess( msg, rest ) =>
+          "parser returned success " + msg must beEqualTo( "failed" )
       }
     }
 
-
     " parse the list c4;;comment" in {
       val parser = new SExpressionParser
-      parser.parse("c4;;comment") match {
-        case parser.Success(result, rest) =>
+      parser.parse( "c4;;comment" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.Atom("c4")::Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.Atom( "c4" ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
-              "matched correct list" must beEqualTo("failed")
+              "matched correct list" must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
-          "parser returned success" must beEqualTo("failed")
+        case parser.NoSuccess( msg, rest ) =>
+          "parser returned success" must beEqualTo( "failed" )
       }
     }
 
     " parse the comments ;;comment 1\n;;comment 2" in {
       val parser = new SExpressionParser
-      parser.parse(";;comment 1\n;;comment 2\n") match {
-        case parser.Success(result, rest) =>
+      parser.parse( ";;comment 1\n;;comment 2\n" ) match {
+        case parser.Success( result, rest ) =>
           result match {
             case Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug("correct result:")
               //debug(result)
-              "matched correct list" must beEqualTo("failed")
+              "matched correct list" must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
+        case parser.NoSuccess( msg, rest ) =>
           //debug(msg)
           //dumpreader(rest)
-          "parser returned success" must beEqualTo("failed")
+          "parser returned success" must beEqualTo( "failed" )
       }
     }
 
     " parse the list ;;comment\nc5" in {
       //debug(" parse the list ;;comment\nc5")
       val parser = new SExpressionParser
-      parser.parse(";;comment\nc5") match {
-        case parser.Success(result, rest) =>
+      parser.parse( ";;comment\nc5" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.Atom("c5")::Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.Atom( "c5" ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
-              "matched correct list "+result must beEqualTo("failed")
+              "matched correct list " + result must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
+        case parser.NoSuccess( msg, rest ) =>
           //debug(msg)
           //dumpreader(rest)
-          "parser returned success "+msg must beEqualTo("failed")
+          "parser returned success " + msg must beEqualTo( "failed" )
       }
     }
 
     " parse the list (c1 (c2 c2) c) ;;comment" in {
       val parser = new SExpressionParser
-      parser.parse("(c1 (c2 c2) c);;comment") match {
-        case parser.Success(result, rest) =>
+      parser.parse( "(c1 (c2 c2) c);;comment" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.List(lisp.Atom("c1")::
-              lisp.List(lisp.Atom("c2"):: lisp.Atom("c2"):: Nil)::
-              lisp.Atom("c")::Nil)::Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.List( lisp.Atom( "c1" ) ::
+              lisp.List( lisp.Atom( "c2" ) :: lisp.Atom( "c2" ) :: Nil ) ::
+              lisp.Atom( "c" ) :: Nil ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
-              "matched correct list "+result must beEqualTo("failed")
+              "matched correct list " + result must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
-          "parser returned success"+msg must beEqualTo("failed")
+        case parser.NoSuccess( msg, rest ) =>
+          "parser returned success" + msg must beEqualTo( "failed" )
       }
     }
 
     " parse the list (c1 (c2 c2)  ;;comment\nc)" in {
       val parser = new SExpressionParser
-      parser.parse("(c1 (c2 c2) c);;comment") match {
-        case parser.Success(result, rest) =>
+      parser.parse( "(c1 (c2 c2) c);;comment" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.List(lisp.Atom("c1")::
-              lisp.List(lisp.Atom("c2"):: lisp.Atom("c2"):: Nil)::
-              lisp.Atom("c")::Nil)::Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.List( lisp.Atom( "c1" ) ::
+              lisp.List( lisp.Atom( "c2" ) :: lisp.Atom( "c2" ) :: Nil ) ::
+              lisp.Atom( "c" ) :: Nil ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
-              "matched correct list "+result must beEqualTo("failed")
+              "matched correct list " + result must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
-          "parser returned success"+msg must beEqualTo("failed")
+        case parser.NoSuccess( msg, rest ) =>
+          "parser returned success" + msg must beEqualTo( "failed" )
       }
     }
-
 
     " parse the list (c1 \"c2 c2\" c) " in {
       val parser = new SExpressionParser
-      parser.parse("(c1 \"c2 c2\" c)") match {
-        case parser.Success(result, rest) =>
+      parser.parse( "(c1 \"c2 c2\" c)" ) match {
+        case parser.Success( result, rest ) =>
           //          debug("parsing ok!")
-          true must beEqualTo(true)
-        case parser.NoSuccess(msg, rest) =>
+          true must beEqualTo( true )
+        case parser.NoSuccess( msg, rest ) =>
           //          debug("parser failed: "+msg)
-          true must beEqualTo(false)
+          true must beEqualTo( false )
       }
     }
 
-
     " parse the list_ a1 b " in {
       val parser = new SExpressionParser
-      parser.parse("a1 b") match {
-        case parser.Success(result, rest) =>
-//          debug("parsing ok!")
-          true must beEqualTo(true)
-        case parser.NoSuccess(msg, rest) =>
-//          debug("parser failed: "+msg)
-          true must beEqualTo(false)
+      parser.parse( "a1 b" ) match {
+        case parser.Success( result, rest ) =>
+          //          debug("parsing ok!")
+          true must beEqualTo( true )
+        case parser.NoSuccess( msg, rest ) =>
+          //          debug("parser failed: "+msg)
+          true must beEqualTo( false )
       }
     }
 
     " parse the list ;;comment 1\n(c1 (c2 c2)  ;;comment 2\nc)" in {
       val parser = new SExpressionParser
-      parser.parse("(\n;;comment 1\nc1 (c2 c2) c);;comment 2") match {
-        case parser.Success(result, rest) =>
+      parser.parse( "(\n;;comment 1\nc1 (c2 c2) c);;comment 2" ) match {
+        case parser.Success( result, rest ) =>
           result match {
-            case lisp.List(lisp.Atom("c1")::
-              lisp.List(lisp.Atom("c2"):: lisp.Atom("c2"):: Nil)::
-              lisp.Atom("c")::Nil) :: Nil =>
-              "matched correct list" must beEqualTo("matched correct list")
+            case lisp.List( lisp.Atom( "c1" ) ::
+              lisp.List( lisp.Atom( "c2" ) :: lisp.Atom( "c2" ) :: Nil ) ::
+              lisp.Atom( "c" ) :: Nil ) :: Nil =>
+              "matched correct list" must beEqualTo( "matched correct list" )
             case _ =>
               //debug(result)
               //dumpreader(rest)
-              "matched correct list" must beEqualTo("failed")
+              "matched correct list" must beEqualTo( "failed" )
           }
-        case parser.NoSuccess(msg, rest) =>
+        case parser.NoSuccess( msg, rest ) =>
           //debug(msg)
           //dumpreader(rest)
-          "parser returned success" must beEqualTo("failed")
+          "parser returned success" must beEqualTo( "failed" )
       }
     }
 
-
     " parse the test file simple.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("simple.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: Nil) =>
-            val pinput1 = IvyParser.parse(lisp.List(input1 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput1)
-            val pinput2 = IvyParser.parse(lisp.List(input2 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput2)
-            val pinput3 = IvyParser.parse(lisp.List(input1 :: instantiate8 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput3)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "simple.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: Nil ) =>
+          val pinput1 = IvyParser.parse( lisp.List( input1 :: Nil ), IvyParser.is_ivy_variable )
+          //debug(pinput1)
+          val pinput2 = IvyParser.parse( lisp.List( input2 :: Nil ), IvyParser.is_ivy_variable )
+          //debug(pinput2)
+          val pinput3 = IvyParser.parse( lisp.List( input1 :: instantiate8 :: Nil ), IvyParser.is_ivy_variable )
+        //debug(pinput3)
 
-
-          case _ =>
-//            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-            "The proof in simple.ivy must have 9 inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+          "The proof in simple.ivy must have 9 inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
     " parse the test file instantiations.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("instantiations.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: instantiate10 :: Nil) =>
-            val pinput3 = IvyParser.parse(lisp.List(paramod3 :: instantiate9 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput3)
-            val pinput4 = IvyParser.parse(lisp.List(instantiate10 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput4)
-            /*
+      val result = SExpressionParser( tempCopyOfClasspathFile( "instantiations.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: instantiate10 :: Nil ) =>
+          val pinput3 = IvyParser.parse( lisp.List( paramod3 :: instantiate9 :: Nil ), IvyParser.is_ivy_variable )
+          //debug(pinput3)
+          val pinput4 = IvyParser.parse( lisp.List( instantiate10 :: Nil ), IvyParser.is_ivy_variable )
+        //debug(pinput4)
+        /*
             pinput4 match {
               case Instantiate(id, exp, sub, clause, parent) =>
                 "instantiate" must beEqualTo("instantiate")
@@ -289,167 +282,163 @@ class IvyTest extends SpecificationWithJUnit with ClasspathFileCopier {
                 "last inference must be instantiate" must beEqualTo("failed")
             } */
 
-          case _ =>
-            //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-            "The proof in instantiations.ivy must have 9 inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+          "The proof in instantiations.ivy must have 9 inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
     " parse the test file flip.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("flip.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case l@lisp.List( input0 :: input1 :: flip2 :: input3 :: para4a :: inst6:: resolve4 :: Nil) =>
-            val pinput3 = IvyParser.parse(lisp.List(input1 :: flip2 :: Nil), IvyParser.is_ivy_variable)
-            //debug(pinput3)
-            val pinput4= IvyParser.parse(l, IvyParser.is_ivy_variable)
-            //println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            //println(pinput4)
-            //println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+      val result = SExpressionParser( tempCopyOfClasspathFile( "flip.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case l @ lisp.List( input0 :: input1 :: flip2 :: input3 :: para4a :: inst6 :: resolve4 :: Nil ) =>
+          val pinput3 = IvyParser.parse( lisp.List( input1 :: flip2 :: Nil ), IvyParser.is_ivy_variable )
+          //debug(pinput3)
+          val pinput4 = IvyParser.parse( l, IvyParser.is_ivy_variable )
+        //println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        //println(pinput4)
+        //println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 
-          case lisp.List(list) =>
-            //println(list)
-            //println(list.length)
-            "The proof in flip.ivy must have 7, not "+list.length +" inferences" must beEqualTo("failed")
-          case _ =>
-            "The proof in flip.ivy must be a nonempty list" must beEqualTo("failed")
-        }
-        ok
+        case lisp.List( list ) =>
+          //println(list)
+          //println(list.length)
+          "The proof in flip.ivy must have 7, not " + list.length + " inferences" must beEqualTo( "failed" )
+        case _ =>
+          "The proof in flip.ivy must be a nonempty list" must beEqualTo( "failed" )
+      }
+      ok
     }
-
-
 
     " parse the test file resulution.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("resolution.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: Nil) =>
-            val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-            //debug("resolution: "+pinput)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "resolution.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( input1 :: input2 :: instantiate8 :: paramod3 :: input4 :: input5 :: instantiate9 :: resolve6 :: resolve7 :: Nil ) =>
+          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        //debug("resolution: "+pinput)
 
-          case _ =>
-            //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-            "The proof in resolution.ivy must have 9 inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+          "The proof in resolution.ivy must have 9 inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
-
 
     " parse the test files factor.ivy and factor2.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("factor.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-            //debug("resolution: "+pinput)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "factor.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        //debug("resolution: "+pinput)
 
-          case _ =>
-            "The proof in factor.ivy must have some inferences" must beEqualTo("failed")
-        }
+        case _ =>
+          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
+      }
 
-        val result2 = SExpressionParser(tempCopyOfClasspathFile("factor2.ivy"))
-        result2 must not beEmpty
-        val proof2 = result2.head
-        proof2 match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof2, IvyParser.is_ivy_variable)
-            //debug("resolution: "+pinput)
+      val result2 = SExpressionParser( tempCopyOfClasspathFile( "factor2.ivy" ) )
+      result2 must not beEmpty
+      val proof2 = result2.head
+      proof2 match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof2, IvyParser.is_ivy_variable )
+        //debug("resolution: "+pinput)
 
-          case _ =>
-            "The proof in factor.ivy must have some inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
-
     " parse the test file manyliterals.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("manyliterals.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-            //debug("resolution: "+pinput)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "manyliterals.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        //debug("resolution: "+pinput)
 
-          case _ =>
-            //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-            "The proof in manyliterals.ivy must have some inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+          "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
     " parse the test file simple2.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("simple2.ivy"))
-        ok
+      val result = SExpressionParser( tempCopyOfClasspathFile( "simple2.ivy" ) )
+      ok
     }
   }
 
   " parse the test file prime1-0sk.ivy (clause set of the 0 instance of the prime proof) " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("prime1-0sk.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          //debug("resolution: "+pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "prime1-0sk.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+      //debug("resolution: "+pinput)
 
-        case _ =>
-          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-          "The proof in prime1-0sk.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+        "The proof in prime1-0sk.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file GRA014+1.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("GRA014+1.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          //debug("resolution: "+pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "GRA014+1.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+      //debug("resolution: "+pinput)
 
-        case _ =>
-          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-          "The proof in manyliterals.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+        "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file GEO037-2.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("GEO037-2.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          //debug("resolution: "+pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "GEO037-2.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+      //debug("resolution: "+pinput)
 
-        case _ =>
-          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-          "The proof in GEO037-2.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+        "The proof in GEO037-2.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file issue221.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("issue221.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          //debug("resolution: "+pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "issue221.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+      //debug("resolution: "+pinput)
 
-        case _ =>
-          //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
-          "The proof in issue221.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        //            "The first two rules of simple.ivy must parse correctly" must beEqualTo("failed")
+        "The proof in issue221.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
 }

--- a/src/test/scala/at/logic/parsing/language/hlk/HOLFormulaParserTest.scala
+++ b/src/test/scala/at/logic/parsing/language/hlk/HOLFormulaParserTest.scala
@@ -23,7 +23,7 @@ import at.logic.language.hol._
 import at.logic.language.hol.logicSymbols._
 import java.io.File.separator
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class HOLASTParserTest extends SpecificationWithJUnit {
 
   "The HOL AST Parser parser" should {
@@ -33,20 +33,20 @@ class HOLASTParserTest extends SpecificationWithJUnit {
         "P(X)", "a", "-P(y)", "-P(Y)",
         "P(x) & P(b)", "q(x) &q(x) & p(y)", "A&B", "X&Y&Z",
         "(P(x) & P(b))", "(q(x) &q(x) & p(y))", "(A&B)", "(X&Y&Z)",
-        "q(x) &(q(x) & p(y))", "(X&Y)&Z")
+        "q(x) &(q(x) & p(y))", "(X&Y)&Z" )
 
       var good: List[ast.LambdaAST] = List[ast.LambdaAST]()
-      var bad: List[(String, Position)] = List[(String, Position)]()
-      for (s <- cases) {
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
+      var bad: List[( String, Position )] = List[( String, Position )]()
+      for ( s <- cases ) {
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
             good = result :: good
-          case HOLASTParser.Failure(msg, input) =>
+          case HOLASTParser.Failure( msg, input ) =>
             //s must beEqualTo("Failure:"+input.pos.toString + ": " +  msg)
-            bad = (msg, input.pos) :: bad
-          case HOLASTParser.Error(msg, input) =>
+            bad = ( msg, input.pos ) :: bad
+          case HOLASTParser.Error( msg, input ) =>
             //s must beEqualTo("Error:"+input.pos.toString + ": " +  msg)
-            bad = (msg, input.pos) :: bad
+            bad = ( msg, input.pos ) :: bad
         }
       }
 
@@ -70,15 +70,15 @@ class HOLASTParserTest extends SpecificationWithJUnit {
         "q(x) &(q(x) & p(y))", "(X&Y)&Z",
         "(all X p(X))", "(exists X p(X))",
         "-(all X p(X))", "-(exists X p(X))",
-        "-(all X --p(X))", "--(exists X p(X))")
+        "-(all X --p(X))", "--(exists X p(X))" )
 
-      cases map ((s: String) =>
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
-            true must beEqualTo(true)
-          case HOLASTParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+      cases map ( ( s: String ) =>
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
+            true must beEqualTo( true )
+          case HOLASTParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
 
@@ -89,34 +89,31 @@ class HOLASTParserTest extends SpecificationWithJUnit {
         "(all X ((\\Y => P(X,Y)) & Q(X)))", "(\\Y => (all X (P(X) & Q(X) & R(Y,Y))))",
         "(\\X=>X)", "(\\X=>X(X))",
         "(all X ((\\\\Y => P(X,\\Y)) & Q(X)))", "(\\\\Y => (all X (P(X) & Q(X) & R(\\Y,\\Y))))",
-        "(\\\\X=>\\X)", "(\\\\X=>\\X(\\X))"
-      )
+        "(\\\\X=>\\X)", "(\\\\X=>\\X(\\X))" )
 
-      cases map ((s: String) =>
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
-            true must beEqualTo(true)
-          case HOLASTParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+      cases map ( ( s: String ) =>
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
+            true must beEqualTo( true )
+          case HOLASTParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
 
     "handle applications" in {
       val cases = List(
-        "(@ P x y)", "(@ P(x,y) z)", "(@ P x y(z))"
-      )
+        "(@ P x y)", "(@ P(x,y) z)", "(@ P x y(z))" )
 
-      cases map ((s: String) =>
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
-            true must beEqualTo(true)
-          case HOLASTParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+      cases map ( ( s: String ) =>
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
+            true must beEqualTo( true )
+          case HOLASTParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
-
 
     "handle complex formulas" in {
       val cases = List(
@@ -125,18 +122,17 @@ class HOLASTParserTest extends SpecificationWithJUnit {
         "(all X (P(X) | Q(X)))", "(all X (P(X) | Q(X) | R(X,X)))",
         "(exists X (P(X) | Q(X)))", "(exists X (P(X) | Q(X) | R(X,X)))",
         //"(all x (q(x,f(x)) | q(x,g(x))))",
-        "(all X (q(X,f(X)) | q(X,g(X))))")
+        "(all X (q(X,f(X)) | q(X,g(X))))" )
 
-      cases map ((s: String) =>
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
-            true must beEqualTo(true)
-          case HOLASTParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+      cases map ( ( s: String ) =>
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
+            true must beEqualTo( true )
+          case HOLASTParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
-
 
     "goat puzzle endsequent" in {
       val oendsequent =
@@ -157,42 +153,39 @@ class HOLASTParserTest extends SpecificationWithJUnit {
           | (all V1 (p(north,south,north,north,V1) -> p(south,south,north,south,take_cabbage(V1)))) ->
           | (exists Z p(north,north,north,north,Z))""".stripMargin
 
-      HOLASTParser.parseAll(HOLASTParser.formula, oendsequent) match {
-        case HOLASTParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case HOLASTParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      HOLASTParser.parseAll( HOLASTParser.formula, oendsequent ) match {
+        case HOLASTParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case HOLASTParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
     }
 
     "(x+x) is a pformula" in {
-      HOLASTParser.parseAll(HOLASTParser.pformula, "(x+x)") match {
-        case HOLASTParser.Success(result, _) =>
+      HOLASTParser.parseAll( HOLASTParser.pformula, "(x+x)" ) match {
+        case HOLASTParser.Success( result, _ ) =>
           ok
-        case HOLASTParser.NoSuccess(msg, input) =>
-          ko(input.pos.toString + ": " + msg)
+        case HOLASTParser.NoSuccess( msg, input ) =>
+          ko( input.pos.toString + ": " + msg )
       }
       ok
     }
 
     "parse infix formulas" in {
-      val terms = List("a = b", "1+X","1+(X*2)","P(1+(X*2))", "f(1+X)= (X*0)+X",
+      val terms = List( "a = b", "1+X", "1+(X*2)", "P(1+(X*2))", "f(1+X)= (X*0)+X",
         "(all X f(1+X)= (X*0)+X)", "(all X f(1+X)= (X*0)+X) | (all X f(1+X)= (X*0)+X)",
-        "(\\ x => (\\y => ( x+x = y+y  )))"
-        //, " (\\ x => (\\y => ( (x+x) = (y+y)  )))"
-        ,"(\\delta + \\kappa) +1","(\\delta + \\kappa) +1 = 0+1"
-        ,"(@ ((\\ x => (\\alpha))) 0)"
-        //,"((\\delta + \\kappa) +1)","((\\delta + \\kappa) +1) = 0+1"
-      )
-      val res : List[(String,String)] = terms.map((s: String) =>
-        HOLASTParser.parseAll(HOLASTParser.formula, s) match {
-          case HOLASTParser.Success(result, _) =>
-            (s,"")
-          case HOLASTParser.NoSuccess(msg, input) =>
-            (s, (input.pos.toString + ": " + msg+"\nproblem is:"+s))
-        }).filterNot(_._2 == "")
+        "(\\ x => (\\y => ( x+x = y+y  )))" //, " (\\ x => (\\y => ( (x+x) = (y+y)  )))"
+        , "(\\delta + \\kappa) +1", "(\\delta + \\kappa) +1 = 0+1", "(@ ((\\ x => (\\alpha))) 0)" //,"((\\delta + \\kappa) +1)","((\\delta + \\kappa) +1) = 0+1"
+        )
+      val res: List[( String, String )] = terms.map( ( s: String ) =>
+        HOLASTParser.parseAll( HOLASTParser.formula, s ) match {
+          case HOLASTParser.Success( result, _ ) =>
+            ( s, "" )
+          case HOLASTParser.NoSuccess( msg, input ) =>
+            ( s, ( input.pos.toString + ": " + msg + "\nproblem is:" + s ) )
+        } ).filterNot( _._2 == "" )
 
-      res.map((x:(String,String)) =>"" mustEqual(x._2) )
+      res.map( ( x: ( String, String ) ) => "" mustEqual ( x._2 ) )
       ok
     }
 
@@ -201,11 +194,11 @@ class HOLASTParserTest extends SpecificationWithJUnit {
 -neq(V,nil) | (all Y (ssList(Y) -> app(W,Y) != X | -totalorderedP(W) | (exists Z (ssItem(Z) & (exists X1 (ssList(X1) &
 app(cons(Z,nil),X1) = Y & (exists X2 (ssItem(X2) & (exists X3 (ssList(X3) & app(X3,cons(X2,nil)) = W &
 leq(X2,Z))))))))))) | nil != X & nil = W | neq(U,nil) & frontsegP(V,U)))))))))"""
-      HOLASTParser.parseAll(HOLASTParser.formula, str) match {
-        case HOLASTParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case HOLASTParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      HOLASTParser.parseAll( HOLASTParser.formula, str ) match {
+        case HOLASTParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case HOLASTParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
 
     }
@@ -249,11 +242,11 @@ p101(Y))) & (-(all X (-r1(Y,X) | -(-p2(X) & -p102(X) & p101(X)))) & -(all X (-r1
 (p111(Y) | -p112(Y)) & (p110(Y) | -p111(Y)) & (p109(Y) | -p110(Y)) & (p108(Y) | -p109(Y)) & (p107(Y) | -p108(Y)) &
 (p106(Y) | -p107(Y)) & (p105(Y) | -p106(Y)) & (p104(Y) | -p105(Y)) & (p103(Y) | -p104(Y)) & (p102(Y) | -p103(Y)) &
 (p101(Y) | -p102(Y)) & (p100(Y) | -p101(Y)))) & -p101(X) & p100(X))))"""
-      HOLASTParser.parseAll(HOLASTParser.formula, str) match {
-        case HOLASTParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case HOLASTParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      HOLASTParser.parseAll( HOLASTParser.formula, str ) match {
+        case HOLASTParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case HOLASTParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
 
     }
@@ -263,15 +256,15 @@ p101(Y))) & (-(all X (-r1(Y,X) | -(-p2(X) & -p102(X) & p101(X)))) & -(all X (-r1
   "The HLK HOL Parser " should {
     "parse declared formulas" in {
       val str = List(
-        "const P : i>o; const Q : i>i>o; var x,y:i; (all x (P(x) -> (exists y Q(x,y) )))")
+        "const P : i>o; const Q : i>i>o; var x,y:i; (all x (P(x) -> (exists y Q(x,y) )))" )
 
       str map { x =>
-        val f = HLKHOLParser.parseFormula(x)
+        val f = HLKHOLParser.parseFormula( x )
         f match {
-          case AllVar(x, Imp(Atom(p, px::Nil), ExVar(y, Atom(q, List(qx,qy))) )) =>
-            "success" mustEqual("success")
+          case AllVar( x, Imp( Atom( p, px :: Nil ), ExVar( y, Atom( q, List( qx, qy ) ) ) ) ) =>
+            "success" mustEqual ( "success" )
           case _ =>
-            f mustEqual("(fails)")
+            f mustEqual ( "(fails)" )
         }
       }
       ok

--- a/src/test/scala/at/logic/parsing/language/prover9/Prover9ParserTest.scala
+++ b/src/test/scala/at/logic/parsing/language/prover9/Prover9ParserTest.scala
@@ -21,7 +21,7 @@ import at.logic.language.fol._
 import at.logic.language.hol.logicSymbols._
 import java.io.File.separator
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class Prover9ParserTest extends SpecificationWithJUnit {
   "The Prover9 language parser" should {
     "handle conjunctions and atoms" in {
@@ -31,23 +31,23 @@ class Prover9ParserTest extends SpecificationWithJUnit {
         "P(X)", "a", "-P(y)", "-P(Y)",
         "P(x) & P(b)", "q(x) &q(x) & p(y)", "A&B", "X&Y&Z",
         "(P(x) & P(b))", "(q(x) &q(x) & p(y))", "(A&B)", "(X&Y&Z)",
-        "q(x) &(q(x) & p(y))", "(X&Y)&Z")
+        "q(x) &(q(x) & p(y))", "(X&Y)&Z" )
 
       var good: List[FOLFormula] = List[FOLFormula]()
-      var bad: List[(String, Position)] = List[(String, Position)]()
-      for (s <- cases) {
-        Prover9TermParser.parseAll(Prover9TermParser.formula, s) match {
-          case Prover9TermParser.Success(result, _) =>
+      var bad: List[( String, Position )] = List[( String, Position )]()
+      for ( s <- cases ) {
+        Prover9TermParser.parseAll( Prover9TermParser.formula, s ) match {
+          case Prover9TermParser.Success( result, _ ) =>
             //println(result)
             good = result :: good
-          case Prover9TermParser.Failure(msg, input) =>
+          case Prover9TermParser.Failure( msg, input ) =>
             //s must beEqualTo("Failure:"+input.pos.toString + ": " +  msg)
             //println("Failure!")
-            bad = (msg, input.pos) :: bad
-          case Prover9TermParser.Error(msg, input) =>
+            bad = ( msg, input.pos ) :: bad
+          case Prover9TermParser.Error( msg, input ) =>
             //s must beEqualTo("Error:"+input.pos.toString + ": " +  msg)
             //println("Error!")
-            bad = (msg, input.pos) :: bad
+            bad = ( msg, input.pos ) :: bad
 
         }
       }
@@ -73,16 +73,16 @@ class Prover9ParserTest extends SpecificationWithJUnit {
         "q(x) &(q(x) & p(y))", "(X&Y)&Z",
         "(all X p(X))", "(exists X p(X))",
         "-(all X p(X))", "-(exists X p(X))",
-        "-(all X --p(X))", "--(exists X p(X))")
+        "-(all X --p(X))", "--(exists X p(X))" )
 
-      cases map ((s: String) =>
-        Prover9TermParser.parseAll(Prover9TermParser.formula, s) match {
-          case Prover9TermParser.Success(result, _) =>
+      cases map ( ( s: String ) =>
+        Prover9TermParser.parseAll( Prover9TermParser.formula, s ) match {
+          case Prover9TermParser.Success( result, _ ) =>
             //println(result)
-            true must beEqualTo(true)
-          case Prover9TermParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+            true must beEqualTo( true )
+          case Prover9TermParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
 
@@ -93,16 +93,16 @@ class Prover9ParserTest extends SpecificationWithJUnit {
         "(all X (P(X) | Q(X)))", "(all X (P(X) | Q(X) | R(X,X)))",
         "(exists X (P(X) | Q(X)))", "(exists X (P(X) | Q(X) | R(X,X)))",
         //"(all x (q(x,f(x)) | q(x,g(x))))",
-        "(all X (q(X,f(X)) | q(X,g(X))))")
+        "(all X (q(X,f(X)) | q(X,g(X))))" )
 
-      cases map ((s: String) =>
-        Prover9TermParser.parseAll(Prover9TermParser.formula, s) match {
-          case Prover9TermParser.Success(result, _) =>
+      cases map ( ( s: String ) =>
+        Prover9TermParser.parseAll( Prover9TermParser.formula, s ) match {
+          case Prover9TermParser.Success( result, _ ) =>
             //println(result)
-            true must beEqualTo(true)
-          case Prover9TermParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+            true must beEqualTo( true )
+          case Prover9TermParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
 
@@ -125,25 +125,25 @@ class Prover9ParserTest extends SpecificationWithJUnit {
           | (all V1 (p(north,south,north,north,V1) -> p(south,south,north,south,take_cabbage(V1)))) ->
           | (exists Z p(north,north,north,north,Z))""".stripMargin
 
-      Prover9TermParser.parseAll(Prover9TermParser.formula, oendsequent) match {
-        case Prover9TermParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case Prover9TermParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      Prover9TermParser.parseAll( Prover9TermParser.formula, oendsequent ) match {
+        case Prover9TermParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case Prover9TermParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
     }
 
     "parse infix formulas" in {
-      val terms = List("a = b", "P(1+(X*2))", "f(1+X)= (X*0)+X",
-        "(all X f(1+X)= (X*0)+X)", "(all X f(1+X)= (X*0)+X) | (all X f(1+X)= (X*0)+X)")
-      terms map ((s: String) =>
-        Prover9TermParser.parseAll(Prover9TermParser.formula, s) match {
-          case Prover9TermParser.Success(result, _) =>
+      val terms = List( "a = b", "P(1+(X*2))", "f(1+X)= (X*0)+X",
+        "(all X f(1+X)= (X*0)+X)", "(all X f(1+X)= (X*0)+X) | (all X f(1+X)= (X*0)+X)" )
+      terms map ( ( s: String ) =>
+        Prover9TermParser.parseAll( Prover9TermParser.formula, s ) match {
+          case Prover9TermParser.Success( result, _ ) =>
             //println(result)
-            true must beEqualTo(true)
-          case Prover9TermParser.NoSuccess(msg, input) =>
-            s must beEqualTo(input.pos.toString + ": " + msg)
-        })
+            true must beEqualTo( true )
+          case Prover9TermParser.NoSuccess( msg, input ) =>
+            s must beEqualTo( input.pos.toString + ": " + msg )
+        } )
       ok
     }
 
@@ -152,12 +152,12 @@ class Prover9ParserTest extends SpecificationWithJUnit {
 -neq(V,nil) | (all Y (ssList(Y) -> app(W,Y) != X | -totalorderedP(W) | (exists Z (ssItem(Z) & (exists X1 (ssList(X1) &
 app(cons(Z,nil),X1) = Y & (exists X2 (ssItem(X2) & (exists X3 (ssList(X3) & app(X3,cons(X2,nil)) = W &
 leq(X2,Z))))))))))) | nil != X & nil = W | neq(U,nil) & frontsegP(V,U)))))))))"""
-      println("parsing large example 1")
-      Prover9TermParser.parseAll(Prover9TermParser.formula, str) match {
-        case Prover9TermParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case Prover9TermParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      println( "parsing large example 1" )
+      Prover9TermParser.parseAll( Prover9TermParser.formula, str ) match {
+        case Prover9TermParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case Prover9TermParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
 
     }
@@ -201,12 +201,12 @@ p101(Y))) & (-(all X (-r1(Y,X) | -(-p2(X) & -p102(X) & p101(X)))) & -(all X (-r1
 (p111(Y) | -p112(Y)) & (p110(Y) | -p111(Y)) & (p109(Y) | -p110(Y)) & (p108(Y) | -p109(Y)) & (p107(Y) | -p108(Y)) &
 (p106(Y) | -p107(Y)) & (p105(Y) | -p106(Y)) & (p104(Y) | -p105(Y)) & (p103(Y) | -p104(Y)) & (p102(Y) | -p103(Y)) &
 (p101(Y) | -p102(Y)) & (p100(Y) | -p101(Y)))) & -p101(X) & p100(X))))"""
-      println("parsing large example 2")
-      Prover9TermParser.parseAll(Prover9TermParser.formula, str) match {
-        case Prover9TermParser.Success(result, _) =>
-          "success" must beEqualTo("success")
-        case Prover9TermParser.NoSuccess(msg, input) =>
-          throw new Exception("Could not parse endsequent! " + msg + " " + input.pos)
+      println( "parsing large example 2" )
+      Prover9TermParser.parseAll( Prover9TermParser.formula, str ) match {
+        case Prover9TermParser.Success( result, _ ) =>
+          "success" must beEqualTo( "success" )
+        case Prover9TermParser.NoSuccess( msg, input ) =>
+          throw new Exception( "Could not parse endsequent! " + msg + " " + input.pos )
       }
 
     }

--- a/src/test/scala/at/logic/parsing/language/simple/SimpleFOLParserTest.scala
+++ b/src/test/scala/at/logic/parsing/language/simple/SimpleFOLParserTest.scala
@@ -10,73 +10,72 @@ package at.logic.parsing.language.simple
 import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import at.logic.language.hol.{HOLVar,HOLConst}
+import at.logic.language.hol.{ HOLVar, HOLConst }
 import at.logic.language.fol._
 import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.parsing.readers.StringReader
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimpleFOLParserTest extends SpecificationWithJUnit {
-  private class MyParser(input: String) extends StringReader(input) with SimpleFOLParser
+  private class MyParser( input: String ) extends StringReader( input ) with SimpleFOLParser
 
-
-  val var1 = FOLVar(new StringSymbol("x1"))
-  val const1 = FOLConst(new StringSymbol("c1"))
-  val var2 = FOLVar(new StringSymbol("x2"))
-  val atom1 = Atom(new StringSymbol("A"),var1::var2::const1::Nil)
-  val var3 = Atom(new StringSymbol("X3"), Nil)
-  val func1 = Function(new StringSymbol("f"), var1::var2::const1::Nil)
-  val and1 = And(atom1, var3)
-  val or1 = Or(atom1, var3)
-  val imp1 = Imp(atom1, var3)
-  val neg1 = Neg(atom1)
-  val ex1 = ExVar(var1,atom1)
-  val all1 = AllVar(var1,atom1)
-  val npx = Neg(Atom(new StringSymbol("p"), FOLVar(new StringSymbol("x"))::Nil))
+  val var1 = FOLVar( new StringSymbol( "x1" ) )
+  val const1 = FOLConst( new StringSymbol( "c1" ) )
+  val var2 = FOLVar( new StringSymbol( "x2" ) )
+  val atom1 = Atom( new StringSymbol( "A" ), var1 :: var2 :: const1 :: Nil )
+  val var3 = Atom( new StringSymbol( "X3" ), Nil )
+  val func1 = Function( new StringSymbol( "f" ), var1 :: var2 :: const1 :: Nil )
+  val and1 = And( atom1, var3 )
+  val or1 = Or( atom1, var3 )
+  val imp1 = Imp( atom1, var3 )
+  val neg1 = Neg( atom1 )
+  val ex1 = ExVar( var1, atom1 )
+  val all1 = AllVar( var1, atom1 )
+  val npx = Neg( Atom( new StringSymbol( "p" ), FOLVar( new StringSymbol( "x" ) ) :: Nil ) )
 
   "SimpleFOLParser" should {
     "parse correctly a variable" in {
-        (new MyParser("x1").getTerm()) must beEqualTo (var1)
+      ( new MyParser( "x1" ).getTerm() ) must beEqualTo( var1 )
     }
     "parse correctly an constant" in {
-        (new MyParser("c1").getTerm()) must beEqualTo (const1)
+      ( new MyParser( "c1" ).getTerm() ) must beEqualTo( const1 )
     }
     "parse correctly an atom" in {
-        (new MyParser("A(x1, x2, c1)").getTerm()) must beEqualTo (atom1)
+      ( new MyParser( "A(x1, x2, c1)" ).getTerm() ) must beEqualTo( atom1 )
     }
     "parse correctly a formula" in {
-        (new MyParser("X3").getTerm()) must beLike {case x: FOLFormula => ok}
-        (new MyParser("X3").getTerm()) must beEqualTo (var3)
+      ( new MyParser( "X3" ).getTerm() ) must beLike { case x: FOLFormula => ok }
+      ( new MyParser( "X3" ).getTerm() ) must beEqualTo( var3 )
     }
     "parse correctly a function 1" in {
-      (new MyParser("f(x1)").getTerm()) must beEqualTo (Function(StringSymbol("f"), var1::Nil))
+      ( new MyParser( "f(x1)" ).getTerm() ) must beEqualTo( Function( StringSymbol( "f" ), var1 :: Nil ) )
     }
     "parse correctly a function 2" in {
-        (new MyParser("f(x1, x2, c1)").getTerm()) must beEqualTo (func1)
+      ( new MyParser( "f(x1, x2, c1)" ).getTerm() ) must beEqualTo( func1 )
     }
     "parse correctly an and" in {
-        (new MyParser("And A(x1, x2, c1) X3").getTerm()) must beEqualTo (and1)
+      ( new MyParser( "And A(x1, x2, c1) X3" ).getTerm() ) must beEqualTo( and1 )
     }
     "parse correctly an or" in {
-        (new MyParser("Or A(x1, x2, c1) X3").getTerm()) must beEqualTo (or1)
+      ( new MyParser( "Or A(x1, x2, c1) X3" ).getTerm() ) must beEqualTo( or1 )
     }
     "parse correctly an imp" in {
-        (new MyParser("Imp A(x1, x2, c1) X3").getTerm()) must beEqualTo (imp1)
+      ( new MyParser( "Imp A(x1, x2, c1) X3" ).getTerm() ) must beEqualTo( imp1 )
     }
     "parse correctly an neg" in {
-        (new MyParser("Neg A(x1, x2, c1)").getTerm()) must beEqualTo (neg1)
+      ( new MyParser( "Neg A(x1, x2, c1)" ).getTerm() ) must beEqualTo( neg1 )
     }
     "parse correctly an exists" in {
-        (new MyParser("Exists x1 A(x1, x2, c1)").getTerm()) must beEqualTo (ex1)
+      ( new MyParser( "Exists x1 A(x1, x2, c1)" ).getTerm() ) must beEqualTo( ex1 )
     }
     "parse correctly a forall" in {
-        (new MyParser("Forall x1 A(x1, x2, c1)").getTerm()) must beEqualTo (all1)
+      ( new MyParser( "Forall x1 A(x1, x2, c1)" ).getTerm() ) must beEqualTo( all1 )
     }
     "reject the empty string" in {
-      (new MyParser("").getTerm()) must throwAn[Exception]
+      ( new MyParser( "" ).getTerm() ) must throwAn[Exception]
     }
     "reject the string p(X)" in {
-      (new MyParser("p(X)").getTerm()) must throwAn[Exception]
+      ( new MyParser( "p(X)" ).getTerm() ) must throwAn[Exception]
     }
   }
 }

--- a/src/test/scala/at/logic/parsing/language/simple/SimpleHOLParserTest.scala
+++ b/src/test/scala/at/logic/parsing/language/simple/SimpleHOLParserTest.scala
@@ -15,70 +15,70 @@ import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.parsing.readers.StringReader
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SimpleHOLParserTest extends SpecificationWithJUnit {
-  private class MyParser(input: String) extends StringReader(input) with SimpleHOLParser
-    "SimpleHOLParser" should {
-        val var1 = HOLVar(StringSymbol("x1"), Ti->(Ti->Ti))
-        "parse correctly a variable" in {
-            (new MyParser("x1: (i -> (i -> i))").getTerm()) must beEqualTo (var1)
-        }
-        val const1 = HOLConst(StringSymbol("c1"), Ti->Ti)
-        "parse correctly an constant" in {    
-            (new MyParser("c1: (i -> i)").getTerm()) must beEqualTo (const1)
-        }
-        val var2 = HOLVar(StringSymbol("x2"), Ti)
-        val atom1 = Atom(HOLConst(StringSymbol("a"), var1.exptype -> (var2.exptype -> (const1.exptype -> To))  ),var1::var2::const1::Nil)
-        "parse correctly an atom" in {  
-            (new MyParser("a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))").getTerm()) must beEqualTo (atom1)
-        }
-        "parse correctly an abs" in {
-            (new MyParser("Abs x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))").getTerm()) must beEqualTo (HOLAbs(var1, atom1))
-        }
-        val var3 = Atom(HOLVar(StringSymbol("x3"), To))
-        "parse correctly a formula variable" in {
-            (new MyParser("x3: o").getTerm()) must beLike {case x: Formula => ok}
-        }
-        "parse correctly a formula constant" in {
-            (new MyParser("c: o").getTerm()) must beLike {case x: Formula => ok}
-        }
-        val f1 = Function(HOLConst(StringSymbol("f"), Ti -> Ti), HOLConst(StringSymbol("a"), Ti)::Nil)
-        "parse correctly a function" in {
-          (new MyParser("f(a:i):i")).getTerm must beEqualTo (f1)
-        }
-        val f2 = Function(HOLVar(StringSymbol("x"), Ti -> Ti), HOLConst(StringSymbol("a"), Ti)::Nil)
-        "parse correctly a function variable 1" in {
-          val term = (new MyParser("x(a:i):i")).getTerm
-          term must beEqualTo (f2)
-        }
-        val and1 = And(atom1, var3)
-        "parse correctly an and" in {
-            (new MyParser("And a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o").getTerm()) must beEqualTo (and1)
-        }
-        val or1 = Or(atom1, var3)
-        "parse correctly an or" in {
-            (new MyParser("Or a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o").getTerm()) must beEqualTo (or1)
-        }
-        val imp1 = Imp(atom1, var3)
-        "parse correctly an imp" in {
-            (new MyParser("Imp a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o").getTerm()) must beEqualTo (imp1)
-        }
-        val neg1 = Neg(atom1)
-        "parse correctly an neg" in {
-            (new MyParser("Neg a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))").getTerm()) must beEqualTo (neg1)
-        }
-        val ex1 = ExVar(var1,atom1)
-        "parse correctly an exists" in {
-            (new MyParser("Exists x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))").getTerm()) must beEqualTo (ex1)
-        }
-        val all1 = AllVar(var1,atom1)
-        "parse correctly a forall" in {
-            (new MyParser("Forall x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))").getTerm()) must beEqualTo (all1)
-        }
-        val str = """p(x_10:i,m(x_3:i,m(m(p(x_4:i,one:i):i,p(x_5:i,one:i):i):i):i):i):i"""
-        "parse correctly a complex term" in {
-            (new MyParser(str).getTerm()) must not(throwAn[Exception])
-        }
+  private class MyParser( input: String ) extends StringReader( input ) with SimpleHOLParser
+  "SimpleHOLParser" should {
+    val var1 = HOLVar( StringSymbol( "x1" ), Ti -> ( Ti -> Ti ) )
+    "parse correctly a variable" in {
+      ( new MyParser( "x1: (i -> (i -> i))" ).getTerm() ) must beEqualTo( var1 )
     }
-    
+    val const1 = HOLConst( StringSymbol( "c1" ), Ti -> Ti )
+    "parse correctly an constant" in {
+      ( new MyParser( "c1: (i -> i)" ).getTerm() ) must beEqualTo( const1 )
+    }
+    val var2 = HOLVar( StringSymbol( "x2" ), Ti )
+    val atom1 = Atom( HOLConst( StringSymbol( "a" ), var1.exptype -> ( var2.exptype -> ( const1.exptype -> To ) ) ), var1 :: var2 :: const1 :: Nil )
+    "parse correctly an atom" in {
+      ( new MyParser( "a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))" ).getTerm() ) must beEqualTo( atom1 )
+    }
+    "parse correctly an abs" in {
+      ( new MyParser( "Abs x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))" ).getTerm() ) must beEqualTo( HOLAbs( var1, atom1 ) )
+    }
+    val var3 = Atom( HOLVar( StringSymbol( "x3" ), To ) )
+    "parse correctly a formula variable" in {
+      ( new MyParser( "x3: o" ).getTerm() ) must beLike { case x: Formula => ok }
+    }
+    "parse correctly a formula constant" in {
+      ( new MyParser( "c: o" ).getTerm() ) must beLike { case x: Formula => ok }
+    }
+    val f1 = Function( HOLConst( StringSymbol( "f" ), Ti -> Ti ), HOLConst( StringSymbol( "a" ), Ti ) :: Nil )
+    "parse correctly a function" in {
+      ( new MyParser( "f(a:i):i" ) ).getTerm must beEqualTo( f1 )
+    }
+    val f2 = Function( HOLVar( StringSymbol( "x" ), Ti -> Ti ), HOLConst( StringSymbol( "a" ), Ti ) :: Nil )
+    "parse correctly a function variable 1" in {
+      val term = ( new MyParser( "x(a:i):i" ) ).getTerm
+      term must beEqualTo( f2 )
+    }
+    val and1 = And( atom1, var3 )
+    "parse correctly an and" in {
+      ( new MyParser( "And a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o" ).getTerm() ) must beEqualTo( and1 )
+    }
+    val or1 = Or( atom1, var3 )
+    "parse correctly an or" in {
+      ( new MyParser( "Or a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o" ).getTerm() ) must beEqualTo( or1 )
+    }
+    val imp1 = Imp( atom1, var3 )
+    "parse correctly an imp" in {
+      ( new MyParser( "Imp a(x1: (i -> (i -> i)), x2: i, c1: (i -> i)) x3: o" ).getTerm() ) must beEqualTo( imp1 )
+    }
+    val neg1 = Neg( atom1 )
+    "parse correctly an neg" in {
+      ( new MyParser( "Neg a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))" ).getTerm() ) must beEqualTo( neg1 )
+    }
+    val ex1 = ExVar( var1, atom1 )
+    "parse correctly an exists" in {
+      ( new MyParser( "Exists x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))" ).getTerm() ) must beEqualTo( ex1 )
+    }
+    val all1 = AllVar( var1, atom1 )
+    "parse correctly a forall" in {
+      ( new MyParser( "Forall x1: (i -> (i -> i)) a(x1: (i -> (i -> i)), x2: i, c1: (i -> i))" ).getTerm() ) must beEqualTo( all1 )
+    }
+    val str = """p(x_10:i,m(x_3:i,m(m(p(x_4:i,one:i):i,p(x_5:i,one:i):i):i):i):i):i"""
+    "parse correctly a complex term" in {
+      ( new MyParser( str ).getTerm() ) must not( throwAn[Exception] )
+    }
+  }
+
 }

--- a/src/test/scala/at/logic/parsing/language/tptp/TPTPHOLExporterTest.scala
+++ b/src/test/scala/at/logic/parsing/language/tptp/TPTPHOLExporterTest.scala
@@ -11,17 +11,17 @@ import at.logic.calculi.lk.base.FSequent
 class TPTPHOLExporterTest extends SpecificationWithJUnit {
   "Export to TPTP thf" should {
     "handle atoms correctly" in {
-      val x = HOLVar("x", Ti -> To)
-      val y = HOLVar("y", To)
-      val c = HOLConst("c", Ti)
+      val x = HOLVar( "x", Ti -> To )
+      val y = HOLVar( "y", To )
+      val c = HOLConst( "c", Ti )
 
-      val ax = Atom(x, List(c))
-      val ay = Atom(y)
+      val ax = Atom( x, List( c ) )
+      val ay = Atom( y )
 
-      println(TPTPHOLExporter(List(FSequent(Nil, List(ax,ay)))))
+      println( TPTPHOLExporter( List( FSequent( Nil, List( ax, ay ) ) ) ) )
 
-      println(TPTPHOLExporter(List(FSequent(List(ax), Nil),
-                                   FSequent(Nil, List(ay)))))
+      println( TPTPHOLExporter( List( FSequent( List( ax ), Nil ),
+        FSequent( Nil, List( ay ) ) ) ) )
       ok
     }
   }

--- a/src/test/scala/at/logic/parsing/language/xml/HOLTermExporterTest.scala
+++ b/src/test/scala/at/logic/parsing/language/xml/HOLTermExporterTest.scala
@@ -17,96 +17,89 @@ import at.logic.language.hol._
 import at.logic.calculi.lk._
 import at.logic.calculi.lk.base._
 import java.util.zip.GZIPInputStream
-import java.io.{FileReader, FileInputStream, InputStreamReader}
+import java.io.{ FileReader, FileInputStream, InputStreamReader }
 import java.io.File.separator
 import at.logic.parsing.language.xml._
 import scala.xml.Utility.trim
 import at.logic.language.lambda.types._
 import at.logic.language.lambda.symbols.StringSymbol
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class HOLTermExporterTest extends SpecificationWithJUnit {
-  
-  val exporter = new HOLTermExporter{}
+
+  val exporter = new HOLTermExporter {}
   // helper to create 0-ary predicate constants
   def pc( sym: String ) = Atom( HOLConst( sym, To ) )
-  
+
   "HOLExpressionExporter" should {
     "export correctly a constant c" in {
-      exporter.exportTerm(HOLConst("c", "i")) must beEqualTo(<constant symbol="c"/>)
+      exporter.exportTerm( HOLConst( "c", "i" ) ) must beEqualTo( <constant symbol="c"/> )
     }
     "export correctly a term g(c)" in {
-      trim(exporter.exportTerm(HOLApp(HOLConst("g",Ti -> Ti), HOLConst("c", "i")))) must beEqualTo(<function symbol="g"><constant symbol="c"/></function>)
+      trim( exporter.exportTerm( HOLApp( HOLConst( "g", Ti -> Ti ), HOLConst( "c", "i" ) ) ) ) must beEqualTo( <function symbol="g"><constant symbol="c"/></function> )
     }
     "export correctly a variable x" in {
-      trim(exporter.exportTerm(HOLVar("x", Ti))) must beEqualTo (<variable symbol="x"></variable>)
+      trim( exporter.exportTerm( HOLVar( "x", Ti ) ) ) must beEqualTo( <variable symbol="x"></variable> )
     }
     "export correctly a term f(x,c)" in {
-      trim(exporter.exportTerm(
-        Function(HOLConst("f", Ti -> (Ti -> Ti)),
-          List(HOLVar(StringSymbol("x"), Ti), HOLConst("c", Ti))))) must beEqualTo (
-        <function symbol="f"><variable symbol="x"/><constant symbol="c"/></function>
-      )
+      trim( exporter.exportTerm(
+        Function( HOLConst( "f", Ti -> ( Ti -> Ti ) ),
+          List( HOLVar( StringSymbol( "x" ), Ti ), HOLConst( "c", Ti ) ) ) ) ) must beEqualTo(
+        <function symbol="f"><variable symbol="x"/><constant symbol="c"/></function> )
     }
     "export correctly an atom formula P(f(x,c),y)" in {
-      trim(exporter.exportTerm(Atom(HOLConst("P",Ti -> (Ti -> To)), List(
-        Function(HOLConst("f", Ti -> (Ti -> Ti)),
-          List(HOLVar("x", Ti), HOLConst("c", Ti))),
-        HOLVar("y", Ti))))) must beEqualTo (trim(
+      trim( exporter.exportTerm( Atom( HOLConst( "P", Ti -> ( Ti -> To ) ), List(
+        Function( HOLConst( "f", Ti -> ( Ti -> Ti ) ),
+          List( HOLVar( "x", Ti ), HOLConst( "c", Ti ) ) ),
+        HOLVar( "y", Ti ) ) ) ) ) must beEqualTo( trim(
         <constantatomformula symbol="P">
           <function symbol="f">
             <variable symbol="x"/>
             <constant symbol="c"/>
           </function>
           <variable symbol="y"/>
-        </constantatomformula>
-      ))
+        </constantatomformula> ) )
     }
     "export correctly a conjunction of atoms P and Q" in {
-      trim(exporter.exportTerm(And(pc("P"), pc("Q")))) must beEqualTo (trim(
+      trim( exporter.exportTerm( And( pc( "P" ), pc( "Q" ) ) ) ) must beEqualTo( trim(
         <conjunctiveformula type="and">
-         <constantatomformula symbol="P"/>
-         <constantatomformula symbol="Q"/>
-        </conjunctiveformula>
-      ))
+          <constantatomformula symbol="P"/>
+          <constantatomformula symbol="Q"/>
+        </conjunctiveformula> ) )
     }
     "export correctly a quantified formula (exists x) x = x" in {
-      trim(exporter.exportTerm(ExVar(HOLVar("x", Ti), Equation(HOLVar("x", Ti), HOLVar("x", Ti))))) must beEqualTo (trim(
+      trim( exporter.exportTerm( ExVar( HOLVar( "x", Ti ), Equation( HOLVar( "x", Ti ), HOLVar( "x", Ti ) ) ) ) ) must beEqualTo( trim(
         <quantifiedformula type="exists">
           <variable symbol="x"/>
           <constantatomformula symbol="=">
             <variable symbol="x"/>
             <variable symbol="x"/>
           </constantatomformula>
-        </quantifiedformula>
-      ))
+        </quantifiedformula> ) )
     }
     "export correctly a second-order variable X" in {
-      trim(exporter.exportTerm(HOLVar("X", Ti -> To))) must beEqualTo (trim(
-        <secondordervariable symbol="X"/>
-      ))
+      trim( exporter.exportTerm( HOLVar( "X", Ti -> To ) ) ) must beEqualTo( trim(
+        <secondordervariable symbol="X"/> ) )
     }
     "export correctly a variable atom formula X(c)" in {
-      trim(exporter.exportTerm(Atom(HOLVar("X",Ti -> To), HOLConst("c", Ti)::Nil))) must beEqualTo (trim(
+      trim( exporter.exportTerm( Atom( HOLVar( "X", Ti -> To ), HOLConst( "c", Ti ) :: Nil ) ) ) must beEqualTo( trim(
         <variableatomformula>
           <secondordervariable symbol="X"/>
           <constant symbol="c"/>
-        </variableatomformula>
-      ))
+        </variableatomformula> ) )
     }
     "export correctly a second-order quantified formula (all Z)Z(c)" in {
-      trim(exporter.exportTerm(AllVar(HOLVar("Z", Ti -> To), Atom(HOLVar("Z", Ti -> To), HOLConst("c", "i")::Nil)))) must beEqualTo (trim(
+      trim( exporter.exportTerm( AllVar( HOLVar( "Z", Ti -> To ), Atom( HOLVar( "Z", Ti -> To ), HOLConst( "c", "i" ) :: Nil ) ) ) ) must beEqualTo( trim(
         <secondorderquantifiedformula type="all">
           <secondordervariable symbol="Z"/>
           <variableatomformula>
             <secondordervariable symbol="Z"/>
             <constant symbol="c"/>
           </variableatomformula>
-        </secondorderquantifiedformula>
-      ))
+        </secondorderquantifiedformula> ) )
     }
     "export correctly a LambdaExpression lambda x . P(x)" in {
-      trim(exporter.exportTerm(HOLAbs(HOLVar("x", Ti), Atom(HOLConst("P", Ti -> To), HOLVar("x", Ti)::Nil)))) must beEqualTo (trim(
+      trim( exporter.exportTerm( HOLAbs( HOLVar( "x", Ti ), Atom( HOLConst( "P", Ti -> To ), HOLVar( "x", Ti ) :: Nil ) ) ) ) must beEqualTo( trim(
         <lambdasubstitution>
           <variablelist>
             <variable symbol="x"/>
@@ -114,12 +107,11 @@ class HOLTermExporterTest extends SpecificationWithJUnit {
           <constantatomformula symbol="P">
             <variable symbol="x"/>
           </constantatomformula>
-        </lambdasubstitution>
-      ))
+        </lambdasubstitution> ) )
     }
     "export correctly a LambdaExpression lambda x,y. R(x,y)" in {
-      trim(exporter.exportTerm(HOLAbs(HOLVar("x", Ti), HOLAbs(HOLVar("y", Ti),
-        Atom(HOLConst("R", Ti -> (Ti -> To)), List(HOLVar("x", Ti), HOLVar("y", Ti))))))) must beEqualTo (trim(
+      trim( exporter.exportTerm( HOLAbs( HOLVar( "x", Ti ), HOLAbs( HOLVar( "y", Ti ),
+        Atom( HOLConst( "R", Ti -> ( Ti -> To ) ), List( HOLVar( "x", Ti ), HOLVar( "y", Ti ) ) ) ) ) ) ) must beEqualTo( trim(
         <lambdasubstitution>
           <variablelist>
             <variable symbol="x"/>
@@ -129,19 +121,17 @@ class HOLTermExporterTest extends SpecificationWithJUnit {
             <variable symbol="x"/>
             <variable symbol="y"/>
           </constantatomformula>
-        </lambdasubstitution>
-      ))
+        </lambdasubstitution> ) )
     }
     "export correctly a defined set \\cap(X, Y)" in {
-      trim(exporter.exportTerm(HOLApp(
-        HOLApp(HOLConst( "\\cap",(Ti -> To) -> ((Ti -> To) -> (Ti -> To))),
-               HOLVar("X", Ti -> To )),
-        HOLVar( "Y", Ti -> To )))) must beEqualTo (trim(
+      trim( exporter.exportTerm( HOLApp(
+        HOLApp( HOLConst( "\\cap", ( Ti -> To ) -> ( ( Ti -> To ) -> ( Ti -> To ) ) ),
+          HOLVar( "X", Ti -> To ) ),
+        HOLVar( "Y", Ti -> To ) ) ) ) must beEqualTo( trim(
         <definedset symbol="\cap" definition="\cap">
           <secondordervariable symbol="X"/>
           <secondordervariable symbol="Y"/>
-        </definedset>
-      ))
+        </definedset> ) )
     }
     // definedsetformula is not supported yet
     /*"export correctly a defined set formula \\cup(X,Y)(c)" in {
@@ -193,4 +183,3 @@ class HOLTermExporterTest extends SpecificationWithJUnit {
     }*/
   }
 }
-    

--- a/src/test/scala/at/logic/parsing/language/xml/XMLParserTest.scala
+++ b/src/test/scala/at/logic/parsing/language/xml/XMLParserTest.scala
@@ -2,7 +2,7 @@
 package at.logic.parsing.language.xml
 
 import at.logic.calculi.lk._
-import at.logic.calculi.lk.base.{Sequent,FSequent,beSyntacticMultisetEqual}
+import at.logic.calculi.lk.base.{ Sequent, FSequent, beSyntacticMultisetEqual }
 import at.logic.calculi.occurrences.factory
 import at.logic.language.hol._
 import at.logic.language.lambda.types._
@@ -11,7 +11,7 @@ import at.logic.parsing.readers.XMLReaders._
 import com.sun.org.apache.xml.internal.resolver.CatalogManager
 import com.sun.org.apache.xml.internal.resolver.tools.CatalogResolver
 import java.io.File.separator
-import java.io.{FileInputStream,InputStreamReader,ByteArrayInputStream}
+import java.io.{ FileInputStream, InputStreamReader, ByteArrayInputStream }
 import java.util.zip.GZIPInputStream
 import org.junit.runner.RunWith
 import org.specs2.matcher.Expectable
@@ -20,201 +20,192 @@ import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import org.xml.sax.ErrorHandler
 import org.xml.sax.helpers.XMLReaderFactory
-import scala.io.{BufferedSource,Source}
+import scala.io.{ BufferedSource, Source }
 import scala.xml.SAXParseException
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class XMLParserTest extends SpecificationWithJUnit {
 
-  implicit def fo2occ(f:HOLFormula) = factory.createFormulaOccurrence(f, Nil)
-  implicit def fseq2seq(s : FSequent) = Sequent(s._1 map fo2occ, s._2 map fo2occ  )
+  implicit def fo2occ( f: HOLFormula ) = factory.createFormulaOccurrence( f, Nil )
+  implicit def fseq2seq( s: FSequent ) = Sequent( s._1 map fo2occ, s._2 map fo2occ )
   // helper to create 0-ary predicate constants
-  def pc( sym: String ) = fo2occ(pcf(sym))
+  def pc( sym: String ) = fo2occ( pcf( sym ) )
   def pcf( sym: String ) = Atom( HOLConst( sym, To ), List() )
 
   "XMLParser" should {
     "parse correctly a constant c" in {
-      (new NodeReader(<constant symbol="c"/>) with XMLTermParser).getTerm() must beEqualTo(
-        HOLConst("c", Ti)
-        )
+      ( new NodeReader( <constant symbol="c"/> ) with XMLTermParser ).getTerm() must beEqualTo(
+        HOLConst( "c", Ti ) )
     }
     "parse correctly a constant c from a StringReader" in {
-      (new XMLReader (new BufferedSource (new ByteArrayInputStream("<constant symbol=\"c\"/>".getBytes("UTF8"))).reader) with XMLTermParser).getTerm() must beEqualTo (HOLConst("c", "i"))
+      ( new XMLReader( new BufferedSource( new ByteArrayInputStream( "<constant symbol=\"c\"/>".getBytes( "UTF8" ) ) ).reader ) with XMLTermParser ).getTerm() must beEqualTo( HOLConst( "c", "i" ) )
     }
     "parse correctly a term g(c)" in {
-      (new NodeReader(<function symbol="g">
-                        <constant symbol="c"/>
-                      </function>) with XMLTermParser).getTerm() must beEqualTo(
-                    HOLApp(HOLConst("g",Ti -> Ti), HOLConst("c", Ti))
-                )
+      ( new NodeReader( <function symbol="g">
+                          <constant symbol="c"/>
+                        </function> ) with XMLTermParser ).getTerm() must beEqualTo(
+        HOLApp( HOLConst( "g", Ti -> Ti ), HOLConst( "c", Ti ) ) )
     }
     "parse correctly a variable x" in {
-      (new NodeReader(<variable symbol="x"></variable>) with XMLTermParser).getTerm() must beEqualTo (
-        HOLVar("x", Ti))
+      ( new NodeReader( <variable symbol="x"></variable> ) with XMLTermParser ).getTerm() must beEqualTo(
+        HOLVar( "x", Ti ) )
 
     }
     "parse correctly a variablelist x,y,z" in {
-      (new NodeReader(<variablelist>
-                        <variable symbol="x"/>
-                        <variable symbol="y"/>
-                        <variable symbol="z"/>
-                      </variablelist>) with XMLVariableListParser).getVariableList() must beEqualTo (
-                    HOLVar("x", Ti)::HOLVar("y", Ti)::HOLVar("z", Ti)::Nil
-                  )
+      ( new NodeReader( <variablelist>
+                          <variable symbol="x"/>
+                          <variable symbol="y"/>
+                          <variable symbol="z"/>
+                        </variablelist> ) with XMLVariableListParser ).getVariableList() must beEqualTo(
+        HOLVar( "x", Ti ) :: HOLVar( "y", Ti ) :: HOLVar( "z", Ti ) :: Nil )
     }
     "parse correctly a term f(x,c)" in {
-      (new NodeReader(<function symbol="f">
-                        <variable symbol="x"/>
-                        <constant symbol="c"/>
-                      </function>) with XMLTermParser).getTerm() must beEqualTo (
-                    Function(HOLConst("f", Ti -> (Ti -> Ti)),
-                         HOLVar("x", Ti)::HOLConst("c", Ti)::Nil)
-                )
-    }
-    "parse correctly an atom formula P(f(x,c),y)" in {
-      (new NodeReader(<constantatomformula symbol="P">
-                        <function symbol="f">
+      ( new NodeReader( <function symbol="f">
                           <variable symbol="x"/>
                           <constant symbol="c"/>
-                        </function>
-                        <variable symbol="y"/>
-                      </constantatomformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                      Atom(HOLConst("P", Ti -> (Ti -> To)),
-                        Function(HOLConst("f", Ti -> (Ti -> Ti)),
-                           HOLVar("x", Ti)::HOLConst("c", Ti)::Nil)
-                         ::HOLVar("y", Ti)::Nil))
+                        </function> ) with XMLTermParser ).getTerm() must beEqualTo(
+        Function( HOLConst( "f", Ti -> ( Ti -> Ti ) ),
+          HOLVar( "x", Ti ) :: HOLConst( "c", Ti ) :: Nil ) )
+    }
+    "parse correctly an atom formula P(f(x,c),y)" in {
+      ( new NodeReader( <constantatomformula symbol="P">
+                          <function symbol="f">
+                            <variable symbol="x"/>
+                            <constant symbol="c"/>
+                          </function>
+                          <variable symbol="y"/>
+                        </constantatomformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        Atom( HOLConst( "P", Ti -> ( Ti -> To ) ),
+          Function( HOLConst( "f", Ti -> ( Ti -> Ti ) ),
+            HOLVar( "x", Ti ) :: HOLConst( "c", Ti ) :: Nil )
+            :: HOLVar( "y", Ti ) :: Nil ) )
 
     }
     "parse correctly a conjunction of atoms P and Q" in {
-      (new NodeReader(<conjunctiveformula type="and">
-                        <constantatomformula symbol="P"/>
-                        <constantatomformula symbol="Q"/>
-                      </conjunctiveformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    And(pcf("P"), pcf("Q")))
+      ( new NodeReader( <conjunctiveformula type="and">
+                          <constantatomformula symbol="P"/>
+                          <constantatomformula symbol="Q"/>
+                        </conjunctiveformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        And( pcf( "P" ), pcf( "Q" ) ) )
     }
     "parse correctly a quantified formula (exists x) x = x" in {
-      (new NodeReader(<quantifiedformula type="exists">
-                        <variable symbol="x"/>
-                        <constantatomformula symbol="=">
+      ( new NodeReader( <quantifiedformula type="exists">
                           <variable symbol="x"/>
-                          <variable symbol="x"/>
-                        </constantatomformula>
-                      </quantifiedformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    ExVar(HOLVar("x", Ti),
-                      Equation(HOLVar("x", Ti), HOLVar("x", Ti)))
-                )
+                          <constantatomformula symbol="=">
+                            <variable symbol="x"/>
+                            <variable symbol="x"/>
+                          </constantatomformula>
+                        </quantifiedformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        ExVar( HOLVar( "x", Ti ),
+          Equation( HOLVar( "x", Ti ), HOLVar( "x", Ti ) ) ) )
     }
     "parse correctly a second-order variable X" in {
-      (new NodeReader(<secondordervariable symbol="X"/>) with XMLSetTermParser).getSetTerm() must
-      beEqualTo(HOLVar("X", Ti -> To))
+      ( new NodeReader( <secondordervariable symbol="X"/> ) with XMLSetTermParser ).getSetTerm() must
+        beEqualTo( HOLVar( "X", Ti -> To ) )
     }
     "parse correctly a variable atom formula X(c)" in {
-      (new NodeReader(<variableatomformula>
-                        <secondordervariable symbol="X"/>
-                        <constant symbol="c"/>
-                      </variableatomformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    Atom(HOLVar("X", Ti -> To),
-                         HOLConst("c", Ti)::Nil)
-                  )
+      ( new NodeReader( <variableatomformula>
+                          <secondordervariable symbol="X"/>
+                          <constant symbol="c"/>
+                        </variableatomformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        Atom( HOLVar( "X", Ti -> To ),
+          HOLConst( "c", Ti ) :: Nil ) )
     }
     "parse correctly a second-order quantified formula (all Z)Z(c)" in {
-      (new NodeReader(<secondorderquantifiedformula type="all">
-                        <secondordervariable symbol="Z"/>
-                        <variableatomformula>
+      ( new NodeReader( <secondorderquantifiedformula type="all">
                           <secondordervariable symbol="Z"/>
-                          <constant symbol="c"/>
-                        </variableatomformula>
-                      </secondorderquantifiedformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    AllVar(HOLVar("Z", Ti -> To),
-                      Atom(HOLVar("Z", Ti -> To),
-                           HOLConst("c", Ti)::Nil))
-                  )
+                          <variableatomformula>
+                            <secondordervariable symbol="Z"/>
+                            <constant symbol="c"/>
+                          </variableatomformula>
+                        </secondorderquantifiedformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        AllVar( HOLVar( "Z", Ti -> To ),
+          Atom( HOLVar( "Z", Ti -> To ),
+            HOLConst( "c", Ti ) :: Nil ) ) )
     }
     "parse correctly a LambdaExpression lambda x . P(x)" in {
-      (new NodeReader(<lambdasubstitution>
-                        <variablelist>
-                          <variable symbol="x"/>
-                        </variablelist>
-                        <constantatomformula symbol="P">
-                          <variable symbol="x"/>
-                        </constantatomformula>
-                      </lambdasubstitution>) with XMLSetTermParser).getSetTerm() must beEqualTo(
-                  HOLAbs(HOLVar("x", Ti), Atom(HOLConst("P", Ti -> To), HOLVar("x", Ti)::Nil)))
+      ( new NodeReader( <lambdasubstitution>
+                          <variablelist>
+                            <variable symbol="x"/>
+                          </variablelist>
+                          <constantatomformula symbol="P">
+                            <variable symbol="x"/>
+                          </constantatomformula>
+                        </lambdasubstitution> ) with XMLSetTermParser ).getSetTerm() must beEqualTo(
+        HOLAbs( HOLVar( "x", Ti ), Atom( HOLConst( "P", Ti -> To ), HOLVar( "x", Ti ) :: Nil ) ) )
     }
     "parse correctly a LambdaExpression lambda x,y. R(x,y)" in {
-      (new NodeReader(<lambdasubstitution>
-                        <variablelist>
-                          <variable symbol="x"/>
-                          <variable symbol="y"/>
-                        </variablelist>
-                        <constantatomformula symbol="R">
-                          <variable symbol="x"/>
-                          <variable symbol="y"/>
-                        </constantatomformula>
-                      </lambdasubstitution>) with XMLSetTermParser).getSetTerm() must beEqualTo(
-                    HOLAbs(HOLVar("x", Ti),
-                      HOLAbs(HOLVar("y", Ti),
-                         Atom(HOLConst("R", Ti -> (Ti -> To)), HOLVar("x", Ti)::HOLVar("y", Ti)::Nil)))
-      )
+      ( new NodeReader( <lambdasubstitution>
+                          <variablelist>
+                            <variable symbol="x"/>
+                            <variable symbol="y"/>
+                          </variablelist>
+                          <constantatomformula symbol="R">
+                            <variable symbol="x"/>
+                            <variable symbol="y"/>
+                          </constantatomformula>
+                        </lambdasubstitution> ) with XMLSetTermParser ).getSetTerm() must beEqualTo(
+        HOLAbs( HOLVar( "x", Ti ),
+          HOLAbs( HOLVar( "y", Ti ),
+            Atom( HOLConst( "R", Ti -> ( Ti -> To ) ), HOLVar( "x", Ti ) :: HOLVar( "y", Ti ) :: Nil ) ) ) )
     }
     "parse correctly a defined set \\cap(X, Y)" in {
-      (new NodeReader(<definedset symbol="\cap" definition="\cap">
-                        <secondordervariable symbol="X"/>
-                        <secondordervariable symbol="Y"/>
-                      </definedset>) with XMLSetTermParser).getSetTerm() must beEqualTo(
-                    Function( HOLConst( "\\cap",
-                                    (Ti -> To) -> ((Ti -> To) -> (Ti -> To))),
-                          HOLVar( "X", Ti -> To )::
-                          HOLVar( "Y", Ti -> To )::Nil)
-                  )
-    }
-    "parse correctly a defined set formula \\cup(X,Y)(c)" in {
-      (new NodeReader(<definedsetformula>
-                        <definedset symbol="\cup" definition="\cup">
+      ( new NodeReader( <definedset symbol="\cap" definition="\cap">
                           <secondordervariable symbol="X"/>
                           <secondordervariable symbol="Y"/>
-                        </definedset>
-                        <constant symbol="c"/>
-                      </definedsetformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    HOLApp(Function( HOLConst( "\\cup",
-                                        (Ti -> To) -> ((Ti -> To) -> (Ti -> To))),
-                               HOLVar( "X", Ti -> To )::
-                               HOLVar( "Y", Ti -> To )::Nil),
-                        HOLConst( "c", Ti ) ) )
+                        </definedset> ) with XMLSetTermParser ).getSetTerm() must beEqualTo(
+        Function( HOLConst( "\\cap",
+          ( Ti -> To ) -> ( ( Ti -> To ) -> ( Ti -> To ) ) ),
+          HOLVar( "X", Ti -> To ) ::
+            HOLVar( "Y", Ti -> To ) :: Nil ) )
+    }
+    "parse correctly a defined set formula \\cup(X,Y)(c)" in {
+      ( new NodeReader( <definedsetformula>
+                          <definedset symbol="\cup" definition="\cup">
+                            <secondordervariable symbol="X"/>
+                            <secondordervariable symbol="Y"/>
+                          </definedset>
+                          <constant symbol="c"/>
+                        </definedsetformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        HOLApp( Function( HOLConst( "\\cup",
+          ( Ti -> To ) -> ( ( Ti -> To ) -> ( Ti -> To ) ) ),
+          HOLVar( "X", Ti -> To ) ::
+            HOLVar( "Y", Ti -> To ) :: Nil ),
+          HOLConst( "c", Ti ) ) )
     }
     "parse correctly a complex sentence (all X)(all Y)(all z) X(z) impl \\cup(X,Y)(z)" in {
-      (new NodeReader(<secondorderquantifiedformula type="all">
-                        <secondordervariable symbol="X"/>
-                        <secondorderquantifiedformula type="all">
-                          <secondordervariable symbol="Y"/>
-                          <quantifiedformula type="all">
-                            <variable symbol="z"/>
-                            <conjunctiveformula type="impl">
-                              <variableatomformula>
-                                <secondordervariable symbol="X"/>
-                                <variable symbol="z"/>
-                              </variableatomformula>
-                              <definedsetformula>
-                                <definedset symbol="\cup" definition="\cup">
+      ( new NodeReader( <secondorderquantifiedformula type="all">
+                          <secondordervariable symbol="X"/>
+                          <secondorderquantifiedformula type="all">
+                            <secondordervariable symbol="Y"/>
+                            <quantifiedformula type="all">
+                              <variable symbol="z"/>
+                              <conjunctiveformula type="impl">
+                                <variableatomformula>
                                   <secondordervariable symbol="X"/>
-                                  <secondordervariable symbol="Y"/>
-                                </definedset>
-                                <variable symbol="z"/>
-                              </definedsetformula>
-                            </conjunctiveformula>
-                          </quantifiedformula>
-                        </secondorderquantifiedformula>
-                      </secondorderquantifiedformula>) with XMLFormulaParser).getFormula() must beEqualTo(
-                    AllVar( HOLVar( "X", Ti -> To ),
-                      AllVar( HOLVar( "Y", Ti -> To),
-                        AllVar( HOLVar( "z", Ti),
-                          Imp( Atom( HOLVar("X", Ti -> To), HOLVar( "z", Ti )::Nil ),
-                            (HOLApp(Function( HOLConst( "\\cup",
-                                               (Ti -> To) -> ((Ti -> To) -> (Ti -> To))),
-                                       HOLVar( "X", Ti -> To )::
-                                       HOLVar( "Y", Ti -> To )::Nil),
-                                HOLVar( "z", Ti ) ) ).asInstanceOf[HOLFormula] ) ) ) //TODO: cast should not be neccessary
-                  ))
+                                  <variable symbol="z"/>
+                                </variableatomformula>
+                                <definedsetformula>
+                                  <definedset symbol="\cup" definition="\cup">
+                                    <secondordervariable symbol="X"/>
+                                    <secondordervariable symbol="Y"/>
+                                  </definedset>
+                                  <variable symbol="z"/>
+                                </definedsetformula>
+                              </conjunctiveformula>
+                            </quantifiedformula>
+                          </secondorderquantifiedformula>
+                        </secondorderquantifiedformula> ) with XMLFormulaParser ).getFormula() must beEqualTo(
+        AllVar( HOLVar( "X", Ti -> To ),
+          AllVar( HOLVar( "Y", Ti -> To ),
+            AllVar( HOLVar( "z", Ti ),
+              Imp( Atom( HOLVar( "X", Ti -> To ), HOLVar( "z", Ti ) :: Nil ),
+                ( HOLApp( Function( HOLConst( "\\cup",
+                  ( Ti -> To ) -> ( ( Ti -> To ) -> ( Ti -> To ) ) ),
+                  HOLVar( "X", Ti -> To ) ::
+                    HOLVar( "Y", Ti -> To ) :: Nil ),
+                  HOLVar( "z", Ti ) ) ).asInstanceOf[HOLFormula] ) ) ) //TODO: cast should not be neccessary
+                  ) )
     }
     // BUG in specs2
     /*
@@ -233,258 +224,258 @@ class XMLParserTest extends SpecificationWithJUnit {
                             pc("C")::pc("D")::Nil))
     }*/
     "parse correctly an axiom P :- P" in {
-      (new NodeReader(<proof symbol="p" calculus="LK">
-                        <rule type="axiom">
-                          <sequent>
-                            <formulalist>
-                              <constantatomformula symbol="P"/>
-                            </formulalist>
-                            <formulalist>
-                              <constantatomformula symbol="P"/>
-                            </formulalist>
-                          </sequent>
-                        </rule>
-                      </proof>) with XMLProofParser).getProof() must
-                      beLike{ case Axiom( conc )
-                               if conc.syntacticMultisetEquals( Sequent( pc("P")::Nil,
-                                                                pc("P")::Nil ))
-                              => ok }
+      ( new NodeReader( <proof symbol="p" calculus="LK">
+                          <rule type="axiom">
+                            <sequent>
+                              <formulalist>
+                                <constantatomformula symbol="P"/>
+                              </formulalist>
+                              <formulalist>
+                                <constantatomformula symbol="P"/>
+                              </formulalist>
+                            </sequent>
+                          </rule>
+                        </proof> ) with XMLProofParser ).getProof() must
+        beLike {
+          case Axiom( conc ) if conc.syntacticMultisetEquals( Sequent( pc( "P" ) :: Nil,
+            pc( "P" ) :: Nil ) ) => ok
+        }
     }
     "parse a permutation parameter (1 2)" in {
-      XMLUtils.permStringToCycles("(1 2)", 2) must
-        beDeeplyEqual( (2::1::Nil).map(i => i - 1).toArray )
+      XMLUtils.permStringToCycles( "(1 2)", 2 ) must
+        beDeeplyEqual( ( 2 :: 1 :: Nil ).map( i => i - 1 ).toArray )
     }
     "parse a permutation parameter (1 2 3)(5 6)" in {
-      XMLUtils.permStringToCycles("(1 2 3)(5 6)", 6) must
-        beDeeplyEqual( (3::1::2::4::6::5::Nil).map( i => i - 1 ).toArray )
+      XMLUtils.permStringToCycles( "(1 2 3)(5 6)", 6 ) must
+        beDeeplyEqual( ( 3 :: 1 :: 2 :: 4 :: 6 :: 5 :: Nil ).map( i => i - 1 ).toArray )
     }
     "parse a permutation parameter (3 4 5) of size 5" in {
-      XMLUtils.permStringToCycles("(3 4 5)", 5) must
-        beDeeplyEqual( (1::2::5::3::4::Nil).map( i => i - 1 ).toArray )
+      XMLUtils.permStringToCycles( "(3 4 5)", 5 ) must
+        beDeeplyEqual( ( 1 :: 2 :: 5 :: 3 :: 4 :: Nil ).map( i => i - 1 ).toArray )
     }
     "parse a permutation rule" in {
-      (new NodeReader(<rule type="permr" param="(1 3)(2)">
-                        <sequent>
-                          <formulalist>
-                            <constantatomformula symbol="A"/>
-                            <constantatomformula symbol="B"/>
-                          </formulalist>
-                          <formulalist>
-                            <constantatomformula symbol="E"/>
-                            <constantatomformula symbol="D"/>
-                            <constantatomformula symbol="C"/>
-                          </formulalist>
-                        </sequent>
-                        <rule type="axiom">
-                          <sequent>
-                          <formulalist>
-                            <constantatomformula symbol="A"/>
-                            <constantatomformula symbol="B"/>
-                          </formulalist>
-                          <formulalist>
-                            <constantatomformula symbol="C"/>
-                            <constantatomformula symbol="D"/>
-                            <constantatomformula symbol="E"/>
-                          </formulalist>
-                        </sequent>
-                      </rule>
-                    </rule>) with XMLProofParser).getProof() must
-                    beLike{ case Axiom( conc ) => ok }
-    }
-    "parse a simple contraction rule" in {
-      ((new NodeReader(<rule type="contrl" param="2">
-                        <sequent>
-                          <formulalist>
-                            <constantatomformula symbol="A"/>
-                          </formulalist>
-                          <formulalist/>
-                        </sequent>
-                        <rule type="axiom">
+      ( new NodeReader( <rule type="permr" param="(1 3)(2)">
                           <sequent>
                             <formulalist>
-                              <constantatomformula symbol="A"/>
-                              <constantatomformula symbol="A"/>
-                            </formulalist>
-                            <formulalist/>
-                          </sequent>
-                        </rule>
-                      </rule>) with XMLProofParser).getProof().root) must beSyntacticMultisetEqual(
-                      Sequent(pc("A")::Nil, Nil))
-    }
-    "parse an involved contraction rule" in {
-      (new NodeReader(<rule type="contrl" param="2,1,2,1,1">
-                        <sequent>
-                          <formulalist>
-                            <constantatomformula symbol="A"/>
-                            <constantatomformula symbol="B"/>
-                            <constantatomformula symbol="C"/>
-                            <constantatomformula symbol="C"/>
-                            <constantatomformula symbol="D"/>
-                          </formulalist>
-                          <formulalist/>
-                        </sequent>
-                        <rule type="axiom">
-                          <sequent>
-                            <formulalist>
-                              <constantatomformula symbol="A"/>
                               <constantatomformula symbol="A"/>
                               <constantatomformula symbol="B"/>
+                            </formulalist>
+                            <formulalist>
+                              <constantatomformula symbol="E"/>
+                              <constantatomformula symbol="D"/>
                               <constantatomformula symbol="C"/>
+                            </formulalist>
+                          </sequent>
+                          <rule type="axiom">
+                            <sequent>
+                              <formulalist>
+                                <constantatomformula symbol="A"/>
+                                <constantatomformula symbol="B"/>
+                              </formulalist>
+                              <formulalist>
+                                <constantatomformula symbol="C"/>
+                                <constantatomformula symbol="D"/>
+                                <constantatomformula symbol="E"/>
+                              </formulalist>
+                            </sequent>
+                          </rule>
+                        </rule> ) with XMLProofParser ).getProof() must
+        beLike { case Axiom( conc ) => ok }
+    }
+    "parse a simple contraction rule" in {
+      ( ( new NodeReader( <rule type="contrl" param="2">
+                            <sequent>
+                              <formulalist>
+                                <constantatomformula symbol="A"/>
+                              </formulalist>
+                              <formulalist/>
+                            </sequent>
+                            <rule type="axiom">
+                              <sequent>
+                                <formulalist>
+                                  <constantatomformula symbol="A"/>
+                                  <constantatomformula symbol="A"/>
+                                </formulalist>
+                                <formulalist/>
+                              </sequent>
+                            </rule>
+                          </rule> ) with XMLProofParser ).getProof().root ) must beSyntacticMultisetEqual(
+        Sequent( pc( "A" ) :: Nil, Nil ) )
+    }
+    "parse an involved contraction rule" in {
+      ( new NodeReader( <rule type="contrl" param="2,1,2,1,1">
+                          <sequent>
+                            <formulalist>
+                              <constantatomformula symbol="A"/>
+                              <constantatomformula symbol="B"/>
                               <constantatomformula symbol="C"/>
                               <constantatomformula symbol="C"/>
                               <constantatomformula symbol="D"/>
                             </formulalist>
                             <formulalist/>
                           </sequent>
-                        </rule>
-                      </rule>) with XMLProofParser).getProof().root must beSyntacticMultisetEqual(
-                      Sequent(pc("A")::pc("B")::pc("C")::pc("C")::pc("D")::Nil, Nil))
+                          <rule type="axiom">
+                            <sequent>
+                              <formulalist>
+                                <constantatomformula symbol="A"/>
+                                <constantatomformula symbol="A"/>
+                                <constantatomformula symbol="B"/>
+                                <constantatomformula symbol="C"/>
+                                <constantatomformula symbol="C"/>
+                                <constantatomformula symbol="C"/>
+                                <constantatomformula symbol="D"/>
+                              </formulalist>
+                              <formulalist/>
+                            </sequent>
+                          </rule>
+                        </rule> ) with XMLProofParser ).getProof().root must beSyntacticMultisetEqual(
+        Sequent( pc( "A" ) :: pc( "B" ) :: pc( "C" ) :: pc( "C" ) :: pc( "D" ) :: Nil, Nil ) )
     }
     "parse correctly a proof of A, A :- A and A" in {
-      (new NodeReader(<proof symbol="p" calculus="LK">
-                        <rule type="andr">
-                          <sequent>
-                            <formulalist>
-                              <constantatomformula symbol="A"/>
-                              <constantatomformula symbol="A"/>
-                            </formulalist>
-                            <formulalist>
-                              <conjunctiveformula type="and">
-                                <constantatomformula symbol="A"/>
-                                <constantatomformula symbol="A"/>
-                              </conjunctiveformula>
-                            </formulalist>
-                          </sequent>
-                          <rule type="axiom">
+      ( new NodeReader( <proof symbol="p" calculus="LK">
+                          <rule type="andr">
                             <sequent>
                               <formulalist>
                                 <constantatomformula symbol="A"/>
-                              </formulalist>
-                              <formulalist>
-                                <constantatomformula symbol="A"/>
-                              </formulalist>
-                            </sequent>
-                          </rule>
-                          <rule type="axiom">
-                            <sequent>
-                              <formulalist>
                                 <constantatomformula symbol="A"/>
                               </formulalist>
                               <formulalist>
-                                <constantatomformula symbol="A"/>
-                              </formulalist>
-                            </sequent>
-                          </rule>
-                        </rule>
-                      </proof>) with XMLProofParser).getProof().root must beSyntacticMultisetEqual(
-                      Sequent(pc("A")::pc("A")::Nil, fo2occ(And(pcf("A"), pcf("A")))::Nil))
-    }
-    "parse correctly a proof with one orr1 rule and one permr rule" in {
-      (new NodeReader(<proof symbol="p" calculus="LK">
-                        <rule type="orr1">
-                          <sequent>
-                            <formulalist/>
-                            <formulalist>
-                              <constantatomformula symbol="B"/>
-                              <conjunctiveformula type="or">
-                                <constantatomformula symbol="A"/>
-                                <constantatomformula symbol="C"/>
-                              </conjunctiveformula>
-                            </formulalist>
-                          </sequent>
-                          <rule type="permr" param="(1 2)">
-                            <sequent>
-                              <formulalist/>
-                              <formulalist>
-                                <constantatomformula symbol="B"/>
-                                <constantatomformula symbol="A"/>
+                                <conjunctiveformula type="and">
+                                  <constantatomformula symbol="A"/>
+                                  <constantatomformula symbol="A"/>
+                                </conjunctiveformula>
                               </formulalist>
                             </sequent>
                             <rule type="axiom">
                               <sequent>
-                                <formulalist/>
                                 <formulalist>
                                   <constantatomformula symbol="A"/>
-                                  <constantatomformula symbol="B"/>
+                                </formulalist>
+                                <formulalist>
+                                  <constantatomformula symbol="A"/>
+                                </formulalist>
+                              </sequent>
+                            </rule>
+                            <rule type="axiom">
+                              <sequent>
+                                <formulalist>
+                                  <constantatomformula symbol="A"/>
+                                </formulalist>
+                                <formulalist>
+                                  <constantatomformula symbol="A"/>
                                 </formulalist>
                               </sequent>
                             </rule>
                           </rule>
-                        </rule>
-                      </proof>) with XMLProofParser).getProof().root must beSyntacticMultisetEqual(
-                    Sequent(Nil, pc("B")::fo2occ(Or(pcf("A"), pcf("C")))::Nil))
+                        </proof> ) with XMLProofParser ).getProof().root must beSyntacticMultisetEqual(
+        Sequent( pc( "A" ) :: pc( "A" ) :: Nil, fo2occ( And( pcf( "A" ), pcf( "A" ) ) ) :: Nil ) )
+    }
+    "parse correctly a proof with one orr1 rule and one permr rule" in {
+      ( new NodeReader( <proof symbol="p" calculus="LK">
+                          <rule type="orr1">
+                            <sequent>
+                              <formulalist/>
+                              <formulalist>
+                                <constantatomformula symbol="B"/>
+                                <conjunctiveformula type="or">
+                                  <constantatomformula symbol="A"/>
+                                  <constantatomformula symbol="C"/>
+                                </conjunctiveformula>
+                              </formulalist>
+                            </sequent>
+                            <rule type="permr" param="(1 2)">
+                              <sequent>
+                                <formulalist/>
+                                <formulalist>
+                                  <constantatomformula symbol="B"/>
+                                  <constantatomformula symbol="A"/>
+                                </formulalist>
+                              </sequent>
+                              <rule type="axiom">
+                                <sequent>
+                                  <formulalist/>
+                                  <formulalist>
+                                    <constantatomformula symbol="A"/>
+                                    <constantatomformula symbol="B"/>
+                                  </formulalist>
+                                </sequent>
+                              </rule>
+                            </rule>
+                          </rule>
+                        </proof> ) with XMLProofParser ).getProof().root must beSyntacticMultisetEqual(
+        Sequent( Nil, pc( "B" ) :: fo2occ( Or( pcf( "A" ), pcf( "C" ) ) ) :: Nil ) )
     }
     "parse correctly a proof with some permutations, an andr, and an orr1 rule from a file" in {
-      val proofs =  (new XMLReader(Source.fromURL(getClass.getResource("/xml/test3.xml")).reader) with XMLProofDatabaseParser).getProofDatabase().proofs
+      val proofs = ( new XMLReader( Source.fromURL( getClass.getResource( "/xml/test3.xml" ) ).reader ) with XMLProofDatabaseParser ).getProofDatabase().proofs
 
-      proofs.size must beEqualTo(1)
+      proofs.size must beEqualTo( 1 )
       proofs.head._2.root must beSyntacticMultisetEqual(
-        Sequent(Nil, pc("A")::pc("C")::pc("F")::
-                     fo2occ(And(pcf("B"), pcf("E")))::
-                     fo2occ(Or(pcf("D"), pcf("G")))::Nil))
+        Sequent( Nil, pc( "A" ) :: pc( "C" ) :: pc( "F" ) ::
+          fo2occ( And( pcf( "B" ), pcf( "E" ) ) ) ::
+          fo2occ( Or( pcf( "D" ), pcf( "G" ) ) ) :: Nil ) )
     }
     "parse correctly a proof with two orr1 rules and two permr rules from a file" in {
-      val proofs =  (new XMLReader(Source.fromURL(getClass.getResource("/xml/test2.xml")).reader) with XMLProofDatabaseParser).getProofDatabase().proofs
+      val proofs = ( new XMLReader( Source.fromURL( getClass.getResource( "/xml/test2.xml" ) ).reader ) with XMLProofDatabaseParser ).getProofDatabase().proofs
 
-      proofs.size must beEqualTo(1)
+      proofs.size must beEqualTo( 1 )
       proofs.head._2.root must beSyntacticMultisetEqual(
-                        Sequent(Nil, fo2occ(Or(pcf("A"), pcf("C")))::
-                        fo2occ(Or(pcf("B"), pcf("D")))::Nil))
+        Sequent( Nil, fo2occ( Or( pcf( "A" ), pcf( "C" ) ) ) ::
+          fo2occ( Or( pcf( "B" ), pcf( "D" ) ) ) :: Nil ) )
     }
     "parse correctly an involved proof from a file" in {
-      val proofs =  (new XMLReader(Source.fromURL(getClass.getResource("/xml/test1.xml")).reader) with XMLProofDatabaseParser).getProofDatabase().proofs
+      val proofs = ( new XMLReader( Source.fromURL( getClass.getResource( "/xml/test1.xml" ) ).reader ) with XMLProofDatabaseParser ).getProofDatabase().proofs
 
-      val X = HOLVar( "X" , Ti -> To )
-      val t = HOLConst( "t" , Ti)
-      val s = HOLConst( "s" , Ti)
-      val r = HOLConst( "r" , Ti)
-      val f = HOLConst( "f" , Ti -> Ti)
-      val x = HOLVar( "x" , Ti )
-      val Rs = HOLConst( "R", Ti -> (Ti -> To) )
-      val f1 = AllVar( X, And( Atom( X, t::Nil ), Neg( Atom( X, s::Nil ) ) ) )
-      val f2 = And( Imp( Atom( Rs, r::t::Nil ), Atom( Rs, r::HOLApp( f, t )::Nil ) ),
-                    ExVar( x, And( Atom( Rs, x::s::Nil ), Neg( Atom( Rs, x::HOLApp( f, s )::Nil ) ) ) ) )
+      val X = HOLVar( "X", Ti -> To )
+      val t = HOLConst( "t", Ti )
+      val s = HOLConst( "s", Ti )
+      val r = HOLConst( "r", Ti )
+      val f = HOLConst( "f", Ti -> Ti )
+      val x = HOLVar( "x", Ti )
+      val Rs = HOLConst( "R", Ti -> ( Ti -> To ) )
+      val f1 = AllVar( X, And( Atom( X, t :: Nil ), Neg( Atom( X, s :: Nil ) ) ) )
+      val f2 = And( Imp( Atom( Rs, r :: t :: Nil ), Atom( Rs, r :: HOLApp( f, t ) :: Nil ) ),
+        ExVar( x, And( Atom( Rs, x :: s :: Nil ), Neg( Atom( Rs, x :: HOLApp( f, s ) :: Nil ) ) ) ) )
 
-      proofs.size must beEqualTo(1)
-      proofs.head._2.root must beSyntacticMultisetEqual( Sequent( f1::Nil, f2::Nil ) )
+      proofs.size must beEqualTo( 1 )
+      proofs.head._2.root must beSyntacticMultisetEqual( Sequent( f1 :: Nil, f2 :: Nil ) )
     }
 
     "parse correctly a sequentlist from a gzipped file" in {
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("xml" + separator + "slist.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "xml" + separator + "slist.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
 
-      proofdb.sequentLists.size must beEqualTo(1)
+      proofdb.sequentLists.size must beEqualTo( 1 )
     }
     "parse correctly a proof with definitions from a gzipped file" in {
-      val proofdb = (new XMLReader(new InputStreamReader(new GZIPInputStream(getClass.getClassLoader.getResourceAsStream("xml" + separator + "prime1-0.xml.gz")))) with XMLProofDatabaseParser).getProofDatabase()
+      val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "xml" + separator + "prime1-0.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
 
-      proofdb.Definitions.size must beEqualTo(21)
+      proofdb.Definitions.size must beEqualTo( 21 )
     }
     "validate and detect bogus XML document using local DTD" in {
       val reader = XMLReaderFactory.createXMLReader()
-      reader.setEntityResolver(new CatalogResolver(new CatalogManager()))
-      reader.setFeature("http://xml.org/sax/features/validation", true)
-      reader.setErrorHandler(new DemoErrorHandler())
+      reader.setEntityResolver( new CatalogResolver( new CatalogManager() ) )
+      reader.setFeature( "http://xml.org/sax/features/validation", true )
+      reader.setErrorHandler( new DemoErrorHandler() )
       //reader.parse("target" + separator + "test-classes" + separator + "xml" + separator + "bogus.xml") must throwA[SAXParseException]
-      reader.parse(getClass.getResource("/xml/bogus.xml").toString) must throwA[SAXParseException]
+      reader.parse( getClass.getResource( "/xml/bogus.xml" ).toString ) must throwA[SAXParseException]
     }
     "validate XML document using local DTD" in {
       val reader = XMLReaderFactory.createXMLReader()
-      reader.setEntityResolver(new CatalogResolver(new CatalogManager()))
-      reader.setFeature("http://xml.org/sax/features/validation", true)
-      reader.setErrorHandler(new DemoErrorHandler())
+      reader.setEntityResolver( new CatalogResolver( new CatalogManager() ) )
+      reader.setFeature( "http://xml.org/sax/features/validation", true )
+      reader.setErrorHandler( new DemoErrorHandler() )
       //reader.parse("target" + separator + "test-classes" + separator + "xml" + separator + "test1.xml") must not (throwA[SAXParseException])
-      reader.parse(getClass.getResource("/xml/test1.xml").toString) must not (throwA[SAXParseException])
+      reader.parse( getClass.getResource( "/xml/test1.xml" ).toString ) must not( throwA[SAXParseException] )
     }
   }
 }
 
-case class beDeeplyEqual[T](a: Array[T]) extends Matcher[Array[T]]() {
-  def apply[S <: Array[T]](v: Expectable[S]) = result( v.value.deep.equals(a.deep), "successful deepEquals", v.value.deep.toString + " not deepEquals " + a.deep.toString,v )
+case class beDeeplyEqual[T]( a: Array[T] ) extends Matcher[Array[T]]() {
+  def apply[S <: Array[T]]( v: Expectable[S] ) = result( v.value.deep.equals( a.deep ), "successful deepEquals", v.value.deep.toString + " not deepEquals " + a.deep.toString, v )
 }
 
 class DemoErrorHandler extends ErrorHandler {
-    override def warning(ex: SAXParseException): Unit = { }
-    override def error(ex: SAXParseException): Unit = { println("Error", ex); throw (ex)}
-    override def fatalError(ex: SAXParseException): Unit = println("Fatal Error", ex)
+  override def warning( ex: SAXParseException ): Unit = {}
+  override def error( ex: SAXParseException ): Unit = { println( "Error", ex ); throw ( ex ) }
+  override def fatalError( ex: SAXParseException ): Unit = println( "Fatal Error", ex )
 }
 

--- a/src/test/scala/at/logic/provers/atp/ProverTest.scala
+++ b/src/test/scala/at/logic/provers/atp/ProverTest.scala
@@ -9,7 +9,7 @@ import org.specs2.runner.JUnitRunner
 
 import at.logic.language.fol._
 import at.logic.parsing.language.simple.SimpleFOLParser
-import at.logic.provers.atp.commands.base.{BranchCommand, Command}
+import at.logic.provers.atp.commands.base.{ BranchCommand, Command }
 import at.logic.provers.atp.commands.logical.DeterministicAndCommand
 import at.logic.algorithms.unification.fol.FOLUnificationAlgorithm
 import at.logic.calculi.lk.base.FSequent
@@ -22,126 +22,126 @@ import at.logic.parsing.readers.StringReader
 import at.logic.calculi.resolution._
 import at.logic.algorithms.subsumption.StillmanSubsumptionAlgorithmFOL
 
-private class MyParser(str: String) extends StringReader(str) with SimpleResolutionParserFOL
+private class MyParser( str: String ) extends StringReader( str ) with SimpleResolutionParserFOL
 private object MyProver extends Prover[Clause]
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ProverTest extends SpecificationWithJUnit {
 
-  def parse(str:String) : FOLFormula = (new StringReader(str) with SimpleFOLParser getTerm).asInstanceOf[FOLFormula]
+  def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 
   // stream based on macro command that optimize the stack usage
-  def stream1a: Stream[Command[Clause]] = Stream.cons(SequentsMacroCommand[Clause](
+  def stream1a: Stream[Command[Clause]] = Stream.cons( SequentsMacroCommand[Clause](
     SimpleRefinementGetCommand[Clause],
-    List(VariantsCommand,ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand(FOLUnificationAlgorithm),FactorCommand(FOLUnificationAlgorithm),
-      SimpleForwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-      SimpleBackwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-      InsertResolventCommand[Clause]),
-    RefutationReachedCommand[Clause]), stream1a)
-  def streama: Stream[Command[Clause]] = Stream.cons(SetTargetClause(FSequent(List(),List())), Stream.cons(SearchForEmptyClauseCommand[Clause], stream1a))
+    List( VariantsCommand, ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand( FOLUnificationAlgorithm ), FactorCommand( FOLUnificationAlgorithm ),
+      SimpleForwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+      SimpleBackwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+      InsertResolventCommand[Clause] ),
+    RefutationReachedCommand[Clause] ), stream1a )
+  def streama: Stream[Command[Clause]] = Stream.cons( SetTargetClause( FSequent( List(), List() ) ), Stream.cons( SearchForEmptyClauseCommand[Clause], stream1a ) )
 
   // stream based on normal stack usage using configurations normally - may explode stack if branching too fast
-  def stream1b:  Stream[Command[Clause]] = Stream.cons(SimpleRefinementGetCommand[Clause],
-    Stream.cons(VariantsCommand,
-    Stream.cons(BranchCommand[Clause](List(
-      Stream(ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand(FOLUnificationAlgorithm), FactorCommand(FOLUnificationAlgorithm)),
-      Stream(ParamodulationCommand(FOLUnificationAlgorithm)))),
-    Stream.cons(SimpleForwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(SimpleBackwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(InsertResolventCommand[Clause],
-    Stream.cons(RefutationReachedCommand[Clause], stream1b)))))))
-  def streamb: Stream[Command[Clause]] = Stream.cons(SetTargetClause(FSequent(List(),List())), Stream.cons(SearchForEmptyClauseCommand[Clause], stream1b))
+  def stream1b: Stream[Command[Clause]] = Stream.cons( SimpleRefinementGetCommand[Clause],
+    Stream.cons( VariantsCommand,
+      Stream.cons( BranchCommand[Clause]( List(
+        Stream( ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand( FOLUnificationAlgorithm ), FactorCommand( FOLUnificationAlgorithm ) ),
+        Stream( ParamodulationCommand( FOLUnificationAlgorithm ) ) ) ),
+        Stream.cons( SimpleForwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+          Stream.cons( SimpleBackwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+            Stream.cons( InsertResolventCommand[Clause],
+              Stream.cons( RefutationReachedCommand[Clause], stream1b ) ) ) ) ) ) )
+  def streamb: Stream[Command[Clause]] = Stream.cons( SetTargetClause( FSequent( List(), List() ) ), Stream.cons( SearchForEmptyClauseCommand[Clause], stream1b ) )
 
   // stream based on "deterministic and command" that allows branching in a sequential way, which can be used in user interfaces as the other commands might
   // ask for an input, put it in the stack and will not necessarily act on it immediately.
-  def stream1c: Stream[Command[Clause]] =  Stream.cons(SimpleRefinementGetCommand[Clause],
-    Stream.cons(VariantsCommand,
-    Stream.cons(DeterministicAndCommand[Clause]((
-      List(ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand(FOLUnificationAlgorithm), FactorCommand(FOLUnificationAlgorithm)),
-      List(ParamodulationCommand(FOLUnificationAlgorithm)))),
-    Stream.cons(SimpleForwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(SimpleBackwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(InsertResolventCommand[Clause],
-    Stream.cons(RefutationReachedCommand[Clause], stream1c)))))))
-  def streamc: Stream[Command[Clause]] = Stream.cons(SetTargetClause(FSequent(List(),List())), Stream.cons(SearchForEmptyClauseCommand[Clause], stream1c))
+  def stream1c: Stream[Command[Clause]] = Stream.cons( SimpleRefinementGetCommand[Clause],
+    Stream.cons( VariantsCommand,
+      Stream.cons( DeterministicAndCommand[Clause]( (
+        List( ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand( FOLUnificationAlgorithm ), FactorCommand( FOLUnificationAlgorithm ) ),
+        List( ParamodulationCommand( FOLUnificationAlgorithm ) ) ) ),
+        Stream.cons( SimpleForwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+          Stream.cons( SimpleBackwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+            Stream.cons( InsertResolventCommand[Clause],
+              Stream.cons( RefutationReachedCommand[Clause], stream1c ) ) ) ) ) ) )
+  def streamc: Stream[Command[Clause]] = Stream.cons( SetTargetClause( FSequent( List(), List() ) ), Stream.cons( SearchForEmptyClauseCommand[Clause], stream1c ) )
 
-  def stream1d: Stream[Command[Clause]] =  Stream.cons(SimpleRefinementGetCommand[Clause],
-    Stream.cons(VariantsCommand,
-    Stream.cons(DeterministicAndCommand[Clause]((
-      List(ClauseFactorCommand(FOLUnificationAlgorithm), ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand(FOLUnificationAlgorithm)),
-      List(ParamodulationCommand(FOLUnificationAlgorithm)))),
-    Stream.cons(InsertResolventCommand[Clause],
-    Stream.cons(RefutationReachedCommand[Clause], stream1d)))))
-  def streamd(f: FSequent): Stream[Command[Clause]] = Stream.cons(SetTargetClause(f), Stream.cons(SearchForEmptyClauseCommand[Clause], stream1d))
-  def stream1e: Stream[Command[Clause]] =  Stream.cons(SimpleRefinementGetCommand[Clause],
-    Stream.cons(VariantsCommand,
-    Stream.cons(ClauseFactorCommand(FOLUnificationAlgorithm),
-    Stream.cons(DeterministicAndCommand[Clause]((
-      List(ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand(FOLUnificationAlgorithm)),
-      List(ParamodulationCommand(FOLUnificationAlgorithm)))),
-    Stream.cons(SimpleForwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(SimpleBackwardSubsumptionCommand[Clause](StillmanSubsumptionAlgorithmFOL),
-    Stream.cons(InsertResolventCommand[Clause],
-    Stream.cons(RefutationReachedCommand[Clause], stream1e))))))))
-  def streame: Stream[Command[Clause]] = Stream.cons(SetTargetClause(FSequent(List(),List())), Stream.cons(SearchForEmptyClauseCommand[Clause], stream1e))
+  def stream1d: Stream[Command[Clause]] = Stream.cons( SimpleRefinementGetCommand[Clause],
+    Stream.cons( VariantsCommand,
+      Stream.cons( DeterministicAndCommand[Clause]( (
+        List( ClauseFactorCommand( FOLUnificationAlgorithm ), ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand( FOLUnificationAlgorithm ) ),
+        List( ParamodulationCommand( FOLUnificationAlgorithm ) ) ) ),
+        Stream.cons( InsertResolventCommand[Clause],
+          Stream.cons( RefutationReachedCommand[Clause], stream1d ) ) ) ) )
+  def streamd( f: FSequent ): Stream[Command[Clause]] = Stream.cons( SetTargetClause( f ), Stream.cons( SearchForEmptyClauseCommand[Clause], stream1d ) )
+  def stream1e: Stream[Command[Clause]] = Stream.cons( SimpleRefinementGetCommand[Clause],
+    Stream.cons( VariantsCommand,
+      Stream.cons( ClauseFactorCommand( FOLUnificationAlgorithm ),
+        Stream.cons( DeterministicAndCommand[Clause]( (
+          List( ApplyOnAllPolarizedLiteralPairsCommand[Clause], ResolveCommand( FOLUnificationAlgorithm ) ),
+          List( ParamodulationCommand( FOLUnificationAlgorithm ) ) ) ),
+          Stream.cons( SimpleForwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+            Stream.cons( SimpleBackwardSubsumptionCommand[Clause]( StillmanSubsumptionAlgorithmFOL ),
+              Stream.cons( InsertResolventCommand[Clause],
+                Stream.cons( RefutationReachedCommand[Clause], stream1e ) ) ) ) ) ) ) )
+  def streame: Stream[Command[Clause]] = Stream.cons( SetTargetClause( FSequent( List(), List() ) ), Stream.cons( SearchForEmptyClauseCommand[Clause], stream1e ) )
 
-  def getRefutation(str: String): Boolean = MyProver.refute(Stream.cons(SetClausesCommand(new MyParser(str).getClauseList), streamc)).next must beLike {
-      case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root =^ Clause(List(),List()) => ok
-      case _ => ko
-    }
-   def getRefutationd(str: String, f: FSequent): Boolean = MyProver.refute(Stream.cons(SetClausesCommand(new MyParser(str).getClauseList), streamd(f))).next must beLike {
-      case Some(_) => ok
-      case _ => ko
-    }
-   def getRefutatione(str: String): Boolean = MyProver.refute(Stream.cons(SetClausesCommand(new MyParser(str).getClauseList), streame)).next must beLike {
-      case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root =^ Clause(List(),List()) => ok
-      case _ => ko
-    }
+  def getRefutation( str: String ): Boolean = MyProver.refute( Stream.cons( SetClausesCommand( new MyParser( str ).getClauseList ), streamc ) ).next must beLike {
+    case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root =^ Clause( List(), List() ) => ok
+    case _ => ko
+  }
+  def getRefutationd( str: String, f: FSequent ): Boolean = MyProver.refute( Stream.cons( SetClausesCommand( new MyParser( str ).getClauseList ), streamd( f ) ) ).next must beLike {
+    case Some( _ ) => ok
+    case _         => ko
+  }
+  def getRefutatione( str: String ): Boolean = MyProver.refute( Stream.cons( SetClausesCommand( new MyParser( str ).getClauseList ), streame ) ).next must beLike {
+    case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root =^ Clause( List(), List() ) => ok
+    case _ => ko
+  }
 
   "Prover" should {
-    
+
     "in case it has only one clause return it if it is the empty clause" in {
-      getRefutation(".") must beTrue    
+      getRefutation( "." ) must beTrue
     }
     "in case it has an empty clause set return None" in {
-      MyProver.refute(Stream.cons(SetClausesCommand(new MyParser("").getClauseList), streamc)).next must beLike {
+      MyProver.refute( Stream.cons( SetClausesCommand( new MyParser( "" ).getClauseList ), streamc ) ).next must beLike {
         case None => ok
-        case _ => ko
+        case _    => ko
       }
     }
     "in case it has only one clause return None if it is not the empty clause" in {
-      MyProver.refute(Stream.cons(SetClausesCommand(new MyParser("P(x).").getClauseList), streamc)).next must beLike {
+      MyProver.refute( Stream.cons( SetClausesCommand( new MyParser( "P(x)." ).getClauseList ), streamc ) ).next must beLike {
         case None => ok
-        case _ => ko
+        case _    => ko
       }
     }
     "refute the following clauses" in {
       "p(a). -p(x) | p(f(x)). -p(f(f(a)))" in {
-        getRefutation("P(a). -P(x) | P(f(x)). -P(f(f(a))).") must beTrue
+        getRefutation( "P(a). -P(x) | P(f(x)). -P(f(f(a)))." ) must beTrue
       }
       "requiring factoring" in {
         "p(a). -p(y) | -p(x) | p(f(y)) | p(f(x)). -p(f(f(a)))" in {
-          getRefutation("P(a). -P(y) | -P(x) | P(f(y)) | P(f(x)). -P(f(f(a))).") must beTrue
+          getRefutation( "P(a). -P(y) | -P(x) | P(f(y)) | P(f(x)). -P(f(f(a)))." ) must beTrue
         }
       }
       "requiring factoring with inefficient factoring" in {
         "=(x,x). -=(a,a) | -=(a,a)." in {
-          getRefutatione("=(x,x). -=(a,a) | -=(a,a).") must beTrue
+          getRefutatione( "=(x,x). -=(a,a) | -=(a,a)." ) must beTrue
         }
       }
       "requiring factoring with inefficient factoring (2)" in {
         "=(x,x). -=(x,x) | -=(x,x)." in {
-          getRefutatione("=(x,x). -=(x,x) | -=(x,x).") must beTrue
+          getRefutatione( "=(x,x). -=(x,x) | -=(x,x)." ) must beTrue
         }
       }
       "requiring non-terminal factoring" in {
         "P(a). -P(x) | P(f(x)) | P(f(y)). -P(f(f(a))). -P(f(f(b)))." in {
-          getRefutation("P(a). -P(x) | P(f(x)) | P(f(y)). -P(f(f(a))). -P(f(f(b))).") must beTrue
+          getRefutation( "P(a). -P(x) | P(f(x)) | P(f(y)). -P(f(f(a))). -P(f(f(b)))." ) must beTrue
         }
       }
-     "requiring paramodulation" in {
+      "requiring paramodulation" in {
         "P(a). -P(b). =(a,b)." in {
-          getRefutation("P(a). -P(b). =(a,b).") must beTrue
+          getRefutation( "P(a). -P(b). =(a,b)." ) must beTrue
         }
       }
       /*"non-trivial example" in {
@@ -150,33 +150,33 @@ class ProverTest extends SpecificationWithJUnit {
     }
     "obtain the conclusion from premises" in {
       "-P(x) | P(f(x)) from -P(x) | -P(y) | P(f(x)). P(x). " in {
-        val var1 = FOLVar("x")
-        val fun1 = Function("f", var1::Nil)
-        val lit1 = Atom("P",var1::Nil)
-        val lit2 = Atom("P",fun1::Nil)
-        val init = new MyParser("-P(x) | -P(y) | P(f(x)). P(x).").getClauseList
-        val target = FSequent(List(lit1),List(lit2))
-        SearchDerivation(init, target) must beLike {
-          case Some(_) => ok
-          case _ => ko
+        val var1 = FOLVar( "x" )
+        val fun1 = Function( "f", var1 :: Nil )
+        val lit1 = Atom( "P", var1 :: Nil )
+        val lit2 = Atom( "P", fun1 :: Nil )
+        val init = new MyParser( "-P(x) | -P(y) | P(f(x)). P(x)." ).getClauseList
+        val target = FSequent( List( lit1 ), List( lit2 ) )
+        SearchDerivation( init, target ) must beLike {
+          case Some( _ ) => ok
+          case _         => ko
         }
       }
       "P(f(a)) from -P(x) | -P(y) | P(f(x)) | P(f(y)). P(a)." in {
-        val pfa = parse("P(f(a))")
-        val init = new MyParser(" -P(x) | -P(y) | P(f(x)) | P(f(y)). P(a).").getClauseList
-        val target = FSequent(List(),List(pfa))
-        SearchDerivation(init, target) must beLike {
-          case Some(_) => ok
-          case _ => ko
+        val pfa = parse( "P(f(a))" )
+        val init = new MyParser( " -P(x) | -P(y) | P(f(x)) | P(f(y)). P(a)." ).getClauseList
+        val target = FSequent( List(), List( pfa ) )
+        SearchDerivation( init, target ) must beLike {
+          case Some( _ ) => ok
+          case _         => ko
         }
       }
       "-P(f(a)) from -=(z,z) | -P(x) | -P(y) | P(f(x)) | P(f(y)). -P(f(f(a))). =(x,x)." in {
-        val pfa = parse("P(f(a))")
-        val init = new MyParser("-=(z,z) | -P(x) | -P(y) | P(f(x)) | P(f(y)). -P(f(f(a))). =(x,x).").getClauseList
-        val target = FSequent(List(pfa),List())
-        SearchDerivation(init, target) must beLike {
-          case Some(_) => ok
-          case _ => ko
+        val pfa = parse( "P(f(a))" )
+        val init = new MyParser( "-=(z,z) | -P(x) | -P(y) | P(f(x)) | P(f(y)). -P(f(f(a))). =(x,x)." ).getClauseList
+        val target = FSequent( List( pfa ), List() )
+        SearchDerivation( init, target ) must beLike {
+          case Some( _ ) => ok
+          case _         => ko
         }
       }
     }
@@ -186,7 +186,7 @@ class ProverTest extends SpecificationWithJUnit {
     // test with a different target clause than the empty
   }
 }
-  /*
+/*
   " Prover with unit refinement" should {
     "refute the following clauses" in {
       "p(a). -p(x) | p(f(x)). -p(f(f(a)))" in {

--- a/src/test/scala/at/logic/provers/atp/RobinsonTest.scala
+++ b/src/test/scala/at/logic/provers/atp/RobinsonTest.scala
@@ -9,26 +9,25 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.calculi.lk.base.FSequent
 import at.logic.parsing.language.prover9.Prover9TermParser.parseFormula
-import at.logic.calculi.resolution.{ResolutionProof, Clause}
+import at.logic.calculi.resolution.{ ResolutionProof, Clause }
 import at.logic.provers.atp.commands.sequents._
 import at.logic.provers.atp.commands.base._
 
-
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class RobinsonTest extends SpecificationWithJUnit {
-  "ParamodulationCommand" should  {
+  "ParamodulationCommand" should {
     "applying paramodulation command on two res.proofs" in {
       "failing replay command for prime0" in {
 
-        val fseq1 = new MyParser("-=(ladr2(ladr8, x), ladr6) | =(x, ladr7(ladr6, ladr5(ladr1(ladr8, x), ladr8))).").getClauseList
+        val fseq1 = new MyParser( "-=(ladr2(ladr8, x), ladr6) | =(x, ladr7(ladr6, ladr5(ladr1(ladr8, x), ladr8)))." ).getClauseList
 
-        val fseq2 = new MyParser("=(ladr7(ladr6, ladr5(y, ladr8)), ladr5(y, ladr8)).").getClauseList
+        val fseq2 = new MyParser( "=(ladr7(ladr6, ladr5(y, ladr8)), ladr5(y, ladr8))." ).getClauseList
 
-        val f2flipseq2 = new MyParser("=(ladr5(y, ladr8), ladr7(ladr6, ladr5(y, ladr8))).").getClauseList
-        val rrp1 = InitialClause(fseq1.head.antecedent.map(f => f.asInstanceOf[FOLFormula]), fseq1.head.succedent.map(f => f.asInstanceOf[FOLFormula]))
-        val rrp2 = InitialClause(Nil,  fseq2.head.succedent.map(f => f.asInstanceOf[FOLFormula]))
-        val rrp2flip = InitialClause(Nil,  f2flipseq2.head.succedent.map(f => f.asInstanceOf[FOLFormula]))
-        val l_para = ParamodulationCommand(FOLUnificationAlgorithm).apply(rrp1, rrp2)// must exist(c => {println(c); false})
+        val f2flipseq2 = new MyParser( "=(ladr5(y, ladr8), ladr7(ladr6, ladr5(y, ladr8)))." ).getClauseList
+        val rrp1 = InitialClause( fseq1.head.antecedent.map( f => f.asInstanceOf[FOLFormula] ), fseq1.head.succedent.map( f => f.asInstanceOf[FOLFormula] ) )
+        val rrp2 = InitialClause( Nil, fseq2.head.succedent.map( f => f.asInstanceOf[FOLFormula] ) )
+        val rrp2flip = InitialClause( Nil, f2flipseq2.head.succedent.map( f => f.asInstanceOf[FOLFormula] ) )
+        val l_para = ParamodulationCommand( FOLUnificationAlgorithm ).apply( rrp1, rrp2 ) // must exist(c => {println(c); false})
         ok
       }
     }

--- a/src/test/scala/at/logic/provers/maxsat/MaxSATTest.scala
+++ b/src/test/scala/at/logic/provers/maxsat/MaxSATTest.scala
@@ -11,7 +11,7 @@ import org.specs2.runner.JUnitRunner
 import at.logic.calculi.resolution._
 import at.logic.language.fol._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class MaxSATTest extends SpecificationWithJUnit {
   val box: List[FClause] = List()
 
@@ -28,41 +28,41 @@ class MaxSATTest extends SpecificationWithJUnit {
    *   -x3
    */
   object SimpleMaxSATFormula {
-    val c1 = FOLConst("c1")
-    val c2 = FOLConst("c2")
-    val c3 = FOLConst("c3")
+    val c1 = FOLConst( "c1" )
+    val c2 = FOLConst( "c2" )
+    val c3 = FOLConst( "c3" )
 
-    val x1 = Atom("X", c1 :: Nil)
-    val x2 = Atom("X", c2 :: Nil)
-    val x3 = Atom("X", c3 :: Nil)
+    val x1 = Atom( "X", c1 :: Nil )
+    val x2 = Atom( "X", c2 :: Nil )
+    val x3 = Atom( "X", c3 :: Nil )
 
-    val h1 = Or(x1, x2)
-    val h2 = Or(x2, x3)
-    val h3 = Or(Or(x1, x2), x3)
+    val h1 = Or( x1, x2 )
+    val h2 = Or( x2, x3 )
+    val h3 = Or( Or( x1, x2 ), x3 )
 
-    val s1 = (Neg(x1), 1)
-    val s2 = (Neg(x2), 1)
-    val s3 = (Neg(x3), 1)
+    val s1 = ( Neg( x1 ), 1 )
+    val s2 = ( Neg( x2 ), 1 )
+    val s3 = ( Neg( x3 ), 1 )
 
     def apply() = {
 
-      val hard = List(h1, h2, h3)
-      val soft = List(s1, s2, s3)
+      val hard = List( h1, h2, h3 )
+      val soft = List( s1, s2, s3 )
 
-      (hard, soft)
+      ( hard, soft )
     }
   }
 
   "QMaxSAT" should {
 
     "deal correctly with a simple instance" in {
-      if (!new MaxSAT(MaxSATSolver.QMaxSAT).isInstalled) skipped("qmaxsat not installed")
+      if ( !new MaxSAT( MaxSATSolver.QMaxSAT ).isInstalled ) skipped( "qmaxsat not installed" )
 
-      val (hard, soft) = SimpleMaxSATFormula()
-      (new MaxSAT(MaxSATSolver.QMaxSAT)).solvePWM(hard, soft) must beLike {
-        case Some(model) => if (model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x2) == true &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x1) == false &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x3) == false) ok
+      val ( hard, soft ) = SimpleMaxSATFormula()
+      ( new MaxSAT( MaxSATSolver.QMaxSAT ) ).solvePWM( hard, soft ) must beLike {
+        case Some( model ) => if ( model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x2 ) == true &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x1 ) == false &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x3 ) == false ) ok
         else ko
         case None => ko
       }
@@ -72,13 +72,13 @@ class MaxSATTest extends SpecificationWithJUnit {
   "ToySAT" should {
 
     "deal correctly with a simple instance" in {
-      if (!new MaxSAT(MaxSATSolver.ToySolver).isInstalled) skipped("toysolver not installed")
+      if ( !new MaxSAT( MaxSATSolver.ToySolver ).isInstalled ) skipped( "toysolver not installed" )
 
-      val (hard, soft) = SimpleMaxSATFormula()
-      (new MaxSAT(MaxSATSolver.ToySAT)).solvePWM(hard, soft) must beLike {
-        case Some(model) => if (model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x2) == true &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x1) == false &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x3) == false) ok
+      val ( hard, soft ) = SimpleMaxSATFormula()
+      ( new MaxSAT( MaxSATSolver.ToySAT ) ).solvePWM( hard, soft ) must beLike {
+        case Some( model ) => if ( model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x2 ) == true &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x1 ) == false &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x3 ) == false ) ok
         else ko
         case None => ko
       }
@@ -88,13 +88,13 @@ class MaxSATTest extends SpecificationWithJUnit {
   "ToySolver" should {
 
     "deal correctly with a simple instance" in {
-      if (!new MaxSAT(MaxSATSolver.ToySolver).isInstalled) skipped("toysolver not installed")
+      if ( !new MaxSAT( MaxSATSolver.ToySolver ).isInstalled ) skipped( "toysolver not installed" )
 
-      val (hard, soft) = SimpleMaxSATFormula()
-      (new MaxSAT(MaxSATSolver.ToySolver)).solvePWM(hard, soft) must beLike {
-        case Some(model) => if (model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x2) == true &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x1) == false &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x3) == false) ok
+      val ( hard, soft ) = SimpleMaxSATFormula()
+      ( new MaxSAT( MaxSATSolver.ToySolver ) ).solvePWM( hard, soft ) must beLike {
+        case Some( model ) => if ( model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x2 ) == true &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x1 ) == false &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x3 ) == false ) ok
         else ko
         case None => ko
       }
@@ -104,13 +104,13 @@ class MaxSATTest extends SpecificationWithJUnit {
   "MiniMaxSAT" should {
 
     "deal correctly with a simple instance" in {
-      if (!new MaxSAT(MaxSATSolver.MiniMaxSAT).isInstalled) skipped("minimaxsat not installed")
+      if ( !new MaxSAT( MaxSATSolver.MiniMaxSAT ).isInstalled ) skipped( "minimaxsat not installed" )
 
-      val (hard, soft) = SimpleMaxSATFormula()
-      (new MaxSAT(MaxSATSolver.MiniMaxSAT)).solvePWM(hard, soft) must beLike {
-        case Some(model) => if (model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x2) == true &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x1) == false &&
-          model.asInstanceOf[MapBasedInterpretation].interpret(SimpleMaxSATFormula.x3) == false) ok
+      val ( hard, soft ) = SimpleMaxSATFormula()
+      ( new MaxSAT( MaxSATSolver.MiniMaxSAT ) ).solvePWM( hard, soft ) must beLike {
+        case Some( model ) => if ( model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x2 ) == true &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x1 ) == false &&
+          model.asInstanceOf[MapBasedInterpretation].interpret( SimpleMaxSATFormula.x3 ) == false ) ok
         else ko
         case None => ko
       }

--- a/src/test/scala/at/logic/provers/minisat/MiniSATTest.scala
+++ b/src/test/scala/at/logic/provers/minisat/MiniSATTest.scala
@@ -15,11 +15,11 @@ import at.logic.calculi.resolution._
 import at.logic.language.lambda.types._
 import at.logic.calculi.lk.base.FSequent
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class MiniSATTest extends SpecificationWithJUnit {
-  val box : Set[FClause] = Set()
+  val box: Set[FClause] = Set()
 
-  args(skipAll = !(new MiniSATProver).isInstalled())
+  args( skipAll = !( new MiniSATProver ).isInstalled() )
 
   object PigeonHolePrinciple {
     // The binary relation symbol.
@@ -27,77 +27,77 @@ class MiniSATTest extends SpecificationWithJUnit {
 
     def apply( ps: Int, hs: Int ) = {
       assert( ps > 1 )
-      Imp( And( (1 to ps).map( p =>
-              Or( (1 to hs).map( h => atom(p, h) ).toList ) ).toList ),
-            Or( (1 to hs).map ( h =>
-              Or( (2 to ps).map( p =>
-                Or( ((1 to p - 1)).map( pp =>
-                  And(atom(p, h),atom(pp,h))).toList)).toList)).toList))
+      Imp( And( ( 1 to ps ).map( p =>
+        Or( ( 1 to hs ).map( h => atom( p, h ) ).toList ) ).toList ),
+        Or( ( 1 to hs ).map( h =>
+          Or( ( 2 to ps ).map( p =>
+            Or( ( ( 1 to p - 1 ) ).map( pp =>
+              And( atom( p, h ), atom( pp, h ) ) ).toList ) ).toList ) ).toList ) )
     }
 
-    def atom( p: Int, h: Int ) = Atom(rel, pigeon(p)::hole(h)::Nil)
+    def atom( p: Int, h: Int ) = Atom( rel, pigeon( p ) :: hole( h ) :: Nil )
 
-    def pigeon(i: Int) = FOLConst("p_" + i)
+    def pigeon( i: Int ) = FOLConst( "p_" + i )
 
-    def hole(i: Int) = FOLConst("h_" + i)
+    def hole( i: Int ) = FOLConst( "h_" + i )
   }
 
   "MiniSAT" should {
-      
-    val c = FOLConst("c")
-    val d = FOLConst("d")
-    val e = FOLConst("e")
-    val pc = Atom("P", c::Nil)
-    val pd = Atom("P", d::Nil)
-    val pe = Atom("P", e::Nil)
-      
-    "find a model for an atom" in {
-      val clause = FClause(Nil, pc::Nil)
-     
-      (new MiniSAT).solve( (clause::Nil) ) must beLike {
-        case Some(model) => ok
-        case None => ko
-      }
-    }
-    
-    "see that Pc and -Pc is unsat" in {
-      val c1 = FClause(Nil, pc::Nil)
-      val c2 = FClause(pc::Nil, Nil)
-      
-      (new MiniSAT).solve( (c1::c2::Nil) ) must beLike {
-        case Some(_) => ko
-        case None => ok
-      }
-    }
-    
-    "see that Pc or -Pc is valid" in {
-      (new MiniSAT).isValid( Or(pc, Neg(pc) ) ) must beTrue
-      (new MiniSATProver).isValid( new FSequent( Nil, Or(pc, Neg(pc) )::Nil) ) must beTrue
-    }
-    
-    "see that Pc is not valid" in {
-      (new MiniSAT).isValid( pc ) must beFalse
-    }
-    
-    "return a correct model" in {
-      val c1 = FClause(Nil, pc::Nil)
-      val c2 = FClause(pc::Nil, pd::Nil)
-      val c3 = FClause(pd::pe::Nil, Nil)
-      
-      (new MiniSAT).solve( (c1::c2::c3::Nil) ) must beLike {
-        case Some(model) => if (model.interpret(pe) == false) ok else ko
-        case None => ko
-      }
-      
-    }
-    
-    "deal correctly with the pigeonhole problem" in {
-      val fparams = List((2,2),(3,3),(4,4))
-      val tparams = List((2,1),(3,2),(4,3),(4,1))
-      def problem(pair: (Int,Int)) = (new MiniSAT).isValid(PigeonHolePrinciple(pair._1,pair._2))
 
-      fparams.map(problem) must_== fparams.map(x => false)
-      tparams.map(problem) must_== tparams.map(x => true)
+    val c = FOLConst( "c" )
+    val d = FOLConst( "d" )
+    val e = FOLConst( "e" )
+    val pc = Atom( "P", c :: Nil )
+    val pd = Atom( "P", d :: Nil )
+    val pe = Atom( "P", e :: Nil )
+
+    "find a model for an atom" in {
+      val clause = FClause( Nil, pc :: Nil )
+
+      ( new MiniSAT ).solve( ( clause :: Nil ) ) must beLike {
+        case Some( model ) => ok
+        case None          => ko
+      }
+    }
+
+    "see that Pc and -Pc is unsat" in {
+      val c1 = FClause( Nil, pc :: Nil )
+      val c2 = FClause( pc :: Nil, Nil )
+
+      ( new MiniSAT ).solve( ( c1 :: c2 :: Nil ) ) must beLike {
+        case Some( _ ) => ko
+        case None      => ok
+      }
+    }
+
+    "see that Pc or -Pc is valid" in {
+      ( new MiniSAT ).isValid( Or( pc, Neg( pc ) ) ) must beTrue
+      ( new MiniSATProver ).isValid( new FSequent( Nil, Or( pc, Neg( pc ) ) :: Nil ) ) must beTrue
+    }
+
+    "see that Pc is not valid" in {
+      ( new MiniSAT ).isValid( pc ) must beFalse
+    }
+
+    "return a correct model" in {
+      val c1 = FClause( Nil, pc :: Nil )
+      val c2 = FClause( pc :: Nil, pd :: Nil )
+      val c3 = FClause( pd :: pe :: Nil, Nil )
+
+      ( new MiniSAT ).solve( ( c1 :: c2 :: c3 :: Nil ) ) must beLike {
+        case Some( model ) => if ( model.interpret( pe ) == false ) ok else ko
+        case None          => ko
+      }
+
+    }
+
+    "deal correctly with the pigeonhole problem" in {
+      val fparams = List( ( 2, 2 ), ( 3, 3 ), ( 4, 4 ) )
+      val tparams = List( ( 2, 1 ), ( 3, 2 ), ( 4, 3 ), ( 4, 1 ) )
+      def problem( pair: ( Int, Int ) ) = ( new MiniSAT ).isValid( PigeonHolePrinciple( pair._1, pair._2 ) )
+
+      fparams.map( problem ) must_== fparams.map( x => false )
+      tparams.map( problem ) must_== tparams.map( x => true )
     }
   }
 }

--- a/src/test/scala/at/logic/provers/prover9/IvyToRobinsonTest.scala
+++ b/src/test/scala/at/logic/provers/prover9/IvyToRobinsonTest.scala
@@ -8,123 +8,122 @@ import org.specs2.mutable.SpecificationWithJUnit
 import at.logic.parsing.lisp
 import java.io.File.separator
 import util.parsing.input.Reader
-import lisp.{SExpressionParser}
+import lisp.{ SExpressionParser }
 
 /**
  * Test for the Ivy interface.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class IvyToRobinsonTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
   "The Ivy Parser " should {
     " parse the test files factor.ivy and factor2.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("factor.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-            val rinput = IvyToRobinson(pinput)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "factor.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+          val rinput = IvyToRobinson( pinput )
 
-          case _ =>
-            "The proof in factor.ivy must have some inferences" must beEqualTo("failed")
-        }
+        case _ =>
+          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
+      }
 
-        val result2 = SExpressionParser(tempCopyOfClasspathFile("factor2.ivy"))
-        result2 must not beEmpty
-        val proof2 = result2.head
-        proof2 match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof2, IvyParser.is_ivy_variable)
-            val rinput = IvyToRobinson(pinput)
+      val result2 = SExpressionParser( tempCopyOfClasspathFile( "factor2.ivy" ) )
+      result2 must not beEmpty
+      val proof2 = result2.head
+      proof2 match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof2, IvyParser.is_ivy_variable )
+          val rinput = IvyToRobinson( pinput )
 
-          case _ =>
-            "The proof in factor.ivy must have some inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
-
     " parse the test file manyliterals.ivy " in {
-        val result = SExpressionParser(tempCopyOfClasspathFile("manyliterals.ivy"))
-        result must not beEmpty
-        val proof = result.head
-        proof match {
-          case lisp.List(_) =>
-            val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-            val rinput = IvyToRobinson(pinput)
+      val result = SExpressionParser( tempCopyOfClasspathFile( "manyliterals.ivy" ) )
+      result must not beEmpty
+      val proof = result.head
+      proof match {
+        case lisp.List( _ ) =>
+          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+          val rinput = IvyToRobinson( pinput )
 
-          case _ =>
-            "The proof in manyliterals.ivy must have some inferences" must beEqualTo("failed")
-        }
-        ok
+        case _ =>
+          "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
+      }
+      ok
     }
 
     " parse the test file simple2.ivy " in {
-      skipped("file missing")
-        val result = SExpressionParser(tempCopyOfClasspathFile("simple2.ivy"))
+      skipped( "file missing" )
+      val result = SExpressionParser( tempCopyOfClasspathFile( "simple2.ivy" ) )
       ok
     }
   }
 
   " parse the test file prime1-0sk.ivy (clause set of the 0 instance of the prime proof) " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("prime1-0sk.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          val rinput = IvyToRobinson(pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "prime1-0sk.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        val rinput = IvyToRobinson( pinput )
 
-        case _ =>
-          "The proof in prime1-0sk.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        "The proof in prime1-0sk.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file GRA014+1.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("GRA014+1.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          val rinput = IvyToRobinson(pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "GRA014+1.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        val rinput = IvyToRobinson( pinput )
 
-        case _ =>
-          "The proof in manyliterals.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file GEO037-2.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("GEO037-2.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          val rinput = IvyToRobinson(pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "GEO037-2.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        val rinput = IvyToRobinson( pinput )
 
-        case _ =>
-          "The proof in GEO037-2.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        "The proof in GEO037-2.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 
   " parse the test file issue221.ivy " in {
-      val result = SExpressionParser(tempCopyOfClasspathFile("issue221.ivy"))
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List(_) =>
-          val pinput = IvyParser.parse(proof, IvyParser.is_ivy_variable)
-          val rinput = IvyToRobinson(pinput)
+    val result = SExpressionParser( tempCopyOfClasspathFile( "issue221.ivy" ) )
+    result must not beEmpty
+    val proof = result.head
+    proof match {
+      case lisp.List( _ ) =>
+        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
+        val rinput = IvyToRobinson( pinput )
 
-        case _ =>
-          "The proof in issue221.ivy must have some inferences" must beEqualTo("failed")
-      }
-      ok
+      case _ =>
+        "The proof in issue221.ivy must have some inferences" must beEqualTo( "failed" )
+    }
+    ok
   }
 }
 

--- a/src/test/scala/at/logic/provers/prover9/Prover9Test.scala
+++ b/src/test/scala/at/logic/provers/prover9/Prover9Test.scala
@@ -6,7 +6,7 @@ package at.logic.provers.prover9
 
 import at.logic.calculi.lk.base.FSequent
 import at.logic.calculi.occurrences.factory
-import at.logic.calculi.resolution.robinson.{Formatter, RobinsonResolutionProof}
+import at.logic.calculi.resolution.robinson.{ Formatter, RobinsonResolutionProof }
 import at.logic.language.fol._
 import at.logic.parsing.language.simple.SimpleFOLParser
 import at.logic.parsing.readers.StringReader
@@ -18,24 +18,24 @@ import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
-  def parse(str:String) : FOLFormula = (new StringReader(str) with SimpleFOLParser getTerm).asInstanceOf[FOLFormula]
+  def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 
-  implicit def fo2occ(f:FOLFormula) = factory.createFormulaOccurrence(f, Nil)
+  implicit def fo2occ( f: FOLFormula ) = factory.createFormulaOccurrence( f, Nil )
 
-  args (skipAll = !Prover9.isInstalled ())
+  args( skipAll = !Prover9.isInstalled() )
   "The Prover9 interface" should {
     "not refute { :- P; Q :- }" in {
 
-      val s1 = FSequent(Nil, List(parse("P")))
-      val t1 = FSequent(List(parse("Q")),Nil)
-      val result  : Option[RobinsonResolutionProof] = Prover9.refute( List(s1,t1) )
+      val s1 = FSequent( Nil, List( parse( "P" ) ) )
+      val t1 = FSequent( List( parse( "Q" ) ), Nil )
+      val result: Option[RobinsonResolutionProof] = Prover9.refute( List( s1, t1 ) )
       result match {
-        case Some(proof) =>
+        case Some( proof ) =>
           "" must beEqualTo( "Refutation found although clause set satisfiable!" )
 
-        case None => true must beEqualTo(true)
+        case None => true must beEqualTo( true )
       }
     }
 
@@ -43,12 +43,11 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
 
       val p = new Prover9Prover()
 
-      val s = FSequent(Nil,List(AllVar(FOLVar("x"), parse("=(x,x)"))))
+      val s = FSequent( Nil, List( AllVar( FOLVar( "x" ), parse( "=(x,x)" ) ) ) )
 
-
-      p.isValid(s) must beTrue
-    // TODO: cannot yet import proofs for arbitrary formulas
-    /*  p.getRobinsonProof (s) must beLike {
+      p.isValid( s ) must beTrue
+      // TODO: cannot yet import proofs for arbitrary formulas
+      /*  p.getRobinsonProof (s) must beLike {
         case Some(_) => ok
         case None => ko
       } */
@@ -57,25 +56,25 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
     "prove { A or B :- -(-A and -B)  }" in {
 
       val p = new Prover9Prover()
-      val s = FSequent(List(Or(parse("A"), parse("B"))), List(Neg(And(Neg(parse("A")), Neg(parse("B"))))))
+      val s = FSequent( List( Or( parse( "A" ), parse( "B" ) ) ), List( Neg( And( Neg( parse( "A" ) ), Neg( parse( "B" ) ) ) ) ) )
 
-      p.isValid(s) must beTrue
-      p.getRobinsonProof (s) must beLike {
-        case Some(_) => ok
-        case None => ko
+      p.isValid( s ) must beTrue
+      p.getRobinsonProof( s ) must beLike {
+        case Some( _ ) => ok
+        case None      => ko
       }
     }
 
     "handle quantified antecedents" in {
 
-      val g1 = parse("Forall x Forall y =(+(s(x), y), s(+(x, y)))")
-      val g2 = parse("Forall z =(+(o, z), z)")
-      val g0 = parse("And =(z, o) =(z, w)")
-      val f = parse("=(+(+(z, s(s(o))), s(s(o))), +(s(s(o)), +(s(s(o)), w)))")
+      val g1 = parse( "Forall x Forall y =(+(s(x), y), s(+(x, y)))" )
+      val g2 = parse( "Forall z =(+(o, z), z)" )
+      val g0 = parse( "And =(z, o) =(z, w)" )
+      val f = parse( "=(+(+(z, s(s(o))), s(s(o))), +(s(s(o)), +(s(s(o)), w)))" )
 
-      Prover9.prove(FSequent(List(g0,g1,g2), List(f))) must beLike {
-        case Some(_) => ok
-        case None => ko
+      Prover9.prove( FSequent( List( g0, g1, g2 ), List( f ) ) ) must beLike {
+        case Some( _ ) => ok
+        case None      => ko
       }
     }
 
@@ -83,22 +82,22 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
 
   "The Prover9 interface" should {
     "successfully load the goat puzzle PUZ047+1.out" in {
-        // if the execution of prooftrans does not work: skip test
-        Prover9.parse_prover9(tempCopyOfClasspathFile("PUZ047+1.out"))
+      // if the execution of prooftrans does not work: skip test
+      Prover9.parse_prover9( tempCopyOfClasspathFile( "PUZ047+1.out" ) )
 
-        "success" must beEqualTo("success")
+      "success" must beEqualTo( "success" )
     }
 
     "successfully load the expansion proof paper example cade13example.out" in {
-        // if the execution of prooftrans does not work: skip test
-        Prover9.parse_prover9(tempCopyOfClasspathFile("cade13example.out"))
+      // if the execution of prooftrans does not work: skip test
+      Prover9.parse_prover9( tempCopyOfClasspathFile( "cade13example.out" ) )
 
-        "success" must beEqualTo("success")
+      "success" must beEqualTo( "success" )
     }
 
     "successfully load a proof with new_symbol" in {
-        val p = Prover9.parse_prover9(tempCopyOfClasspathFile("ALG138+1.out"))
-        Formatter.asHumanReadableString(p._1)
+      val p = Prover9.parse_prover9( tempCopyOfClasspathFile( "ALG138+1.out" ) )
+      Formatter.asHumanReadableString( p._1 )
       ok
     }
 
@@ -106,9 +105,9 @@ class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
 
   "The Prover9 interface" should {
     "load a Prover9 proof and verify the validity of the sequent" in {
-      for (testfilename <- "PUZ047+1.out"::"ALG138+1.out"::"cade13example.out"::Nil) {
-         val (robResProof, seq, _) = Prover9.parse_prover9(tempCopyOfClasspathFile(testfilename))
-        (new Prover9Prover).isValid(seq) must beTrue
+      for ( testfilename <- "PUZ047+1.out" :: "ALG138+1.out" :: "cade13example.out" :: Nil ) {
+        val ( robResProof, seq, _ ) = Prover9.parse_prover9( tempCopyOfClasspathFile( testfilename ) )
+        ( new Prover9Prover ).isValid( seq ) must beTrue
       }
       ok
     }

--- a/src/test/scala/at/logic/provers/prover9/ReplayTest.scala
+++ b/src/test/scala/at/logic/provers/prover9/ReplayTest.scala
@@ -8,7 +8,7 @@ import at.logic.calculi.lk.base.FSequent
 import at.logic.calculi.occurrences.factory
 import at.logic.calculi.resolution.Clause
 import at.logic.calculi.resolution.ResolutionProof
-import at.logic.calculi.resolution.robinson.{Formatter, RobinsonResolutionProof}
+import at.logic.calculi.resolution.robinson.{ Formatter, RobinsonResolutionProof }
 import at.logic.language.fol._
 import at.logic.language.lambda.symbols._
 import at.logic.parsing.calculi.simple.SimpleResolutionParserFOL
@@ -16,7 +16,7 @@ import at.logic.parsing.language.simple.SimpleFOLParser
 import at.logic.parsing.language.tptp.TPTPFOLExporter
 import at.logic.parsing.readers.StringReader
 import at.logic.provers.atp.Prover
-import at.logic.provers.atp.commands.base.{SetStreamCommand, PrependCommand}
+import at.logic.provers.atp.commands.base.{ SetStreamCommand, PrependCommand }
 import at.logic.provers.atp.commands.sequents.SetTargetClause
 import at.logic.provers.prover9.commands.Prover9InitCommand
 import java.io.File.separator
@@ -33,25 +33,25 @@ import scala.Some
 import at.logic.provers.atp.commands.sequents.SetTargetClause
 import at.logic.provers.atp.commands.base.SetStreamCommand
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ReplayTest extends SpecificationWithJUnit {
-  def parse(str:String) : FOLFormula = (new StringReader(str) with SimpleFOLParser getTerm).asInstanceOf[FOLFormula]
+  def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 
   val box = List()
-  def checkForProver9OrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
+  def checkForProver9OrSkip = Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
-  implicit def fo2occ(f:FOLFormula) = factory.createFormulaOccurrence(f, Nil)
+  implicit def fo2occ( f: FOLFormula ) = factory.createFormulaOccurrence( f, Nil )
 
   private object MyProver extends Prover[Clause]
 
-  def getRefutation(ls: Iterable[FSequent]): Boolean = MyProver.refute(Stream(SetTargetClause(FSequent(List(),List())), Prover9InitCommand(ls), SetStreamCommand())).next must beLike {
-      case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals (FSequent(List(),List())) => ok
-      case _ => ko
+  def getRefutation( ls: Iterable[FSequent] ): Boolean = MyProver.refute( Stream( SetTargetClause( FSequent( List(), List() ) ), Prover9InitCommand( ls ), SetStreamCommand() ) ).next must beLike {
+    case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals ( FSequent( List(), List() ) ) => ok
+    case _ => ko
   }
 
-  def getRefutation2(ls: Iterable[FSequent]) = MyProver.refute(Stream(SetTargetClause(FSequent(List(),List())), Prover9InitCommand(ls), SetStreamCommand())).next
+  def getRefutation2( ls: Iterable[FSequent] ) = MyProver.refute( Stream( SetTargetClause( FSequent( List(), List() ) ), Prover9InitCommand( ls ), SetStreamCommand() ) ).next
 
-  args (skipAll = !Prover9.isInstalled ())
+  args( skipAll = !Prover9.isInstalled() )
   "replay" should {
     /*"prove (with para) SKKx = Ix : { :- f(a,x) = x; :- f(f(f(b,x),y),z) = f(f(x,z), f(y,z)); :- f(f(c,x),y) = x; f(f(f(b,c),c),x) = f(a,x) :- }" in {
 
@@ -143,47 +143,43 @@ class ReplayTest extends SpecificationWithJUnit {
         "f(X + Z0) = 0",
         "f(((X + Z0) + 1) + Z1) = 0",
         "f(X + Z0) = 1",
-        "f(((X + Z0) + 1) + Z1) = 1"
-      ).map(parseFormula)
+        "f(((X + Z0) + 1) + Z1) = 1" ).map( parseFormula )
 
-      val c1 = FSequent(Nil, List(formulas(0), formulas(1)))
-      val c2 = FSequent(List(formulas(2), formulas(3)),Nil)
-      val c3 = FSequent(List(formulas(4), formulas(5)),Nil)
+      val c1 = FSequent( Nil, List( formulas( 0 ), formulas( 1 ) ) )
+      val c2 = FSequent( List( formulas( 2 ), formulas( 3 ) ), Nil )
+      val c3 = FSequent( List( formulas( 4 ), formulas( 5 ) ), Nil )
 
-      val ls = List(c1,c2,c3)
+      val ls = List( c1, c2, c3 )
 
       val prover = new Prover[Clause] {}
 
-      prover.refute(Stream(
-        SetTargetClause(FSequent(List(),List())),
-        Prover9InitCommand(ls),
-        SetStreamCommand()
-      )).next must beLike {
-        case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals (FSequent(List(),List())) =>
+      prover.refute( Stream(
+        SetTargetClause( FSequent( List(), List() ) ),
+        Prover9InitCommand( ls ),
+        SetStreamCommand() ) ).next must beLike {
+        case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root syntacticMultisetEquals ( FSequent( List(), List() ) ) =>
           ok
         case _ =>
           ko
       }
     }
 
-
-
     "prove (with xx - 3) -=(a,a) | -=(a,a)." in {
 
       //checks, if the execution of prover9 works (used by getRefutation2), o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
+      Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
-      val eaa = parse("=(a,a)")
-      val s = FSequent(List(eaa,eaa),Nil)
-      (getRefutation2(List(s)) match {
-        case Some(a) if a.asInstanceOf[ResolutionProof[Clause]].root.toFSequent multiSetEquals  (FSequent(List(),List())) => true
+      val eaa = parse( "=(a,a)" )
+      val s = FSequent( List( eaa, eaa ), Nil )
+      ( getRefutation2( List( s ) ) match {
+        case Some( a ) if a.asInstanceOf[ResolutionProof[Clause]].root.toFSequent multiSetEquals ( FSequent( List(), List() ) ) => true
         case _ => false
-      }) must beTrue
+      } ) must beTrue
     }
 
-     "prove an example from the automated deduction exercises" in {
-       skipped("never worked")
-       Prover9.refute(box ) must not(throwA[IOException]).orSkip
+    "prove an example from the automated deduction exercises" in {
+      skipped( "never worked" )
+      Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
       /* loops at derivation of clause 7:
         <clause id="7">
@@ -197,36 +193,36 @@ class ReplayTest extends SpecificationWithJUnit {
        */
 
       //println("=======AD Example: =======")
-      val assoc = parse("=(*(x,*(y,z)), *(*(x,y),z) )")
-      val neutr = parse("=(*(x,e), x)")
-      val idem = parse("=(*(x,x), e)")
-      val comm = parse("=(*(x,y), *(y,x))")
-      val ncomm = parse("=(*(c1,c2), *(c2,c1))")
-      val s1 = FSequent(Nil,List(assoc))
-      val s2 = FSequent(Nil,List(neutr))
-      val s3 = FSequent(Nil,List(idem))
-      val s4 = FSequent(List(ncomm), Nil)
-      (getRefutation2(List(s1,s2,s3,s4)) match {
-        case Some(a) if a.asInstanceOf[RobinsonResolutionProof].root.toFSequent multiSetEquals  (FSequent(List(),List())) =>
+      val assoc = parse( "=(*(x,*(y,z)), *(*(x,y),z) )" )
+      val neutr = parse( "=(*(x,e), x)" )
+      val idem = parse( "=(*(x,x), e)" )
+      val comm = parse( "=(*(x,y), *(y,x))" )
+      val ncomm = parse( "=(*(c1,c2), *(c2,c1))" )
+      val s1 = FSequent( Nil, List( assoc ) )
+      val s2 = FSequent( Nil, List( neutr ) )
+      val s3 = FSequent( Nil, List( idem ) )
+      val s4 = FSequent( List( ncomm ), Nil )
+      ( getRefutation2( List( s1, s2, s3, s4 ) ) match {
+        case Some( a ) if a.asInstanceOf[RobinsonResolutionProof].root.toFSequent multiSetEquals ( FSequent( List(), List() ) ) =>
           //println(Formatter.asHumanReadableString(a)   )
           //println("======= GraphViz output: =======\n" + Formatter.asGraphViz(a)   )
           true
         case _ => false
-      }) must beTrue
+      } ) must beTrue
     }
 
     "refute { :- P; P :- }" in {
       //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
+      Prover9.refute( box ) must not( throwA[IOException] ).orSkip
 
-      val p = Atom("P", Nil)
-      val s1 = FSequent(Nil, p::Nil)
-      val s2 = FSequent(p::Nil, Nil)
-      val result : Option[RobinsonResolutionProof] = Prover9.refute( s1::s2::Nil )
+      val p = Atom( "P", Nil )
+      val s1 = FSequent( Nil, p :: Nil )
+      val s2 = FSequent( p :: Nil, Nil )
+      val result: Option[RobinsonResolutionProof] = Prover9.refute( s1 :: s2 :: Nil )
       result match {
-        case Some(proof) =>
+        case Some( proof ) =>
           //println(Formatter.asHumanReadableString(proof))
-          true must beEqualTo(true)
+          true must beEqualTo( true )
         case None => "" must beEqualTo( "Refutation failed!" )
       }
 
@@ -234,21 +230,21 @@ class ReplayTest extends SpecificationWithJUnit {
 
     "find a refutation for a simple clause set " in {
       //checks, if the execution of prover9 works, o.w. skip test
-      Prover9.refute(box ) must not(throwA[IOException]).orSkip
+      Prover9.refute( box ) must not( throwA[IOException] ).orSkip
       //println("==== SIMPLE EXAMPLE ====")
-      val f_eq_g = parse("=(f(x),g(x))")
-      val px = parse("P(x)")
-      val pfx = parse("P(f(x))")
-      val pa = parse("P(a)")
-      val goal = parse("P(g(a))")
+      val f_eq_g = parse( "=(f(x),g(x))" )
+      val px = parse( "P(x)" )
+      val pfx = parse( "P(f(x))" )
+      val pa = parse( "P(a)" )
+      val goal = parse( "P(g(a))" )
 
-      val s1 = FSequent(Nil, List(f_eq_g))
-      val s2 = FSequent(List(px), List(pfx))
-      val s3 = FSequent(Nil, List(pa))
-      val t1 = FSequent(List(goal),Nil)
+      val s1 = FSequent( Nil, List( f_eq_g ) )
+      val s2 = FSequent( List( px ), List( pfx ) )
+      val s3 = FSequent( Nil, List( pa ) )
+      val t1 = FSequent( List( goal ), Nil )
       //println(TPTPFOLExporter.tptp_problem(List(s1,s2,s3,t1)))
       //println()
-      val Some(result) = getRefutation2( List(s1,s2,s3,t1) )
+      val Some( result ) = getRefutation2( List( s1, s2, s3, t1 ) )
       //println(result)
 
       //println(Formatter.asTex(result))

--- a/src/test/scala/at/logic/provers/vampire/vampireTest.scala
+++ b/src/test/scala/at/logic/provers/vampire/vampireTest.scala
@@ -11,59 +11,59 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.fol._
 import at.logic.calculi.lk.base.FSequent
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class VampireTest extends SpecificationWithJUnit {
 
-  args (skipAll = !Vampire.isInstalled ())
+  args( skipAll = !Vampire.isInstalled() )
 
   "The Vampire interface" should {
     "refute { :- P; P :- }" in {
-      val p = Atom("P", Nil)
-      val s1 = FSequent(Nil, p::Nil)
-      val s2 = FSequent(p::Nil, Nil)
-      val result : Boolean = Vampire.refute( s1::s2::Nil )
+      val p = Atom( "P", Nil )
+      val s1 = FSequent( Nil, p :: Nil )
+      val s2 = FSequent( p :: Nil, Nil )
+      val result: Boolean = Vampire.refute( s1 :: s2 :: Nil )
       result must beEqualTo( true )
     }
   }
 
   "The Vampire interface" should {
     "prove SKKx = Ix : { :- f(a,x) = x; :- f(f(f(b,x),y),z) = f(f(x,z), f(y,z)); :- f(f(c,x),y) = x; f(f(f(b,c),c),x) = f(a,x) :- }" in {
-      val x = FOLVar("x")
-      val y = FOLVar("y")
-      val z = FOLVar("z")
-      val a = FOLConst("a")
-      val b = FOLConst("b")
-      val c = FOLConst("c")
-      val fax = Function("f", a::x::Nil)
-      val fbx = Function("f", b::x::Nil)
-      val fcx = Function("f", c::x::Nil)
-      val fffbxyz = Function("f", Function("f", fbx::y::Nil)::z::Nil)
-      val fxz = Function("f", x::z::Nil)
-      val fyz = Function("f", y::z::Nil)
-      val ffxzfyz = Function("f", fxz::fyz::Nil)
-      val ffcxy = Function("f", fcx::y::Nil)
-      val fbc = Function("f", b::c::Nil)
-      val fffbccx = Function("f", Function("f", fbc::c::Nil)::x::Nil)
+      val x = FOLVar( "x" )
+      val y = FOLVar( "y" )
+      val z = FOLVar( "z" )
+      val a = FOLConst( "a" )
+      val b = FOLConst( "b" )
+      val c = FOLConst( "c" )
+      val fax = Function( "f", a :: x :: Nil )
+      val fbx = Function( "f", b :: x :: Nil )
+      val fcx = Function( "f", c :: x :: Nil )
+      val fffbxyz = Function( "f", Function( "f", fbx :: y :: Nil ) :: z :: Nil )
+      val fxz = Function( "f", x :: z :: Nil )
+      val fyz = Function( "f", y :: z :: Nil )
+      val ffxzfyz = Function( "f", fxz :: fyz :: Nil )
+      val ffcxy = Function( "f", fcx :: y :: Nil )
+      val fbc = Function( "f", b :: c :: Nil )
+      val fffbccx = Function( "f", Function( "f", fbc :: c :: Nil ) :: x :: Nil )
 
-      val i = Equation(fax, x)
-      val s = Equation(fffbxyz, ffxzfyz)
-      val k = Equation(ffcxy, x)
-      val skk_i = Equation(fffbccx, fax)
+      val i = Equation( fax, x )
+      val s = Equation( fffbxyz, ffxzfyz )
+      val k = Equation( ffcxy, x )
+      val skk_i = Equation( fffbccx, fax )
 
-      val s1 = FSequent(Nil, List(i))
-      val s2 = FSequent(Nil, List(k))
-      val s3 = FSequent(Nil, List(s))
-      val t1 = FSequent(List(skk_i),Nil)
-      val result : Boolean = Vampire.refute( List(s1,s2,s3,t1) )
+      val s1 = FSequent( Nil, List( i ) )
+      val s2 = FSequent( Nil, List( k ) )
+      val s3 = FSequent( Nil, List( s ) )
+      val t1 = FSequent( List( skk_i ), Nil )
+      val result: Boolean = Vampire.refute( List( s1, s2, s3, t1 ) )
       result must beEqualTo( true )
     }
   }
 
   "The Vampire interface" should {
     "not refute { :- P; Q :- }" in {
-      val s1 = FSequent(Nil, List(Atom("P", Nil)))
-      val t1 = FSequent(List(Atom("Q", Nil)),Nil)
-      val result : Boolean = Vampire.refute( List(s1,t1) )
+      val s1 = FSequent( Nil, List( Atom( "P", Nil ) ) )
+      val t1 = FSequent( List( Atom( "Q", Nil ) ), Nil )
+      val result: Boolean = Vampire.refute( List( s1, t1 ) )
       result must beEqualTo( false )
     }
   }

--- a/src/test/scala/at/logic/transformations/ceres/ClauseSetsTest.scala
+++ b/src/test/scala/at/logic/transformations/ceres/ClauseSetsTest.scala
@@ -1,75 +1,74 @@
 
 package at.logic.transformations.ceres.clauseSets
 
-import at.logic.algorithms.lk.{getAncestors, getCutAncestors}
+import at.logic.algorithms.lk.{ getAncestors, getCutAncestors }
 import at.logic.calculi.lk.base.Sequent
 import at.logic.calculi.occurrences._
 import at.logic.calculi.slk.SchemaProofDB
-import at.logic.language.hol.{Substitution => HOLSubstitution, Atom => HOLAtom, _}
-import at.logic.language.schema.{Substitution => SchemaSubstitution, _}
+import at.logic.language.hol.{ Substitution => HOLSubstitution, Atom => HOLAtom, _ }
+import at.logic.language.schema.{ Substitution => SchemaSubstitution, _ }
 import at.logic.language.lambda.types._
 import at.logic.parsing.shlk_parsing.sFOParser
-import at.logic.transformations.ceres.projections.{DeleteTautology, DeleteRedundantSequents}
+import at.logic.transformations.ceres.projections.{ DeleteTautology, DeleteRedundantSequents }
 import at.logic.transformations.ceres.struct._
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import scala.io._
 import scala.xml._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ClauseSetsTest extends SpecificationWithJUnit {
 
   sequential
   "ClauseSets" should {
     "- transform a Struct into a standard clause set" in {
 
-      val a = HOLAtom(HOLVar( "a", To ))
-      val b = HOLAtom(HOLVar( "b", To ))
-      val c = HOLAtom(HOLVar( "c", To ))
-      val d = HOLAtom(HOLVar( "d", To ))
-      val fa = defaultFormulaOccurrenceFactory.createFormulaOccurrence(a, Nil)
-      val fb = defaultFormulaOccurrenceFactory.createFormulaOccurrence(b, Nil)
-      val fc = defaultFormulaOccurrenceFactory.createFormulaOccurrence(c, Nil)
-      val fd = defaultFormulaOccurrenceFactory.createFormulaOccurrence(d, Nil)
+      val a = HOLAtom( HOLVar( "a", To ) )
+      val b = HOLAtom( HOLVar( "b", To ) )
+      val c = HOLAtom( HOLVar( "c", To ) )
+      val d = HOLAtom( HOLVar( "d", To ) )
+      val fa = defaultFormulaOccurrenceFactory.createFormulaOccurrence( a, Nil )
+      val fb = defaultFormulaOccurrenceFactory.createFormulaOccurrence( b, Nil )
+      val fc = defaultFormulaOccurrenceFactory.createFormulaOccurrence( c, Nil )
+      val fd = defaultFormulaOccurrenceFactory.createFormulaOccurrence( d, Nil )
 
-      val struct = Times(Plus(A(fa), A(fb)), Plus(A(fc), A(fd)))
+      val struct = Times( Plus( A( fa ), A( fb ) ), Plus( A( fc ), A( fd ) ) )
       val cs = StandardClauseSet.transformStructToClauseSet( struct )
       val res = cs.forall( seq => seq.antecedent.isEmpty && (
-        seq =^ Sequent(Nil, List(fa,fc)) || seq =^ Sequent(Nil, List(fa,fd)) ||
-        seq =^ Sequent(Nil, List(fb,fc)) || seq =^ Sequent(Nil, List(fb,fd))))
+        seq =^ Sequent( Nil, List( fa, fc ) ) || seq =^ Sequent( Nil, List( fa, fd ) ) ||
+        seq =^ Sequent( Nil, List( fb, fc ) ) || seq =^ Sequent( Nil, List( fb, fd ) ) ) )
       res must beTrue
     }
 
     "test the schematic struct in journal_example.slk" in {
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("ceres-journal_example.lks"))
-      val map = sFOParser.parseProof(s)
-      val p = map.get("\\psi").get._2.get("root").get
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "ceres-journal_example.lks" ) )
+      val map = sFOParser.parseProof( s )
+      val p = map.get( "\\psi" ).get._2.get( "root" ).get
       ok
     }
 
-
     "test the schematic struct in sEXP.slk" in {
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sEXP.lks"))
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sEXP.lks" ) )
       SchemaProofDB.clear
-      val map = sFOParser.parseProof(s)
-      val p1s = map.get("\\psi").get._2.get("root").get
-      val p2s = map.get("\\varphi").get._2.get("root").get
-      val p1b = map.get("\\psi").get._1.get("root").get
-      val p2b = map.get("\\varphi").get._1.get("root").get
+      val map = sFOParser.parseProof( s )
+      val p1s = map.get( "\\psi" ).get._2.get( "root" ).get
+      val p2s = map.get( "\\varphi" ).get._2.get( "root" ).get
+      val p1b = map.get( "\\psi" ).get._1.get( "root" ).get
+      val p2b = map.get( "\\varphi" ).get._1.get( "root" ).get
 
-      val n = IntVar("n")
-      val struct = StructCreators.extract(p1s, getCutAncestors(p1s))
-      val cs : List[Sequent] = DeleteRedundantSequents( DeleteTautology( StandardClauseSet.transformStructToClauseSet(struct) ))
+      val n = IntVar( "n" )
+      val struct = StructCreators.extract( p1s, getCutAncestors( p1s ) )
+      val cs: List[Sequent] = DeleteRedundantSequents( DeleteTautology( StandardClauseSet.transformStructToClauseSet( struct ) ) )
 
-      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2(IntVar("k"), Succ(IntZero()) )
-      var subst = SchemaSubstitution(new_map)
-      val gr = groundStruct(struct, subst.asInstanceOf[HOLSubstitution])
-      val unfold_gr = unfoldGroundStruct(gr)
+      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2( IntVar( "k" ), Succ( IntZero() ) )
+      var subst = SchemaSubstitution( new_map )
+      val gr = groundStruct( struct, subst.asInstanceOf[HOLSubstitution] )
+      val unfold_gr = unfoldGroundStruct( gr )
 
-      val cs_gr = StandardClauseSet.transformStructToClauseSet(gr)
+      val cs_gr = StandardClauseSet.transformStructToClauseSet( gr )
       ok
     }
   }

--- a/src/test/scala/at/logic/transformations/ceres/ProjectionTermTest.scala
+++ b/src/test/scala/at/logic/transformations/ceres/ProjectionTermTest.scala
@@ -1,144 +1,142 @@
 package at.logic.transformations.ceres
 
-import at.logic.algorithms.lk.{getCutAncestors, getAncestors}
+import at.logic.algorithms.lk.{ getCutAncestors, getAncestors }
 import at.logic.algorithms.shlk._
 import at.logic.calculi.lk._
-import at.logic.calculi.lk.base.{Sequent, LKProof}
-import at.logic.calculi.occurrences.{FormulaOccurrence, defaultFormulaOccurrenceFactory}
-import at.logic.calculi.slk.{SchemaProof, SchemaProofDB}
+import at.logic.calculi.lk.base.{ Sequent, LKProof }
+import at.logic.calculi.occurrences.{ FormulaOccurrence, defaultFormulaOccurrenceFactory }
+import at.logic.calculi.slk.{ SchemaProof, SchemaProofDB }
 import at.logic.language.schema._
-import at.logic.parsing.shlk_parsing.{SHLK, sFOParser}
+import at.logic.parsing.shlk_parsing.{ SHLK, sFOParser }
 import at.logic.utils.ds.trees.BinaryTree
 import at.logic.utils.testing.ClasspathFileCopier
 import clauseSchema.ParseResSchema._
 import clauseSchema._
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.junit.runner.RunWith
 
 import org.specs2.execute.Success
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ProjectionTermTest extends SpecificationWithJUnit with ClasspathFileCopier {
   implicit val factory = defaultFormulaOccurrenceFactory
 
   sequential
   "ProjectionTermTest" should {
     "create a ProjectionTerm" in {
-      val k = IntVar("k")
-      val real_n = IntVar("n")
+      val k = IntVar( "k" )
+      val real_n = IntVar( "n" )
       val n = k
-      val n1 = Succ(k); val n2 = Succ(n1); val n3 = Succ(n2)
-      val k1 = Succ(k); val k2 = Succ(n1); val k3 = Succ(n2)
+      val n1 = Succ( k ); val n2 = Succ( n1 ); val n3 = Succ( n2 )
+      val k1 = Succ( k ); val k2 = Succ( n1 ); val k3 = Succ( n2 )
       val s = Set[FormulaOccurrence]()
 
-      val i = IntVar("i")
-      val A = IndexedPredicate("A", i)
-      val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-      val four = Succ(three);val five = Succ(four); val six = Succ(Succ(four));val seven = Succ(Succ(five));
-      val A0 = IndexedPredicate("A", IntZero())
-      val A1 = IndexedPredicate("A", one)
-      val A2 = IndexedPredicate("A", two)
-      val A3 = IndexedPredicate("A", three)
+      val i = IntVar( "i" )
+      val A = IndexedPredicate( "A", i )
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val four = Succ( three ); val five = Succ( four ); val six = Succ( Succ( four ) ); val seven = Succ( Succ( five ) );
+      val A0 = IndexedPredicate( "A", IntZero() )
+      val A1 = IndexedPredicate( "A", one )
+      val A2 = IndexedPredicate( "A", two )
+      val A3 = IndexedPredicate( "A", three )
 
-      val B0 = IndexedPredicate("B", IntZero())
+      val B0 = IndexedPredicate( "B", IntZero() )
 
-      val Ak = IndexedPredicate("A", k)
-      val Ai = IndexedPredicate("A", i)
-      val Ai1 = IndexedPredicate("A", Succ(i))
+      val Ak = IndexedPredicate( "A", k )
+      val Ai = IndexedPredicate( "A", i )
+      val Ai1 = IndexedPredicate( "A", Succ( i ) )
 
-      val orneg = Or(Neg(Ai), Ai1.asInstanceOf[SchemaFormula])
-      val Ak1 = IndexedPredicate("A", Succ(k))
-      val An = IndexedPredicate("A", k)
-      val An1 = IndexedPredicate("A", n1)
-      val An2 = IndexedPredicate("A", n2)
-      val An3 = IndexedPredicate("A", n3)
+      val orneg = Or( Neg( Ai ), Ai1.asInstanceOf[SchemaFormula] )
+      val Ak1 = IndexedPredicate( "A", Succ( k ) )
+      val An = IndexedPredicate( "A", k )
+      val An1 = IndexedPredicate( "A", n1 )
+      val An2 = IndexedPredicate( "A", n2 )
+      val An3 = IndexedPredicate( "A", n3 )
 
-      val ax1 = Axiom(A0 :: Nil, A0 ::Nil)
-      val w1 = WeakeningRightRule(ax1, A3)
-      val negl1 = NegLeftRule(w1,A0)
-      val ax2 = Axiom(A1 :: Nil, A1 ::Nil)
-      val orl1 = OrLeftRule(negl1, ax2, Neg(A0), A1)
-      val ax3 = Axiom(A1 :: Nil, A1 ::Nil)
-      val root = CutRule(orl1, ax3, A1)
+      val ax1 = Axiom( A0 :: Nil, A0 :: Nil )
+      val w1 = WeakeningRightRule( ax1, A3 )
+      val negl1 = NegLeftRule( w1, A0 )
+      val ax2 = Axiom( A1 :: Nil, A1 :: Nil )
+      val orl1 = OrLeftRule( negl1, ax2, Neg( A0 ), A1 )
+      val ax3 = Axiom( A1 :: Nil, A1 :: Nil )
+      val root = CutRule( orl1, ax3, A1 )
 
-
-      val str = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("ceres-adder.lks"))
+      val str = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "ceres-adder.lks" ) )
       val proof_name = "psi"
 
+      val map = SHLK.parseProof( str )
 
-      val map = SHLK.parseProof(str)
+      val pterm = ProjectionTermCreators.extract( map.get( proof_name ).get._2.get( "root" ).get, Set.empty[FormulaOccurrence], getCutAncestors( map.get( proof_name ).get._2.get( "root" ).get ) )
+      val t = PStructToExpressionTree.applyConsole( pterm )
 
-      val pterm = ProjectionTermCreators.extract(map.get(proof_name).get._2.get("root").get, Set.empty[FormulaOccurrence], getCutAncestors(map.get(proof_name).get._2.get("root").get))
-      val t = PStructToExpressionTree.applyConsole(pterm)
-
-      val ptermcc = ProjectionTermCreators.extract(map.get(proof_name).get._2.get("root").get, Set.empty[FormulaOccurrence] + map.get(proof_name).get._2.get("root").get.root.succedent.head, getCutAncestors(map.get(proof_name).get._2.get("root").get))
-      val tcc = PStructToExpressionTree.applyConsole(ptermcc)
+      val ptermcc = ProjectionTermCreators.extract( map.get( proof_name ).get._2.get( "root" ).get, Set.empty[FormulaOccurrence] + map.get( proof_name ).get._2.get( "root" ).get.root.succedent.head, getCutAncestors( map.get( proof_name ).get._2.get( "root" ).get ) )
+      val tcc = PStructToExpressionTree.applyConsole( ptermcc )
 
       Success()
     }
 
     "should extract proj.term for the sEXP.lks" in {
-      skipped("Class cast exception")
+      skipped( "Class cast exception" )
 
       SchemaProofDB.clear
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sEXP.lks"))
-      val res = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("resSchema1.rs"))
-      val map = sFOParser.parseProof(s)
-      ParseResSchema(res)
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sEXP.lks" ) )
+      val res = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "resSchema1.rs" ) )
+      val map = sFOParser.parseProof( s )
+      ParseResSchema( res )
       val proof_name = "\\psi"
-      val p1 = map.get(proof_name).get._2.get("root").get
-      val p2 = map.get("\\varphi").get._2.get("root").get
+      val p1 = map.get( proof_name ).get._2.get( "root" ).get
+      val p2 = map.get( "\\varphi" ).get._2.get( "root" ).get
 
       val fo = p2.root.succedent.head
 
-      val pterm = ProjectionTermCreators.extract(p1, Set.empty[FormulaOccurrence], getCutAncestors(p1))
-      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2(IntVar("k"), Succ(Succ(IntZero())).asInstanceOf[IntegerTerm])
-      var sub = Substitution(new_map)
-      val t = PStructToExpressionTree.applyConsole(pterm)
+      val pterm = ProjectionTermCreators.extract( p1, Set.empty[FormulaOccurrence], getCutAncestors( p1 ) )
+      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2( IntVar( "k" ), Succ( Succ( IntZero() ) ).asInstanceOf[IntegerTerm] )
+      var sub = Substitution( new_map )
+      val t = PStructToExpressionTree.applyConsole( pterm )
 
-      val ground = GroundingProjectionTerm(pterm, sub)
-      val t_ground = PStructToExpressionTree.applyConsole(ground)
+      val ground = GroundingProjectionTerm( pterm, sub )
+      val t_ground = PStructToExpressionTree.applyConsole( ground )
 
-      val ground_unfold = UnfoldProjectionTerm(ground)
-      val t_ground_unfold = PStructToExpressionTree.applyConsole(ground_unfold)
+      val ground_unfold = UnfoldProjectionTerm( ground )
+      val t_ground_unfold = PStructToExpressionTree.applyConsole( ground_unfold )
 
-      val rm_arrow_ground_unfold = RemoveArrowRules(ground_unfold)
-      val t_rm_arrow_ground_unfold = PStructToExpressionTree.applyConsole(rm_arrow_ground_unfold)
+      val rm_arrow_ground_unfold = RemoveArrowRules( ground_unfold )
+      val t_rm_arrow_ground_unfold = PStructToExpressionTree.applyConsole( rm_arrow_ground_unfold )
 
-      val projSet = ProjectionTermToSetOfProofs(rm_arrow_ground_unfold)
+      val projSet = ProjectionTermToSetOfProofs( rm_arrow_ground_unfold )
 
-      val ground_proj_set = projSet.map(set => GroundingProjections(set, fo2SubstDB.map.toMap))
+      val ground_proj_set = projSet.map( set => GroundingProjections( set, fo2SubstDB.map.toMap ) )
 
       Success()
     }
 
     "should extract proj.term for the sINDauto.lks" in {
-      skipped("Class cast exception")
+      skipped( "Class cast exception" )
 
       SchemaProofDB.clear
-      val s = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sINDauto.lks"))
-      val map = sFOParser.parseProof(s)
+      val s = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sINDauto.lks" ) )
+      val map = sFOParser.parseProof( s )
       val proof_name = "\\sigma"
-      val p1 = map.get(proof_name).get._2.get("root").get
-      val p2 = map.get("\\varphi").get._2.get("root").get
+      val p1 = map.get( proof_name ).get._2.get( "root" ).get
+      val p2 = map.get( "\\varphi" ).get._2.get( "root" ).get
       val fo = p2.root.succedent.head
 
-      val pterm = ProjectionTermCreators.extract(p1, Set.empty[FormulaOccurrence], getCutAncestors(p1))
-      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2(IntVar("k"), Succ(Succ(IntZero())).asInstanceOf[IntegerTerm])
-      var sub = Substitution(new_map)
+      val pterm = ProjectionTermCreators.extract( p1, Set.empty[FormulaOccurrence], getCutAncestors( p1 ) )
+      val new_map = Map.empty[SchemaVar, IntegerTerm] + Tuple2( IntVar( "k" ), Succ( Succ( IntZero() ) ).asInstanceOf[IntegerTerm] )
+      var sub = Substitution( new_map )
 
-      val t = PStructToExpressionTree.applyConsole(pterm)
+      val t = PStructToExpressionTree.applyConsole( pterm )
 
-      val ground = GroundingProjectionTerm(pterm, sub)
-      val t_ground = PStructToExpressionTree.applyConsole(ground)
+      val ground = GroundingProjectionTerm( pterm, sub )
+      val t_ground = PStructToExpressionTree.applyConsole( ground )
 
-      val ground_unfold = RemoveArrowRules(UnfoldProjectionTerm(ground))
-      val t_ground_unfold = PStructToExpressionTree.applyConsole(ground_unfold)
+      val ground_unfold = RemoveArrowRules( UnfoldProjectionTerm( ground ) )
+      val t_ground_unfold = PStructToExpressionTree.applyConsole( ground_unfold )
 
-      val projSet = ProjectionTermToSetOfProofs(ground_unfold)
+      val projSet = ProjectionTermToSetOfProofs( ground_unfold )
 
       Success()
     }

--- a/src/test/scala/at/logic/transformations/ceres/SubstituteProofTest.scala
+++ b/src/test/scala/at/logic/transformations/ceres/SubstituteProofTest.scala
@@ -3,7 +3,7 @@ package at.logic.transformations.ceres.ACNF
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.mutable.SpecificationWithJUnit
-import at.logic.calculi.lk.base.{FSequent, LKProof}
+import at.logic.calculi.lk.base.{ FSequent, LKProof }
 import at.logic.algorithms.hlk.HybridLatexParser
 import java.io.File.separator
 import at.logic.language.hol._
@@ -61,4 +61,4 @@ class SubstituteProofTest extends SpecificationWithJUnit {
   }
 
 }
-*/
+*/ 

--- a/src/test/scala/at/logic/transformations/ceres/acnfTest.scala
+++ b/src/test/scala/at/logic/transformations/ceres/acnfTest.scala
@@ -3,11 +3,11 @@ package at.logic.transformations.ceres.ACNF
 import at.logic.algorithms.resolution.RobinsonToLK
 import at.logic.algorithms.shlk._
 import at.logic.calculi.lk._
-import at.logic.calculi.lk.base.{LKProof, Sequent}
-import at.logic.calculi.occurrences.{FormulaOccurrence, defaultFormulaOccurrenceFactory}
+import at.logic.calculi.lk.base.{ LKProof, Sequent }
+import at.logic.calculi.occurrences.{ FormulaOccurrence, defaultFormulaOccurrenceFactory }
 import at.logic.calculi.slk.SchemaProofDB
-import at.logic.language.fol.{Substitution => FOLSubstitution, FOLExpression, AllVar, FOLConst, FOLVar}
-import at.logic.language.hol.{HOLFormula, HOLVar, HOLAbs, HOLExpression}
+import at.logic.language.fol.{ Substitution => FOLSubstitution, FOLExpression, AllVar, FOLConst, FOLVar }
+import at.logic.language.hol.{ HOLFormula, HOLVar, HOLAbs, HOLExpression }
 import at.logic.language.lambda.types._
 import at.logic.parsing.language.prover9.Prover9TermParserLadrStyle
 import at.logic.parsing.shlk_parsing.sFOParser
@@ -17,7 +17,7 @@ import at.logic.transformations.ceres.clauseSets.StandardClauseSet
 import at.logic.transformations.ceres.projections.Projections
 import at.logic.transformations.ceres.struct.StructCreators
 import java.io.File.separator
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import org.junit.runner.RunWith
 //import org.specs2.internal.scalaz.Success
 import org.specs2.mutable.SpecificationWithJUnit
@@ -25,94 +25,93 @@ import org.specs2.runner.JUnitRunner
 import scala.io._
 import at.logic.algorithms.lk.applySubstitution
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class acnfTest extends SpecificationWithJUnit {
   implicit val factory = defaultFormulaOccurrenceFactory
 
-  args (skipAll = !Prover9.isInstalled ());
+  args( skipAll = !Prover9.isInstalled() );
 
   sequential
   "ACNFTest" should {
     "should create correctly the ACNF for journal_example.lks" in {
-      skipped("Error at: at.logic.transformations.ceres.clauseSchema.ResDeductionToLKTree$.apply(clauseSchema.scala:659)")
+      skipped( "Error at: at.logic.transformations.ceres.clauseSchema.ResDeductionToLKTree$.apply(clauseSchema.scala:659)" )
 
-      val s1 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("ceres-journal_example.lks"))
-      val s2 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("resSchema1.rs"))
-      val map = sFOParser.parseProof(s1)
-      ParseResSchema(s2)
-      val p = ACNF("\\varphi", "\\rho_1", 2)
+      val s1 = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "ceres-journal_example.lks" ) )
+      val s2 = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "resSchema1.rs" ) )
+      val map = sFOParser.parseProof( s1 )
+      ParseResSchema( s2 )
+      val p = ACNF( "\\varphi", "\\rho_1", 2 )
       ok
     }
 
     //TODO: fix it ! The problem is that it needs cloning before plugging in a projection into the skeleton resolution proof.
-//
-//    "should create correctly the ACNF for journal_example.lks" in {
-//      //println(Console.BLUE+"\n\n\n\n------- ACNF for the journal example instance = 0 ------- \n\n"+Console.RESET)
-//      val s1 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("ceres-journal_example.lks"))
-//      val s2 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("resSchema1.rs"))
-//      val map = sFOParser.parseProof(s1)
-//      ParseResSchema(s2)
-//      val p = ACNF("\\varphi", "\\rho_1", 0)
-////      printSchemaProof(p)
-//      //println("\n\n--- END ---\n\n")
-//      ok
-//    }
+    //
+    //    "should create correctly the ACNF for journal_example.lks" in {
+    //      //println(Console.BLUE+"\n\n\n\n------- ACNF for the journal example instance = 0 ------- \n\n"+Console.RESET)
+    //      val s1 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("ceres-journal_example.lks"))
+    //      val s2 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("resSchema1.rs"))
+    //      val map = sFOParser.parseProof(s1)
+    //      ParseResSchema(s2)
+    //      val p = ACNF("\\varphi", "\\rho_1", 0)
+    ////      printSchemaProof(p)
+    //      //println("\n\n--- END ---\n\n")
+    //      ok
+    //    }
 
     "should create correctly the ACNF for sEXP.lks" in {
-      skipped("Error at: at.logic.transformations.ceres.clauseSchema.ResDeductionToLKTree$.apply(clauseSchema.scala:659)")
+      skipped( "Error at: at.logic.transformations.ceres.clauseSchema.ResDeductionToLKTree$.apply(clauseSchema.scala:659)" )
 
-      val s1 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("sEXP.lks"))
-      val s2 = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("resSchema_sEXP.rs"))
-      val map = sFOParser.parseProof(s1)
-      ParseResSchema(s2)
-      val p = ACNF("\\psi", "\\rho_1", 1)
+      val s1 = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "sEXP.lks" ) )
+      val s2 = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "resSchema_sEXP.rs" ) )
+      val map = sFOParser.parseProof( s1 )
+      ParseResSchema( s2 )
+      val p = ACNF( "\\psi", "\\rho_1", 1 )
       ok
     }
 
     "should correctly handle equality rules" in {
-      def groundproj(projections: Set[LKProof], groundSubs: List[(HOLVar, HOLExpression)]): Set[LKProof] = {
-        groundSubs.map(subs => projections.map(pr => renameIndexedVarInProjection(pr, subs))).flatten.toSet
+      def groundproj( projections: Set[LKProof], groundSubs: List[( HOLVar, HOLExpression )] ): Set[LKProof] = {
+        groundSubs.map( subs => projections.map( pr => renameIndexedVarInProjection( pr, subs ) ) ).flatten.toSet
       }
 
-      val List(uv,fuu,fuv,ab,fab) = List("u = v", "f(u)=f(u)", "f(u)=f(v)", "a=b", "f(a)=f(b)") map (Prover9TermParserLadrStyle.parseFormula)
-      val List(uy,xy,ay) = List("(all y (u = y -> f(u) = f(y)))",
-                                "(all x all y (x = y -> f(x) = f(y)))",
-                                "(all y (a = y -> f(a) = f(y)))") map (Prover9TermParserLadrStyle.parseFormula)
-      val List(u,v) = List("u","v").map(s => FOLVar(s))
-      val List(a,b) = List("a","b").map(s => FOLConst(s))
-      val ax1 = Axiom(List(uv),List(uv))
-      val ax2 = Axiom(List(),List(fuu))
-      val ax3 = Axiom(List(ab),List(ab))
-      val ax4 = Axiom(List(fab),List(fab))
+      val List( uv, fuu, fuv, ab, fab ) = List( "u = v", "f(u)=f(u)", "f(u)=f(v)", "a=b", "f(a)=f(b)" ) map ( Prover9TermParserLadrStyle.parseFormula )
+      val List( uy, xy, ay ) = List( "(all y (u = y -> f(u) = f(y)))",
+        "(all x all y (x = y -> f(x) = f(y)))",
+        "(all y (a = y -> f(a) = f(y)))" ) map ( Prover9TermParserLadrStyle.parseFormula )
+      val List( u, v ) = List( "u", "v" ).map( s => FOLVar( s ) )
+      val List( a, b ) = List( "a", "b" ).map( s => FOLConst( s ) )
+      val ax1 = Axiom( List( uv ), List( uv ) )
+      val ax2 = Axiom( List(), List( fuu ) )
+      val ax3 = Axiom( List( ab ), List( ab ) )
+      val ax4 = Axiom( List( fab ), List( fab ) )
 
-      val i1 = EquationRight1Rule(ax1,ax2,ax1.root.succedent(0),ax2.root.succedent(0), fuv)
-      val i2 = ImpRightRule(i1, i1.root.antecedent(0),i1.root.succedent(0))
-      val i3 = ForallRightRule(i2, i2.root.succedent(0), uy, v )
-      val i4 = ForallRightRule(i3, i3.root.succedent(0), xy, u )
+      val i1 = EquationRight1Rule( ax1, ax2, ax1.root.succedent( 0 ), ax2.root.succedent( 0 ), fuv )
+      val i2 = ImpRightRule( i1, i1.root.antecedent( 0 ), i1.root.succedent( 0 ) )
+      val i3 = ForallRightRule( i2, i2.root.succedent( 0 ), uy, v )
+      val i4 = ForallRightRule( i3, i3.root.succedent( 0 ), xy, u )
 
-      val i5 = ImpLeftRule(ax3,ax4,ax3.root.succedent(0),ax4.root.antecedent(0))
-      val i6 = ForallLeftRule(i5, i5.root.antecedent(1),ay, b)
-      val i7 = ForallLeftRule(i6, i6.root.antecedent(1),xy, a)
+      val i5 = ImpLeftRule( ax3, ax4, ax3.root.succedent( 0 ), ax4.root.antecedent( 0 ) )
+      val i6 = ForallLeftRule( i5, i5.root.antecedent( 1 ), ay, b )
+      val i7 = ForallLeftRule( i6, i6.root.antecedent( 1 ), xy, a )
 
-      val es = CutRule(i4,i7,i4.root.succedent(0),i7.root.antecedent(1))
+      val es = CutRule( i4, i7, i4.root.succedent( 0 ), i7.root.antecedent( 1 ) )
 
-      val cs = StandardClauseSet.transformStructToClauseSet(StructCreators.extract(es))
+      val cs = StandardClauseSet.transformStructToClauseSet( StructCreators.extract( es ) )
 
-      val rp = Prover9.refute(cs.toList.map(_.toFSequent))
+      val rp = Prover9.refute( cs.toList.map( _.toFSequent ) )
       rp must not beEmpty
 
-
-      val proj = Projections(es)
+      val proj = Projections( es )
       proj must not beEmpty
 
       //for (p <- proj) println(p)
-      val rlkp = RobinsonToLK(rp.get)
-      val gproj = proj map (applySubstitution(_, FOLSubstitution((u,b)::Nil))._1)
+      val rlkp = RobinsonToLK( rp.get )
+      val gproj = proj map ( applySubstitution( _, FOLSubstitution( ( u, b ) :: Nil ) )._1 )
       //gproj map (x => println(" "+x))
-      val acnf = ACNF.plugProjections(rlkp, gproj, es.root.toFSequent)
+      val acnf = ACNF.plugProjections( rlkp, gproj, es.root.toFSequent )
       //println(acnf)
 
-      true must beEqualTo(true)
+      true must beEqualTo( true )
     }
   }
 }

--- a/src/test/scala/at/logic/transformations/ceres/clauseSchemaTest.scala
+++ b/src/test/scala/at/logic/transformations/ceres/clauseSchemaTest.scala
@@ -1,9 +1,9 @@
 package at.logic.transformations.ceres.clauseSchema
 
 import at.logic.algorithms.shlk._
-import at.logic.calculi.lk.base.{LKProof, FSequent}
+import at.logic.calculi.lk.base.{ LKProof, FSequent }
 import at.logic.calculi.lk._
-import at.logic.calculi.occurrences.{FormulaOccurrence, defaultFormulaOccurrenceFactory}
+import at.logic.calculi.occurrences.{ FormulaOccurrence, defaultFormulaOccurrenceFactory }
 import at.logic.language.schema._
 import at.logic.language.lambda.types._
 import java.io.File.separator
@@ -13,349 +13,347 @@ import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 import scala.io._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class clauseSchemaTest extends SpecificationWithJUnit {
   "clauseSchemaTest" should {
     "create a correct schema clause" in {
-      val k = IntVar("k")
-      val n1 = Succ(k); val n2 = Succ(n1); val n3 = Succ(n2)
-      val k1 = Succ(k); val k2 = Succ(n1); val k3 = Succ(n2)
-      val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-      val four = Succ(three);val five = Succ(four); val six = Succ(Succ(four));val seven = Succ(Succ(five));       
-      val A0 = IndexedPredicate("A", IntZero())
+      val k = IntVar( "k" )
+      val n1 = Succ( k ); val n2 = Succ( n1 ); val n3 = Succ( n2 )
+      val k1 = Succ( k ); val k2 = Succ( n1 ); val k3 = Succ( n2 )
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val four = Succ( three ); val five = Succ( four ); val six = Succ( Succ( four ) ); val seven = Succ( Succ( five ) );
+      val A0 = IndexedPredicate( "A", IntZero() )
 
-      val Pk = IndexedPredicate("P", k)
-      val P0 = IndexedPredicate("P", IntZero())
-      val Q0 = IndexedPredicate("Q", IntZero())
-      val Pk1 = IndexedPredicate("P", Succ(k))
-      val c0 = nonVarSclause(List.empty[SchemaFormula], P0::Nil)
-      val ck1 = nonVarSclause(List.empty[SchemaFormula], Pk1::Nil)
-      val X = sClauseVar("X")
-      val base: sClause = sClauseComposition(c0, X)
-      val rec: sClause = sClauseComposition(ck1, X)
-      val non = nonVarSclause(Q0::Nil, List.empty[SchemaFormula])
-      val map = Map[sClauseVar, sClause]() + Tuple2(X.asInstanceOf[sClauseVar], non)
-      val l = Ti::To::Tindex::Nil
-      l.foldLeft(To.asInstanceOf[TA])((x,t) => ->(x, t))
+      val Pk = IndexedPredicate( "P", k )
+      val P0 = IndexedPredicate( "P", IntZero() )
+      val Q0 = IndexedPredicate( "Q", IntZero() )
+      val Pk1 = IndexedPredicate( "P", Succ( k ) )
+      val c0 = nonVarSclause( List.empty[SchemaFormula], P0 :: Nil )
+      val ck1 = nonVarSclause( List.empty[SchemaFormula], Pk1 :: Nil )
+      val X = sClauseVar( "X" )
+      val base: sClause = sClauseComposition( c0, X )
+      val rec: sClause = sClauseComposition( ck1, X )
+      val non = nonVarSclause( Q0 :: Nil, List.empty[SchemaFormula] )
+      val map = Map[sClauseVar, sClause]() + Tuple2( X.asInstanceOf[sClauseVar], non )
+      val l = Ti :: To :: Tindex :: Nil
+      l.foldLeft( To.asInstanceOf[TA] )( ( x, t ) => ->( x, t ) )
 
       ok
     }
 
-
     "create a fist-order schema clause" in {
-      val k = IntVar("k")
-      val l = IntVar("l")
-      val n1 = Succ(k); val n2 = Succ(n1); val n3 = Succ(n2)
+      val k = IntVar( "k" )
+      val l = IntVar( "l" )
+      val n1 = Succ( k ); val n2 = Succ( n1 ); val n3 = Succ( n2 )
 
-      val zero = IntZero(); 
-      val one = Succ(IntZero()); 
-      val two = Succ(Succ(IntZero())); 
-      val three = Succ(Succ(Succ(IntZero())))
-      val four = Succ(three);
-      val five = Succ(four); 
-      val six = Succ(Succ(four));val seven = Succ(Succ(five));       
-      val A0 = IndexedPredicate("A", IntZero())
+      val zero = IntZero();
+      val one = Succ( IntZero() );
+      val two = Succ( Succ( IntZero() ) );
+      val three = Succ( Succ( Succ( IntZero() ) ) )
+      val four = Succ( three );
+      val five = Succ( four );
+      val six = Succ( Succ( four ) ); val seven = Succ( Succ( five ) );
+      val A0 = IndexedPredicate( "A", IntZero() )
 
-      val Pk1 = IndexedPredicate("P", Succ(k))
-      val X = sClauseVar("X")
-      val x = fo2Var("x")
-      val P = SchemaConst("P", ->(Ti, To))
-      val g = SchemaConst("g", ->(Ti,Ti))
-      val sigma0x0 = sTermN("σ", zero::x::zero::Nil)
-      val sigmaskxsk = sTermN("σ", Succ(k)::x::Succ(k)::Nil)
-      val Psigma0x0 = Atom(P, sigma0x0::Nil)
-      val Psigmaskxsk = Atom(P, sigmaskxsk::Nil)
+      val Pk1 = IndexedPredicate( "P", Succ( k ) )
+      val X = sClauseVar( "X" )
+      val x = fo2Var( "x" )
+      val P = SchemaConst( "P", ->( Ti, To ) )
+      val g = SchemaConst( "g", ->( Ti, Ti ) )
+      val sigma0x0 = sTermN( "σ", zero :: x :: zero :: Nil )
+      val sigmaskxsk = sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil )
+      val Psigma0x0 = Atom( P, sigma0x0 :: Nil )
+      val Psigmaskxsk = Atom( P, sigmaskxsk :: Nil )
 
       // --- trs sigma ---
-      val sigma_base = sTermN("σ", zero::x::l::Nil)
-      val sigma_rec = sTermN("σ", Succ(k)::x::l::Nil)
-      val st = sTermN("σ", k::x::l::Nil)
-      val rewrite_base = indexedFOVar("x", l)
-      val rewrite_step = SchemaApp(g, st)
-      var trsSigma = dbTRSsTermN("σ", Tuple2(sigma_base, rewrite_base), Tuple2(sigma_rec, rewrite_step))
+      val sigma_base = sTermN( "σ", zero :: x :: l :: Nil )
+      val sigma_rec = sTermN( "σ", Succ( k ) :: x :: l :: Nil )
+      val st = sTermN( "σ", k :: x :: l :: Nil )
+      val rewrite_base = indexedFOVar( "x", l )
+      val rewrite_step = SchemaApp( g, st )
+      var trsSigma = dbTRSsTermN( "σ", Tuple2( sigma_base, rewrite_base ), Tuple2( sigma_rec, rewrite_step ) )
 
       // --- trs clause schema ---
-      val c1 = clauseSchema("c", k::x::X::Nil)
-      val ck = clauseSchema("c", Succ(k)::x::X::Nil)
-      val c0 = clauseSchema("c", zero::x::X::Nil)
-      val clauseSchBase: sClause = sClauseComposition(X, nonVarSclause(Nil, Psigma0x0::Nil))
-      val clauseSchRec: sClause = sClauseComposition(c1, nonVarSclause(Nil, Psigmaskxsk::Nil))
-      val trsClauseSch = dbTRSclauseSchema("c", Tuple2(c0, clauseSchBase), Tuple2(ck, clauseSchRec))
+      val c1 = clauseSchema( "c", k :: x :: X :: Nil )
+      val ck = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val c0 = clauseSchema( "c", zero :: x :: X :: Nil )
+      val clauseSchBase: sClause = sClauseComposition( X, nonVarSclause( Nil, Psigma0x0 :: Nil ) )
+      val clauseSchRec: sClause = sClauseComposition( c1, nonVarSclause( Nil, Psigmaskxsk :: Nil ) )
+      val trsClauseSch = dbTRSclauseSchema( "c", Tuple2( c0, clauseSchBase ), Tuple2( ck, clauseSchRec ) )
       // ----------
 
-      val map = Map[SchemaVar, SchemaExpression]() + Tuple2(k, two) + Tuple2(l, three)
-      val subst = Substitution(map)
+      val map = Map[SchemaVar, SchemaExpression]() + Tuple2( k, two ) + Tuple2( l, three )
+      val subst = Substitution( map )
 
-      val sig = subst(trsSigma.map.get("σ").get._2._1)
-      val sigma3 = unfoldSTermN(sig, trsSigma)
+      val sig = subst( trsSigma.map.get( "σ" ).get._2._1 )
+      val sigma3 = unfoldSTermN( sig, trsSigma )
 
-      val clause3 = applySubToSclauseOrSclauseTerm(subst, trsClauseSch.map.get("c").get._2._1).asInstanceOf[sClause]
-      val rwclause3 = unfoldSchemaClause(clause3, trsClauseSch, trsSigma, subst)
+      val clause3 = applySubToSclauseOrSclauseTerm( subst, trsClauseSch.map.get( "c" ).get._2._1 ).asInstanceOf[sClause]
+      val rwclause3 = unfoldSchemaClause( clause3, trsClauseSch, trsSigma, subst )
 
       // --- trs sigma' ---
-      val a = SchemaVar("a", Ti)
-      val sigma1_base = sTermN("σ'", zero::Nil)
-      val sigma1_rec = sTermN("σ'", Succ(k)::Nil)
-      val st1 = sTermN("σ'", k::Nil)
+      val a = SchemaVar( "a", Ti )
+      val sigma1_base = sTermN( "σ'", zero :: Nil )
+      val sigma1_rec = sTermN( "σ'", Succ( k ) :: Nil )
+      val st1 = sTermN( "σ'", k :: Nil )
       val rewrite_base1 = a
-      val rewrite_step1 = SchemaApp(g, st1)
-      trsSigma = trsSigma.add("σ'", Tuple2(sigma1_base, rewrite_base1), Tuple2(sigma1_rec, rewrite_step1))
+      val rewrite_step1 = SchemaApp( g, st1 )
+      trsSigma = trsSigma.add( "σ'", Tuple2( sigma1_base, rewrite_base1 ), Tuple2( sigma1_rec, rewrite_step1 ) )
 
-      val sig1 = subst(trsSigma.map.get("σ'").get._1._1)
-      val sigma13 = unfoldSTermN(sig, trsSigma)
-      val sclterm = sclTimes(sclPlus(c1, ck), sclTermVar("ξ"))
-      val groundsterm = applySubToSclauseOrSclauseTerm(subst, sclterm)
-      val clauseSubst = new sClauseVarSubstitution(Map[sClauseVar, nonVarSclause]() + Tuple2(X.asInstanceOf[sClauseVar], nonVarSclause(Psigmaskxsk::Nil, Psigma0x0::Nil)))
-      val cl = trsClauseSch.map.get("c").get._2._1
-      
+      val sig1 = subst( trsSigma.map.get( "σ'" ).get._1._1 )
+      val sigma13 = unfoldSTermN( sig, trsSigma )
+      val sclterm = sclTimes( sclPlus( c1, ck ), sclTermVar( "ξ" ) )
+      val groundsterm = applySubToSclauseOrSclauseTerm( subst, sclterm )
+      val clauseSubst = new sClauseVarSubstitution( Map[sClauseVar, nonVarSclause]() + Tuple2( X.asInstanceOf[sClauseVar], nonVarSclause( Psigmaskxsk :: Nil, Psigma0x0 :: Nil ) ) )
+      val cl = trsClauseSch.map.get( "c" ).get._2._1
+
       ok
     }
 
     "create a schema clause term : ⊗ and ⊕ " in {
-      val k = IntVar("k")
-      val X = sClauseVar("X")
-      val g = SchemaVar("g", ->(Ti,Ti))
-      val x = fo2Var("x")
-      val zero = IntZero(); 
-      val one = Succ(IntZero()); 
-      val two = Succ(Succ(IntZero())); 
-      val three = Succ(Succ(Succ(IntZero())))
-      val a = SchemaVar("a", Ti)
-      val sigma1_base = sTermN("σ'", zero::Nil)
-      val sigma1_rec = sTermN("σ'", Succ(k)::Nil)
-      val st1 = sTermN("σ'", k::Nil)
+      val k = IntVar( "k" )
+      val X = sClauseVar( "X" )
+      val g = SchemaVar( "g", ->( Ti, Ti ) )
+      val x = fo2Var( "x" )
+      val zero = IntZero();
+      val one = Succ( IntZero() );
+      val two = Succ( Succ( IntZero() ) );
+      val three = Succ( Succ( Succ( IntZero() ) ) )
+      val a = SchemaVar( "a", Ti )
+      val sigma1_base = sTermN( "σ'", zero :: Nil )
+      val sigma1_rec = sTermN( "σ'", Succ( k ) :: Nil )
+      val st1 = sTermN( "σ'", k :: Nil )
       val rewrite_base1 = a
-      val rewrite_step1 = SchemaApp(g, st1)
-      val P = SchemaConst("P", ->(Ti, To))
-      val d1base = clauseSetTerm("d1", zero::x::X::Nil)
-      val d1step = clauseSetTerm("d1", Succ(k)::x::X::Nil)
-      val d2base = clauseSetTerm("d2", zero::x::X::Nil)
-      val d2step = clauseSetTerm("d2", Succ(k)::x::X::Nil)
-      val d2k = clauseSetTerm("d2", k::x::X::Nil)
-      val cstep = clauseSchema("c", Succ(k)::x::X::Nil)
-      val cbase = clauseSchema("c", zero::x::X::Nil)
-      val Pa = Atom(P, a::Nil)
-      val Psig1 = Atom(P, sigma1_rec::Nil)
-      val xi = sclTermVar("ξ")
-      val pair1base = Tuple2(d1base, sclPlus(d2base, xi))
-      val pair1step = Tuple2(d1step, sclPlus(d2step, cstep))
-      val pair2base = Tuple2(d2base, nonVarSclause(Pa::Nil, Nil))
-      val pair2step = Tuple2(d2step, sclPlus(d2k, nonVarSclause(Psig1::Nil, Nil)))
-      val c1 = clauseSchema("c", k::x::X::Nil)
-      val ck = clauseSchema("c", Succ(k)::x::X::Nil)
-      val c0 = clauseSchema("c", zero::x::X::Nil)
-      val sigma0x0 = sTermN("σ", zero::x::zero::Nil)
-      val sigmaskxsk = sTermN("σ", Succ(k)::x::Succ(k)::Nil)
-      val Psigma0x0 = Atom(P, sigma0x0::Nil)
-      val Psigmaskxsk = Atom(P, sigmaskxsk::Nil)
-      val clauseSchBase: sClause = sClauseComposition(X, nonVarSclause(Nil, Psigma0x0::Nil))
-      val clauseSchRec: sClause = sClauseComposition(c1, nonVarSclause(Nil, Psigmaskxsk::Nil))
-      val trsClauseSch = dbTRSclauseSchema("c", Tuple2(c0, clauseSchBase), Tuple2(ck, clauseSchRec))
-      val trsSigma = dbTRSsTermN("σ'", Tuple2(sigma1_base, rewrite_base1), Tuple2(sigma1_rec, rewrite_step1))
-      val trsSCLterm = dbTRSclauseSetTerm("d1", pair1base, pair1step)
-      trsSCLterm.add("d2", pair2base, pair2step)
+      val rewrite_step1 = SchemaApp( g, st1 )
+      val P = SchemaConst( "P", ->( Ti, To ) )
+      val d1base = clauseSetTerm( "d1", zero :: x :: X :: Nil )
+      val d1step = clauseSetTerm( "d1", Succ( k ) :: x :: X :: Nil )
+      val d2base = clauseSetTerm( "d2", zero :: x :: X :: Nil )
+      val d2step = clauseSetTerm( "d2", Succ( k ) :: x :: X :: Nil )
+      val d2k = clauseSetTerm( "d2", k :: x :: X :: Nil )
+      val cstep = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val cbase = clauseSchema( "c", zero :: x :: X :: Nil )
+      val Pa = Atom( P, a :: Nil )
+      val Psig1 = Atom( P, sigma1_rec :: Nil )
+      val xi = sclTermVar( "ξ" )
+      val pair1base = Tuple2( d1base, sclPlus( d2base, xi ) )
+      val pair1step = Tuple2( d1step, sclPlus( d2step, cstep ) )
+      val pair2base = Tuple2( d2base, nonVarSclause( Pa :: Nil, Nil ) )
+      val pair2step = Tuple2( d2step, sclPlus( d2k, nonVarSclause( Psig1 :: Nil, Nil ) ) )
+      val c1 = clauseSchema( "c", k :: x :: X :: Nil )
+      val ck = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val c0 = clauseSchema( "c", zero :: x :: X :: Nil )
+      val sigma0x0 = sTermN( "σ", zero :: x :: zero :: Nil )
+      val sigmaskxsk = sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil )
+      val Psigma0x0 = Atom( P, sigma0x0 :: Nil )
+      val Psigmaskxsk = Atom( P, sigmaskxsk :: Nil )
+      val clauseSchBase: sClause = sClauseComposition( X, nonVarSclause( Nil, Psigma0x0 :: Nil ) )
+      val clauseSchRec: sClause = sClauseComposition( c1, nonVarSclause( Nil, Psigmaskxsk :: Nil ) )
+      val trsClauseSch = dbTRSclauseSchema( "c", Tuple2( c0, clauseSchBase ), Tuple2( ck, clauseSchRec ) )
+      val trsSigma = dbTRSsTermN( "σ'", Tuple2( sigma1_base, rewrite_base1 ), Tuple2( sigma1_rec, rewrite_step1 ) )
+      val trsSCLterm = dbTRSclauseSetTerm( "d1", pair1base, pair1step )
+      trsSCLterm.add( "d2", pair2base, pair2step )
 
-      val map = Map[SchemaVar, SchemaExpression]() + Tuple2(k, two)
-      val subst = Substitution(map)
-      val d1step_ground = applySubToSclauseOrSclauseTerm(subst, d1step)
+      val map = Map[SchemaVar, SchemaExpression]() + Tuple2( k, two )
+      val subst = Substitution( map )
+      val d1step_ground = applySubToSclauseOrSclauseTerm( subst, d1step )
 
-      val mapX = Map[sClauseVar, sClause]() + Tuple2(X.asInstanceOf[sClauseVar], nonVarSclause(Nil, Nil))
+      val mapX = Map[sClauseVar, sClause]() + Tuple2( X.asInstanceOf[sClauseVar], nonVarSclause( Nil, Nil ) )
 
-      val rhoBase = ResolutionProofSchema("ρ", zero::x::X::Nil)
-      val rhoStep = ResolutionProofSchema("ρ", Succ(k)::x::X::Nil)
-      val rwBase = rTerm(sClauseComposition(nonVarSclause(Nil, Atom(P, sTermN("σ", zero::x::zero::Nil)::Nil)::Nil), X), nonVarSclause(Atom(P, sTermN("σ'", zero::Nil)::Nil)::Nil , Nil) , Atom(P, sTermN("σ", zero::x::zero::Nil)::Nil))
-      val rwStep = rTerm(ResolutionProofSchema("ρ", k::x::sClauseComposition(nonVarSclause(Nil, Atom(P, sTermN("σ", Succ(k)::x::Succ(k)::Nil)::Nil)::Nil), X)::Nil),              nonVarSclause(Atom(P, sTermN("σ'", Succ(k)::Nil)::Nil)::Nil , Nil) , Atom(P, sTermN("σ", Succ(k)::x::Succ(k)::Nil)::Nil))
+      val rhoBase = ResolutionProofSchema( "ρ", zero :: x :: X :: Nil )
+      val rhoStep = ResolutionProofSchema( "ρ", Succ( k ) :: x :: X :: Nil )
+      val rwBase = rTerm( sClauseComposition( nonVarSclause( Nil, Atom( P, sTermN( "σ", zero :: x :: zero :: Nil ) :: Nil ) :: Nil ), X ), nonVarSclause( Atom( P, sTermN( "σ'", zero :: Nil ) :: Nil ) :: Nil, Nil ), Atom( P, sTermN( "σ", zero :: x :: zero :: Nil ) :: Nil ) )
+      val rwStep = rTerm( ResolutionProofSchema( "ρ", k :: x :: sClauseComposition( nonVarSclause( Nil, Atom( P, sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil ) :: Nil ) :: Nil ), X ) :: Nil ), nonVarSclause( Atom( P, sTermN( "σ'", Succ( k ) :: Nil ) :: Nil ) :: Nil, Nil ), Atom( P, sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil ) :: Nil ) )
       resolutionProofSchemaDB.clear
-      resolutionProofSchemaDB.add("ρ", Tuple2(rhoBase, rwBase), Tuple2(rhoStep, rwStep))
+      resolutionProofSchemaDB.add( "ρ", Tuple2( rhoBase, rwBase ), Tuple2( rhoStep, rwStep ) )
       ok
     }
 
     "check 1" in {
-      val k = IntVar("k")
-      val l = IntVar("l")
-      val n1 = Succ(k); 
-      val n2 = Succ(n1); 
-      val n3 = Succ(n2)
+      val k = IntVar( "k" )
+      val l = IntVar( "l" )
+      val n1 = Succ( k );
+      val n2 = Succ( n1 );
+      val n3 = Succ( n2 )
 
-      val zero = IntZero(); 
-      val one = Succ(IntZero()); 
-      val two = Succ(Succ(IntZero())); 
-      val three = Succ(Succ(Succ(IntZero())))
-      val four = Succ(three);
-      val five = Succ(four); 
-      val six = Succ(Succ(four));val seven = Succ(Succ(five));       
-      val A0 = IndexedPredicate("A", IntZero())
+      val zero = IntZero();
+      val one = Succ( IntZero() );
+      val two = Succ( Succ( IntZero() ) );
+      val three = Succ( Succ( Succ( IntZero() ) ) )
+      val four = Succ( three );
+      val five = Succ( four );
+      val six = Succ( Succ( four ) ); val seven = Succ( Succ( five ) );
+      val A0 = IndexedPredicate( "A", IntZero() )
 
-      val Pk1 = IndexedPredicate("P", Succ(k))
-      val X = sClauseVar("X")
-      val x = fo2Var("x")
-      val P = SchemaConst("P", ->(Ti, To))
-      val g = SchemaConst("g", ->(Ti,Ti))
-      val sigma0x0 = sTermN("σ", zero::x::zero::Nil)
-      val sigmaskxsk = sTermN("σ", Succ(k)::x::Succ(k)::Nil)
-      val Psigma0x0 = Atom(P, sigma0x0::Nil)
-      val Psigmaskxsk = Atom(P, sigmaskxsk::Nil)
+      val Pk1 = IndexedPredicate( "P", Succ( k ) )
+      val X = sClauseVar( "X" )
+      val x = fo2Var( "x" )
+      val P = SchemaConst( "P", ->( Ti, To ) )
+      val g = SchemaConst( "g", ->( Ti, Ti ) )
+      val sigma0x0 = sTermN( "σ", zero :: x :: zero :: Nil )
+      val sigmaskxsk = sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil )
+      val Psigma0x0 = Atom( P, sigma0x0 :: Nil )
+      val Psigmaskxsk = Atom( P, sigmaskxsk :: Nil )
 
       // --- trs sigma ---
-      val sigma_base = sTermN("σ", zero::x::l::Nil)
-      val sigma_rec = sTermN("σ", Succ(k)::x::l::Nil)
-      val st = sTermN("σ", k::x::l::Nil)
-      val rewrite_base = indexedFOVar("x", l)
-      val rewrite_step = SchemaApp(g, st)
-      var trsSigma = dbTRSsTermN("σ", Tuple2(sigma_base, rewrite_base), Tuple2(sigma_rec, rewrite_step))
+      val sigma_base = sTermN( "σ", zero :: x :: l :: Nil )
+      val sigma_rec = sTermN( "σ", Succ( k ) :: x :: l :: Nil )
+      val st = sTermN( "σ", k :: x :: l :: Nil )
+      val rewrite_base = indexedFOVar( "x", l )
+      val rewrite_step = SchemaApp( g, st )
+      var trsSigma = dbTRSsTermN( "σ", Tuple2( sigma_base, rewrite_base ), Tuple2( sigma_rec, rewrite_step ) )
 
       // --- trs clause schema ---
-      val c1 = clauseSchema("c", k::x::X::Nil)
-      val ck = clauseSchema("c", Succ(k)::x::X::Nil)
-      val c0 = clauseSchema("c", zero::x::X::Nil)
-      val clauseSchBase: sClause = sClauseComposition(X, nonVarSclause(Nil, Psigma0x0::Nil))
-      val clauseSchRec: sClause = sClauseComposition(c1, nonVarSclause(Nil, Psigmaskxsk::Nil))
-      val trsClauseSch = dbTRSclauseSchema("c", Tuple2(c0, clauseSchBase), Tuple2(ck, clauseSchRec))
+      val c1 = clauseSchema( "c", k :: x :: X :: Nil )
+      val ck = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val c0 = clauseSchema( "c", zero :: x :: X :: Nil )
+      val clauseSchBase: sClause = sClauseComposition( X, nonVarSclause( Nil, Psigma0x0 :: Nil ) )
+      val clauseSchRec: sClause = sClauseComposition( c1, nonVarSclause( Nil, Psigmaskxsk :: Nil ) )
+      val trsClauseSch = dbTRSclauseSchema( "c", Tuple2( c0, clauseSchBase ), Tuple2( ck, clauseSchRec ) )
       // ----------
 
-      val map = Map[SchemaVar, SchemaExpression]() + Tuple2(k, two) + Tuple2(l, three)
-      val subst = Substitution(map)
+      val map = Map[SchemaVar, SchemaExpression]() + Tuple2( k, two ) + Tuple2( l, three )
+      val subst = Substitution( map )
 
-      val sig = subst(trsSigma.map.get("σ").get._2._1)
-      val sigma3 = unfoldSTermN(sig, trsSigma)
+      val sig = subst( trsSigma.map.get( "σ" ).get._2._1 )
+      val sigma3 = unfoldSTermN( sig, trsSigma )
 
-      val clause3 = applySubToSclauseOrSclauseTerm(subst, trsClauseSch.map.get("c").get._2._1).asInstanceOf[sClause]
-      val rwclause3 = unfoldSchemaClause(clause3, trsClauseSch, trsSigma, subst)
+      val clause3 = applySubToSclauseOrSclauseTerm( subst, trsClauseSch.map.get( "c" ).get._2._1 ).asInstanceOf[sClause]
+      val rwclause3 = unfoldSchemaClause( clause3, trsClauseSch, trsSigma, subst )
       ok
     }
 
     "check 2" in {
-      val l = IntVar("l")
-      val k = IntVar("k")
-      val X = sClauseVar("X")
-      val g = SchemaConst("g", ->(Ti,Ti))
-      val x = fo2Var("x")
-      val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-      val a = SchemaVar("a", Ti)
-      val sigma1_base = sTermN("σ'", zero::Nil)
-      val sigma1_rec = sTermN("σ'", Succ(k)::Nil)
-      val st1 = sTermN("σ'", k::Nil)
+      val l = IntVar( "l" )
+      val k = IntVar( "k" )
+      val X = sClauseVar( "X" )
+      val g = SchemaConst( "g", ->( Ti, Ti ) )
+      val x = fo2Var( "x" )
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val a = SchemaVar( "a", Ti )
+      val sigma1_base = sTermN( "σ'", zero :: Nil )
+      val sigma1_rec = sTermN( "σ'", Succ( k ) :: Nil )
+      val st1 = sTermN( "σ'", k :: Nil )
 
       val rewrite_base1 = a
-      val rewrite_step1 = SchemaApp(g, st1)
-      val P = SchemaConst("P", ->(Ti, To))
-      val d1base = clauseSetTerm("d1", zero::x::X::Nil)
-      val d1step = clauseSetTerm("d1", Succ(k)::x::X::Nil)
-      val d2base = clauseSetTerm("d2", zero::x::X::Nil)
-      val d2step = clauseSetTerm("d2", Succ(k)::x::X::Nil)
-      val d2k = clauseSetTerm("d2", k::x::X::Nil)
-      val cstep = clauseSchema("c", Succ(k)::x::X::Nil)
-      val cbase = clauseSchema("c", zero::x::X::Nil)
-      val Pa = Atom(P, a::Nil)
-      val Psig1 = Atom(P, sigma1_rec::Nil)
-      val xi = sclTermVar("ξ")
-      val pair1base = Tuple2(d1base, sclPlus(d2base, xi))
-      val pair1step = Tuple2(d1step, sclPlus(d2step, cstep))
-      val pair2base = Tuple2(d2base, nonVarSclause(Pa::Nil, Nil))
-      val pair2step = Tuple2(d2step, sclPlus(d2k, nonVarSclause(Psig1::Nil, Nil)))
-      val c1 = clauseSchema("c", k::x::X::Nil)
-      val ck = clauseSchema("c", Succ(k)::x::X::Nil)
-      val c0 = clauseSchema("c", zero::x::X::Nil)
-      val sigma0x0 = sTermN("σ", zero::x::zero::Nil)
-      val sigmaskxsk = sTermN("σ", Succ(k)::x::Succ(k)::Nil)
-      val Psigma0x0 = Atom(P, sigma0x0::Nil)
-      val Psigmaskxsk = Atom(P, sigmaskxsk::Nil)
-      val clauseSchBase: sClause = sClauseComposition(X, nonVarSclause(Nil, Psigma0x0::Nil))
-      val clauseSchRec: sClause = sClauseComposition(c1, nonVarSclause(Nil, Psigmaskxsk::Nil))
-      val trsClauseSch = dbTRSclauseSchema("c", Tuple2(c0, clauseSchBase), Tuple2(ck, clauseSchRec))
-      val trsSCLterm = dbTRSclauseSetTerm("d1", pair1base, pair1step)
-      val sigma_base = sTermN("σ", zero::x::l::Nil)
-      val sigma_rec = sTermN("σ", Succ(k)::x::l::Nil)
-      val st = sTermN("σ", k::x::l::Nil)
-      val rewrite_base = indexedFOVar("x", l)
-      val rewrite_step = SchemaApp(g, st)
-      var trsSigma = dbTRSsTermN("σ", Tuple2(sigma_base, rewrite_base), Tuple2(sigma_rec, rewrite_step))
+      val rewrite_step1 = SchemaApp( g, st1 )
+      val P = SchemaConst( "P", ->( Ti, To ) )
+      val d1base = clauseSetTerm( "d1", zero :: x :: X :: Nil )
+      val d1step = clauseSetTerm( "d1", Succ( k ) :: x :: X :: Nil )
+      val d2base = clauseSetTerm( "d2", zero :: x :: X :: Nil )
+      val d2step = clauseSetTerm( "d2", Succ( k ) :: x :: X :: Nil )
+      val d2k = clauseSetTerm( "d2", k :: x :: X :: Nil )
+      val cstep = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val cbase = clauseSchema( "c", zero :: x :: X :: Nil )
+      val Pa = Atom( P, a :: Nil )
+      val Psig1 = Atom( P, sigma1_rec :: Nil )
+      val xi = sclTermVar( "ξ" )
+      val pair1base = Tuple2( d1base, sclPlus( d2base, xi ) )
+      val pair1step = Tuple2( d1step, sclPlus( d2step, cstep ) )
+      val pair2base = Tuple2( d2base, nonVarSclause( Pa :: Nil, Nil ) )
+      val pair2step = Tuple2( d2step, sclPlus( d2k, nonVarSclause( Psig1 :: Nil, Nil ) ) )
+      val c1 = clauseSchema( "c", k :: x :: X :: Nil )
+      val ck = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val c0 = clauseSchema( "c", zero :: x :: X :: Nil )
+      val sigma0x0 = sTermN( "σ", zero :: x :: zero :: Nil )
+      val sigmaskxsk = sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil )
+      val Psigma0x0 = Atom( P, sigma0x0 :: Nil )
+      val Psigmaskxsk = Atom( P, sigmaskxsk :: Nil )
+      val clauseSchBase: sClause = sClauseComposition( X, nonVarSclause( Nil, Psigma0x0 :: Nil ) )
+      val clauseSchRec: sClause = sClauseComposition( c1, nonVarSclause( Nil, Psigmaskxsk :: Nil ) )
+      val trsClauseSch = dbTRSclauseSchema( "c", Tuple2( c0, clauseSchBase ), Tuple2( ck, clauseSchRec ) )
+      val trsSCLterm = dbTRSclauseSetTerm( "d1", pair1base, pair1step )
+      val sigma_base = sTermN( "σ", zero :: x :: l :: Nil )
+      val sigma_rec = sTermN( "σ", Succ( k ) :: x :: l :: Nil )
+      val st = sTermN( "σ", k :: x :: l :: Nil )
+      val rewrite_base = indexedFOVar( "x", l )
+      val rewrite_step = SchemaApp( g, st )
+      var trsSigma = dbTRSsTermN( "σ", Tuple2( sigma_base, rewrite_base ), Tuple2( sigma_rec, rewrite_step ) )
 
+      trsSCLterm.add( "d2", pair2base, pair2step )
 
-      trsSCLterm.add("d2", pair2base, pair2step)
+      val map = Map[SchemaVar, SchemaExpression]() + Tuple2( k, two ) + Tuple2( l, three )
+      val subst = Substitution( map )
 
-      val map = Map[SchemaVar, SchemaExpression]() + Tuple2(k, two) + Tuple2(l, three)
-      val subst = Substitution(map)
-
-      val clause3 = applySubToSclauseOrSclauseTerm(subst, trsClauseSch.map.get("c").get._2._1).asInstanceOf[sClause]
-      val rwclause3 = unfoldSchemaClause(clause3, trsClauseSch, trsSigma, subst)
+      val clause3 = applySubToSclauseOrSclauseTerm( subst, trsClauseSch.map.get( "c" ).get._2._1 ).asInstanceOf[sClause]
+      val rwclause3 = unfoldSchemaClause( clause3, trsClauseSch, trsSigma, subst )
 
       ok
     }
 
     "check resolution deduction" in {
-      skipped("Class cast exception")
+      skipped( "Class cast exception" )
 
-      val l = IntVar("l")
-      val k = IntVar("k")
-      val X = sClauseVar("X")
-      val g = SchemaConst("g", ->(Ti,Ti))
-      val x = fo2Var("x")
-      val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-      val a = SchemaVar("a", Ti)
-      val sigma1_base = sTermN("σ'", zero::Nil)
-      val sigma1_rec = sTermN("σ'", Succ(k)::Nil)
-      val st1 = sTermN("σ'", k::Nil)
+      val l = IntVar( "l" )
+      val k = IntVar( "k" )
+      val X = sClauseVar( "X" )
+      val g = SchemaConst( "g", ->( Ti, Ti ) )
+      val x = fo2Var( "x" )
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val a = SchemaVar( "a", Ti )
+      val sigma1_base = sTermN( "σ'", zero :: Nil )
+      val sigma1_rec = sTermN( "σ'", Succ( k ) :: Nil )
+      val st1 = sTermN( "σ'", k :: Nil )
 
-      val rewrite_base1 = a 
-      val rewrite_step1 = SchemaApp(g, st1)
-      val P = SchemaConst("P", ->(Ti, To))
-      val c = SchemaConst("c", Ti)
-      val b = SchemaConst("b", Ti)
-      val Pc = SchemaApp(P, c)
-      val Pa = SchemaApp(P, a)
-      val Pb = SchemaApp(P, b)
+      val rewrite_base1 = a
+      val rewrite_step1 = SchemaApp( g, st1 )
+      val P = SchemaConst( "P", ->( Ti, To ) )
+      val c = SchemaConst( "c", Ti )
+      val b = SchemaConst( "b", Ti )
+      val Pc = SchemaApp( P, c )
+      val Pa = SchemaApp( P, a )
+      val Pb = SchemaApp( P, b )
 
-      val sigma_base = sTermN("σ", zero::x::l::Nil)
-      val sigma_rec = sTermN("σ", Succ(k)::x::l::Nil)
-      val st = sTermN("σ", k::x::l::Nil)
-      val rewrite_base = SchemaApp(x, l)
-      val rewrite_step = SchemaApp(g, st)
-      var trsSigma = dbTRSsTermN("σ", Tuple2(sigma_base, rewrite_base), Tuple2(sigma_rec, rewrite_step))
+      val sigma_base = sTermN( "σ", zero :: x :: l :: Nil )
+      val sigma_rec = sTermN( "σ", Succ( k ) :: x :: l :: Nil )
+      val st = sTermN( "σ", k :: x :: l :: Nil )
+      val rewrite_base = SchemaApp( x, l )
+      val rewrite_step = SchemaApp( g, st )
+      var trsSigma = dbTRSsTermN( "σ", Tuple2( sigma_base, rewrite_base ), Tuple2( sigma_rec, rewrite_step ) )
 
-      trsSigma = trsSigma.add("σ'", Tuple2(sigma1_base, rewrite_base1), Tuple2(sigma1_rec, rewrite_step1))
-      val c1 = clauseSchema("c", k::x::X::Nil)
-      val ck = clauseSchema("c", Succ(k)::x::X::Nil)
-      val c0 = clauseSchema("c", zero::x::X::Nil)
-      val sigma0x0 = sTermN("σ", zero::x::zero::Nil)
-      val sigmaskxsk = sTermN("σ", Succ(k)::x::Succ(k)::Nil)
-      val Psigma0x0 = Atom(P, sigma0x0::Nil)
-      val Psigmaskxsk = Atom(P, sigmaskxsk::Nil)
-      val clauseSchBase: sClause = sClauseComposition(X, nonVarSclause(Nil, Psigma0x0::Nil))
-      val clauseSchRec: sClause = sClauseComposition(c1, nonVarSclause(Nil, Psigmaskxsk::Nil))
-      val trsClauseSch = dbTRSclauseSchema("c", Tuple2(c0, clauseSchBase), Tuple2(ck, clauseSchRec))
+      trsSigma = trsSigma.add( "σ'", Tuple2( sigma1_base, rewrite_base1 ), Tuple2( sigma1_rec, rewrite_step1 ) )
+      val c1 = clauseSchema( "c", k :: x :: X :: Nil )
+      val ck = clauseSchema( "c", Succ( k ) :: x :: X :: Nil )
+      val c0 = clauseSchema( "c", zero :: x :: X :: Nil )
+      val sigma0x0 = sTermN( "σ", zero :: x :: zero :: Nil )
+      val sigmaskxsk = sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil )
+      val Psigma0x0 = Atom( P, sigma0x0 :: Nil )
+      val Psigmaskxsk = Atom( P, sigmaskxsk :: Nil )
+      val clauseSchBase: sClause = sClauseComposition( X, nonVarSclause( Nil, Psigma0x0 :: Nil ) )
+      val clauseSchRec: sClause = sClauseComposition( c1, nonVarSclause( Nil, Psigmaskxsk :: Nil ) )
+      val trsClauseSch = dbTRSclauseSchema( "c", Tuple2( c0, clauseSchBase ), Tuple2( ck, clauseSchRec ) )
 
-      val map = Map[SchemaVar, SchemaExpression]() + Tuple2(k, two) + Tuple2(l, three)
-      val subst = Substitution(map)
+      val map = Map[SchemaVar, SchemaExpression]() + Tuple2( k, two ) + Tuple2( l, three )
+      val subst = Substitution( map )
 
-      val sig1 = subst(trsSigma.map.get("σ'").get._2._1)
-      val sigma13 = unfoldSTermN(sig1, trsSigma)
-      val f = SchemaApp(P, sig1)
-      val Psig1 = unfoldGroundAtom(f.asInstanceOf[SchemaFormula], trsSigma)
+      val sig1 = subst( trsSigma.map.get( "σ'" ).get._2._1 )
+      val sigma13 = unfoldSTermN( sig1, trsSigma )
+      val f = SchemaApp( P, sig1 )
+      val Psig1 = unfoldGroundAtom( f.asInstanceOf[SchemaFormula], trsSigma )
 
-      val mapX = Map[sClauseVar, sClause]() + Tuple2(X.asInstanceOf[sClauseVar], nonVarSclause(Nil, Nil))
+      val mapX = Map[sClauseVar, sClause]() + Tuple2( X.asInstanceOf[sClauseVar], nonVarSclause( Nil, Nil ) )
 
-      val clause3 = applySubToSclauseOrSclauseTerm(subst, trsClauseSch.map.get("c").get._2._1).asInstanceOf[sClause]
-      val de = deComposeSClause(unfoldSchemaClause(clause3, trsClauseSch, trsSigma, subst))
+      val clause3 = applySubToSclauseOrSclauseTerm( subst, trsClauseSch.map.get( "c" ).get._2._1 ).asInstanceOf[sClause]
+      val de = deComposeSClause( unfoldSchemaClause( clause3, trsClauseSch, trsSigma, subst ) )
 
-      val rhoBase = ResolutionProofSchema("ρ", zero::x::X::Nil)
-      val rhoStep = ResolutionProofSchema("ρ", Succ(k)::x::X::Nil)
-      val rwBase = rTerm(sClauseComposition(nonVarSclause(Nil, Atom(P, sTermN("σ", zero::x::zero::Nil)::Nil)::Nil), X), nonVarSclause(Atom(P, sTermN("σ'", zero::Nil)::Nil)::Nil , Nil) , Atom(P, sTermN("σ", zero::x::zero::Nil)::Nil))
-      val rwStep = rTerm(ResolutionProofSchema("ρ", k::x::sClauseComposition(nonVarSclause(Nil, Atom(P, sTermN("σ", Succ(k)::x::Succ(k)::Nil)::Nil)::Nil), X)::Nil),              nonVarSclause(Atom(P, sTermN("σ'", Succ(k)::Nil)::Nil)::Nil , Nil) , Atom(P, sTermN("σ", Succ(k)::x::Succ(k)::Nil)::Nil))
+      val rhoBase = ResolutionProofSchema( "ρ", zero :: x :: X :: Nil )
+      val rhoStep = ResolutionProofSchema( "ρ", Succ( k ) :: x :: X :: Nil )
+      val rwBase = rTerm( sClauseComposition( nonVarSclause( Nil, Atom( P, sTermN( "σ", zero :: x :: zero :: Nil ) :: Nil ) :: Nil ), X ), nonVarSclause( Atom( P, sTermN( "σ'", zero :: Nil ) :: Nil ) :: Nil, Nil ), Atom( P, sTermN( "σ", zero :: x :: zero :: Nil ) :: Nil ) )
+      val rwStep = rTerm( ResolutionProofSchema( "ρ", k :: x :: sClauseComposition( nonVarSclause( Nil, Atom( P, sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil ) :: Nil ) :: Nil ), X ) :: Nil ), nonVarSclause( Atom( P, sTermN( "σ'", Succ( k ) :: Nil ) :: Nil ) :: Nil, Nil ), Atom( P, sTermN( "σ", Succ( k ) :: x :: Succ( k ) :: Nil ) :: Nil ) )
       resolutionProofSchemaDB.clear
-      resolutionProofSchemaDB.add("ρ", Tuple2(rhoBase, rwBase), Tuple2(rhoStep, rwStep))
-      val base = resolutionProofSchemaDB.map.get("ρ").get._1._2
-      var step = ResolutionProofSchema("ρ", three::x::X::Nil)
-      step = sClauseVarSubstitution(step, mapX).asInstanceOf[ResolutionProofSchema]
+      resolutionProofSchemaDB.add( "ρ", Tuple2( rhoBase, rwBase ), Tuple2( rhoStep, rwStep ) )
+      val base = resolutionProofSchemaDB.map.get( "ρ" ).get._1._2
+      var step = ResolutionProofSchema( "ρ", three :: x :: X :: Nil )
+      step = sClauseVarSubstitution( step, mapX ).asInstanceOf[ResolutionProofSchema]
 
-      val rez2 = unfoldingAtomsInResTerm(step, trsSigma, subst)
-      val h = SchemaAbs(k, a)
-      val mapfo2 = Map[fo2Var, SchemaExpression]() + Tuple2(x.asInstanceOf[fo2Var], h)
-      val rez3 = unfoldResolutionProofSchema(rez2)
-      val fo2sub = fo2VarSubstitution(rez3, mapfo2).asInstanceOf[sResolutionTerm]
+      val rez2 = unfoldingAtomsInResTerm( step, trsSigma, subst )
+      val h = SchemaAbs( k, a )
+      val mapfo2 = Map[fo2Var, SchemaExpression]() + Tuple2( x.asInstanceOf[fo2Var], h )
+      val rez3 = unfoldResolutionProofSchema( rez2 )
+      val fo2sub = fo2VarSubstitution( rez3, mapfo2 ).asInstanceOf[sResolutionTerm]
 
-      val rez4 = resolutionDeduction(fo2sub, trsClauseSch, trsSigma, subst, mapX)
-      
+      val rez4 = resolutionDeduction( fo2sub, trsClauseSch, trsSigma, subst, mapX )
+
       ok
     }
   }

--- a/src/test/scala/at/logic/transformations/herbrandSequent/extractExpansionTreesTest.scala
+++ b/src/test/scala/at/logic/transformations/herbrandSequent/extractExpansionTreesTest.scala
@@ -7,139 +7,132 @@ import at.logic.language.lambda.types._
 import at.logic.language.hol._
 import at.logic.calculi.lk._
 import at.logic.transformations.herbrandExtraction._
-import at.logic.calculi.expansionTrees.{StrongQuantifier => StrongQuantifierET, WeakQuantifier => WeakQuantifierET, Atom => AtomET, Imp => ImpET}
+import at.logic.calculi.expansionTrees.{ StrongQuantifier => StrongQuantifierET, WeakQuantifier => WeakQuantifierET, Atom => AtomET, Imp => ImpET }
 import at.logic.calculi.lk.base.LKProof
-import at.logic.language.fol.{Atom => FOLAtom, Function => FOLFunction, FOLConst, FOLVar, Utils}
+import at.logic.language.fol.{ Atom => FOLAtom, Function => FOLFunction, FOLConst, FOLVar, Utils }
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class ExtractExpansionTreesTest extends SpecificationWithJUnit {
 
-  def LinearExampleProof(k: Int, n: Int): LKProof = {
+  def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"
     val p = "P"
 
-    val x = FOLVar("x")
-    val ass = AllVar(x, Imp(FOLAtom(p, x :: Nil), FOLAtom(p, FOLFunction(s, x :: Nil) :: Nil)))
-    if (k == n) {
-      val a = FOLAtom(p, Utils.numeral(n) :: Nil)
-      WeakeningLeftRule(Axiom(a :: Nil, a :: Nil), ass)
+    val x = FOLVar( "x" )
+    val ass = AllVar( x, Imp( FOLAtom( p, x :: Nil ), FOLAtom( p, FOLFunction( s, x :: Nil ) :: Nil ) ) )
+    if ( k == n ) {
+      val a = FOLAtom( p, Utils.numeral( n ) :: Nil )
+      WeakeningLeftRule( Axiom( a :: Nil, a :: Nil ), ass )
     } else {
-      val p1 = FOLAtom(p, Utils.numeral(k) :: Nil)
-      val p2 = FOLAtom(p, Utils.numeral(k + 1) :: Nil)
-      val aux = Imp(p1, p2)
-      ContractionLeftRule(ForallLeftRule(ImpLeftRule(Axiom(p1 :: Nil, p1 :: Nil), LinearExampleProof(k + 1, n), p1, p2), aux, ass, Utils.numeral(k)), ass)
+      val p1 = FOLAtom( p, Utils.numeral( k ) :: Nil )
+      val p2 = FOLAtom( p, Utils.numeral( k + 1 ) :: Nil )
+      val aux = Imp( p1, p2 )
+      ContractionLeftRule( ForallLeftRule( ImpLeftRule( Axiom( p1 :: Nil, p1 :: Nil ), LinearExampleProof( k + 1, n ), p1, p2 ), aux, ass, Utils.numeral( k ) ), ass )
     }
   }
-
 
   "The expansion tree extraction" should {
 
     "handle successive contractions " in {
-      val etSeq = extractExpansionSequent(LinearExampleProof(0, 2), false)
+      val etSeq = extractExpansionSequent( LinearExampleProof( 0, 2 ), false )
 
       val p = "P"
-      val x = FOLVar("x")
+      val x = FOLVar( "x" )
       val s = "s"
 
-      val ass = AllVar(x, Imp(FOLAtom(p, x :: Nil), FOLAtom(p, FOLFunction(s, x :: Nil) :: Nil)))
+      val ass = AllVar( x, Imp( FOLAtom( p, x :: Nil ), FOLAtom( p, FOLFunction( s, x :: Nil ) :: Nil ) ) )
 
       val equal_permut_1 = etSeq.antecedent equals List(
-        AtomET(FOLAtom(p, Utils.numeral(0)::Nil)),
+        AtomET( FOLAtom( p, Utils.numeral( 0 ) :: Nil ) ),
         WeakQuantifierET( ass, List(
-          (ImpET( AtomET( FOLAtom(p, Utils.numeral(0)::Nil)), AtomET( FOLAtom(p, Utils.numeral(1)::Nil) ) ), Utils.numeral(0)),
-          (ImpET( AtomET( FOLAtom(p, Utils.numeral(1)::Nil)), AtomET( FOLAtom(p, Utils.numeral(2)::Nil) ) ), Utils.numeral(1)))
-        )
-      )
+          ( ImpET( AtomET( FOLAtom( p, Utils.numeral( 0 ) :: Nil ) ), AtomET( FOLAtom( p, Utils.numeral( 1 ) :: Nil ) ) ), Utils.numeral( 0 ) ),
+          ( ImpET( AtomET( FOLAtom( p, Utils.numeral( 1 ) :: Nil ) ), AtomET( FOLAtom( p, Utils.numeral( 2 ) :: Nil ) ) ), Utils.numeral( 1 ) ) ) ) )
 
       val equal_permut_2 = etSeq.antecedent equals List(
-        AtomET(FOLAtom(p, Utils.numeral(0)::Nil)),
+        AtomET( FOLAtom( p, Utils.numeral( 0 ) :: Nil ) ),
         WeakQuantifierET( ass, List(
-          (ImpET( AtomET( FOLAtom(p, Utils.numeral(1)::Nil)), AtomET( FOLAtom(p, Utils.numeral(2)::Nil) ) ), Utils.numeral(1)),
-          (ImpET( AtomET( FOLAtom(p, Utils.numeral(0)::Nil)), AtomET( FOLAtom(p, Utils.numeral(1)::Nil) ) ), Utils.numeral(0)))
-        )
-      )
+          ( ImpET( AtomET( FOLAtom( p, Utils.numeral( 1 ) :: Nil ) ), AtomET( FOLAtom( p, Utils.numeral( 2 ) :: Nil ) ) ), Utils.numeral( 1 ) ),
+          ( ImpET( AtomET( FOLAtom( p, Utils.numeral( 0 ) :: Nil ) ), AtomET( FOLAtom( p, Utils.numeral( 1 ) :: Nil ) ) ), Utils.numeral( 0 ) ) ) ) )
 
-      (equal_permut_1 || equal_permut_2) must beTrue
+      ( equal_permut_1 || equal_permut_2 ) must beTrue
 
-      etSeq.succedent mustEqual( List( AtomET( FOLAtom(p, Utils.numeral(2)::Nil) ) ) )
+      etSeq.succedent mustEqual ( List( AtomET( FOLAtom( p, Utils.numeral( 2 ) :: Nil ) ) ) )
     }
 
     "do merge triggering a substitution triggering a merge" in {
 
-      val alpha = HOLVar("\\alpha", Ti)
-      val beta = HOLVar("\\beta", Ti)
-      val c = HOLConst("c", Ti)
-      val d = HOLConst("d", Ti)
-      val f = HOLConst("f", Ti->Ti)
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val z = HOLVar("z", Ti)
-      val P = HOLConst("P", Ti->To)
-      val Q = HOLConst("Q", Ti->(Ti->To))
+      val alpha = HOLVar( "\\alpha", Ti )
+      val beta = HOLVar( "\\beta", Ti )
+      val c = HOLConst( "c", Ti )
+      val d = HOLConst( "d", Ti )
+      val f = HOLConst( "f", Ti -> Ti )
+      val x = HOLVar( "x", Ti )
+      val y = HOLVar( "y", Ti )
+      val z = HOLVar( "z", Ti )
+      val P = HOLConst( "P", Ti -> To )
+      val Q = HOLConst( "Q", Ti -> ( Ti -> To ) )
 
-      val p0 = Axiom(List(Atom(P, alpha::Nil), Atom(P, beta::Nil)), // P(a), P(b)
-                     List(Atom(Q, Function(f, alpha::Nil)::c::Nil), Atom(Q, Function(f, beta::Nil)::d::Nil))) // Q(f(a), c), Q(f(b), d)
-      val p1 = ExistsRightRule(p0, Atom(Q, Function(f, alpha::Nil)::c::Nil), ExVar(z, Atom(Q, Function(f, alpha::Nil)::z::Nil)), c)
-      val p2 = ExistsRightRule(p1, Atom(Q, Function(f, beta::Nil)::d::Nil), ExVar(z, Atom(Q, Function(f, beta::Nil)::z::Nil)), d)
+      val p0 = Axiom( List( Atom( P, alpha :: Nil ), Atom( P, beta :: Nil ) ), // P(a), P(b)
+        List( Atom( Q, Function( f, alpha :: Nil ) :: c :: Nil ), Atom( Q, Function( f, beta :: Nil ) :: d :: Nil ) ) ) // Q(f(a), c), Q(f(b), d)
+      val p1 = ExistsRightRule( p0, Atom( Q, Function( f, alpha :: Nil ) :: c :: Nil ), ExVar( z, Atom( Q, Function( f, alpha :: Nil ) :: z :: Nil ) ), c )
+      val p2 = ExistsRightRule( p1, Atom( Q, Function( f, beta :: Nil ) :: d :: Nil ), ExVar( z, Atom( Q, Function( f, beta :: Nil ) :: z :: Nil ) ), d )
 
-      val p2_1 = ExistsRightRule(p2, ExVar(z, Atom(Q, Function(f, alpha::Nil)::z::Nil)), ExVar(y, ExVar(z, Atom(Q, y::z::Nil))), Function(f, alpha::Nil))
-      val p2_2 = ExistsRightRule(p2_1, ExVar(z, Atom(Q, Function(f, beta::Nil)::z::Nil)), ExVar(y, ExVar(z, Atom(Q, y::z::Nil))), Function(f, beta::Nil))
+      val p2_1 = ExistsRightRule( p2, ExVar( z, Atom( Q, Function( f, alpha :: Nil ) :: z :: Nil ) ), ExVar( y, ExVar( z, Atom( Q, y :: z :: Nil ) ) ), Function( f, alpha :: Nil ) )
+      val p2_2 = ExistsRightRule( p2_1, ExVar( z, Atom( Q, Function( f, beta :: Nil ) :: z :: Nil ) ), ExVar( y, ExVar( z, Atom( Q, y :: z :: Nil ) ) ), Function( f, beta :: Nil ) )
 
-      val p2_3 = ContractionRightRule(p2_2, ExVar(y, ExVar(z, Atom(Q, y::z::Nil))))
+      val p2_3 = ContractionRightRule( p2_2, ExVar( y, ExVar( z, Atom( Q, y :: z :: Nil ) ) ) )
 
-      val p3 = ExistsLeftRule(p2_3, Atom(P, alpha::Nil), ExVar(x, Atom(P, x::Nil)), alpha)
-      val p4 = ExistsLeftRule(p3, Atom(P, beta::Nil), ExVar(x, Atom(P, x::Nil)), beta)
-      val p5 = ContractionLeftRule(p4, ExVar(x, Atom(P, x::Nil)))
+      val p3 = ExistsLeftRule( p2_3, Atom( P, alpha :: Nil ), ExVar( x, Atom( P, x :: Nil ) ), alpha )
+      val p4 = ExistsLeftRule( p3, Atom( P, beta :: Nil ), ExVar( x, Atom( P, x :: Nil ) ), beta )
+      val p5 = ContractionLeftRule( p4, ExVar( x, Atom( P, x :: Nil ) ) )
 
-      val (ante, succ) = extractExpansionSequent( p5, false ).toTuple()
+      val ( ante, succ ) = extractExpansionSequent( p5, false ).toTuple()
 
-      ante mustEqual( List(StrongQuantifierET( ExVar(x, Atom(P, x::Nil)), alpha, AtomET(Atom(P, alpha::Nil)))) )
+      ante mustEqual ( List( StrongQuantifierET( ExVar( x, Atom( P, x :: Nil ) ), alpha, AtomET( Atom( P, alpha :: Nil ) ) ) ) )
       // this assumes that the first variable wins, f(beta) would also be valid
-      val f_alpha = Function(f, alpha::Nil)
-      succ mustEqual( List(WeakQuantifierET(  ExVar(y, ExVar(z, Atom(Q, y::z::Nil)) ),
-                            List(
-                               (WeakQuantifierET( ExVar(z, Atom(Q, f_alpha::z::Nil)),
-                                    List( (AtomET(Atom(Q, f_alpha::c::Nil)), c),
-                                          (AtomET(Atom(Q, f_alpha::d::Nil)), d))),
-                               f_alpha)
-                            )
-      )))
+      val f_alpha = Function( f, alpha :: Nil )
+      succ mustEqual ( List( WeakQuantifierET( ExVar( y, ExVar( z, Atom( Q, y :: z :: Nil ) ) ),
+        List(
+          ( WeakQuantifierET( ExVar( z, Atom( Q, f_alpha :: z :: Nil ) ),
+            List( ( AtomET( Atom( Q, f_alpha :: c :: Nil ) ), c ),
+              ( AtomET( Atom( Q, f_alpha :: d :: Nil ) ), d ) ) ),
+            f_alpha ) ) ) ) )
 
     }
 
     "handle polarity" in {
-      val p0 = Axiom(BottomC::Nil, TopC::Nil)
-      val p1 = WeakeningRightRule(p0, TopC) // weakened, hence bot on right side
-      val p2 = ContractionRightRule(p1, TopC) // polarity is positive, so bottom [merge] top = top
-      val p3 = WeakeningLeftRule(p2, BottomC) // weakened, hence top on left side
-      val p4 = ContractionLeftRule(p3, BottomC) // negative polarity, bottom must win
+      val p0 = Axiom( BottomC :: Nil, TopC :: Nil )
+      val p1 = WeakeningRightRule( p0, TopC ) // weakened, hence bot on right side
+      val p2 = ContractionRightRule( p1, TopC ) // polarity is positive, so bottom [merge] top = top
+      val p3 = WeakeningLeftRule( p2, BottomC ) // weakened, hence top on left side
+      val p4 = ContractionLeftRule( p3, BottomC ) // negative polarity, bottom must win
 
-      val (ante, succ) = extractExpansionSequent(p4, false).toTuple()
-      ante mustEqual AtomET(BottomC)::Nil
-      succ mustEqual AtomET(TopC)::Nil
+      val ( ante, succ ) = extractExpansionSequent( p4, false ).toTuple()
+      ante mustEqual AtomET( BottomC ) :: Nil
+      succ mustEqual AtomET( TopC ) :: Nil
     }
 
     "handle multiple formulas in axiom" in {
       val s = "s"
-      val c = FOLConst("c")
-      val d = FOLConst("d")
-      val x = FOLVar("x")
+      val c = FOLConst( "c" )
+      val d = FOLConst( "d" )
+      val x = FOLVar( "x" )
       val p = "P"
 
-      val f = AllVar(x, FOLAtom(p, x::Nil))
+      val f = AllVar( x, FOLAtom( p, x :: Nil ) )
 
-      val p0_0 = Axiom(FOLAtom(p, c::Nil)::f::Nil, FOLAtom(p, c::Nil)::Nil)
+      val p0_0 = Axiom( FOLAtom( p, c :: Nil ) :: f :: Nil, FOLAtom( p, c :: Nil ) :: Nil )
 
-      val p0_1 = Axiom(FOLAtom(p, d::Nil)::Nil, FOLAtom(p, d::Nil)::Nil)
-      val p0_2 = ForallLeftRule(p0_1, FOLAtom(p, d::Nil), f, d)
+      val p0_1 = Axiom( FOLAtom( p, d :: Nil ) :: Nil, FOLAtom( p, d :: Nil ) :: Nil )
+      val p0_2 = ForallLeftRule( p0_1, FOLAtom( p, d :: Nil ), f, d )
 
-      val p1 = AndRightRule(p0_0, p0_2, FOLAtom(p, c::Nil), FOLAtom(p, d::Nil))
-      val p2 = ContractionLeftRule(p1, f)
+      val p1 = AndRightRule( p0_0, p0_2, FOLAtom( p, c :: Nil ), FOLAtom( p, d :: Nil ) )
+      val p2 = ContractionLeftRule( p1, f )
 
-      val etSeq = extractExpansionSequent(p2, false)
+      val etSeq = extractExpansionSequent( p2, false )
 
-      etSeq.antecedent.count(_.isInstanceOf[WeakQuantifierET]) mustEqual 1
-      etSeq.antecedent.count(_.isInstanceOf[AtomET]) mustEqual 1
+      etSeq.antecedent.count( _.isInstanceOf[WeakQuantifierET] ) mustEqual 1
+      etSeq.antecedent.count( _.isInstanceOf[AtomET] ) mustEqual 1
 
     }
   }

--- a/src/test/scala/at/logic/transformations/herbrandSequent/lksk/extractLKSKExpansionTreesTest.scala
+++ b/src/test/scala/at/logic/transformations/herbrandSequent/lksk/extractLKSKExpansionTreesTest.scala
@@ -5,216 +5,211 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import at.logic.calculi.lk._
 import at.logic.language.hol._
-import at.logic.calculi.lk.base.{FSequent, Sequent}
-import at.logic.language.lambda.types.{Ti, To}
+import at.logic.calculi.lk.base.{ FSequent, Sequent }
+import at.logic.language.lambda.types.{ Ti, To }
 import at.logic.calculi.lksk
 import at.logic.transformations.herbrandExtraction.lksk.extractLKSKExpansionSequent
-import at.logic.calculi.expansionTrees.{Atom => AtomTree, Neg => NegTree, SkolemQuantifier, ExpansionTree, ExpansionSequent, WeakQuantifier, Imp => ImpTree}
+import at.logic.calculi.expansionTrees.{ Atom => AtomTree, Neg => NegTree, SkolemQuantifier, ExpansionTree, ExpansionSequent, WeakQuantifier, Imp => ImpTree }
 import at.logic.calculi.lksk.LabelledFormulaOccurrence
-import at.logic.transformations.skolemization.lksk.{LKtoLKskc => skolemize }
+import at.logic.transformations.skolemization.lksk.{ LKtoLKskc => skolemize }
 
 /**
  * Created by marty on 8/7/14.
  */
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class extractLKSKExpansionSequentTest extends SpecificationWithJUnit {
   object simpleHOLProof {
-    val p = Atom(HOLConst("P", To), Nil)
-    val x = HOLVar("X", To)
-    val xatom = Atom(x, Nil)
-    val existsx = ExVar(x,xatom)
+    val p = Atom( HOLConst( "P", To ), Nil )
+    val x = HOLVar( "X", To )
+    val xatom = Atom( x, Nil )
+    val existsx = ExVar( x, xatom )
 
-    val ax = Axiom(List(p), List(p))
-    val i1 = ExistsRightRule(ax, ax.root.succedent(0), existsx, p)
-    val i2 = NegRightRule(i1, i1.root.antecedent(0))
-    val i3 = ExistsRightRule(i2, i2.root.succedent(1), existsx, Neg(p))
-    val i4 = ContractionRightRule(i3, i3.root.succedent(0), i3.root.succedent(1))
-    val proof = skolemize(i4)
+    val ax = Axiom( List( p ), List( p ) )
+    val i1 = ExistsRightRule( ax, ax.root.succedent( 0 ), existsx, p )
+    val i2 = NegRightRule( i1, i1.root.antecedent( 0 ) )
+    val i3 = ExistsRightRule( i2, i2.root.succedent( 1 ), existsx, Neg( p ) )
+    val i4 = ContractionRightRule( i3, i3.root.succedent( 0 ), i3.root.succedent( 1 ) )
+    val proof = skolemize( i4 )
   }
 
   object simpleLKSKProof {
-    val p = Atom(HOLConst("P", To), Nil)
-    val x = HOLVar("X", To)
-    val xatom = Atom(x, Nil)
-    val existsx = ExVar(x,xatom)
+    val p = Atom( HOLConst( "P", To ), Nil )
+    val x = HOLVar( "X", To )
+    val xatom = Atom( x, Nil )
+    val existsx = ExVar( x, xatom )
 
-    val (ax,_) = lksk.Axiom.createDefault(FSequent(List(p), List(p)), (List(Set(Neg(p))), List(Set(p))) )
-    val i1 = lksk.ExistsSkRightRule(ax, ax.root.succedent(0).asInstanceOf[LabelledFormulaOccurrence], existsx, p, true )
-    val i2 = NegRightRule(i1, i1.root.antecedent(0))
-    val i3 = lksk.ExistsSkRightRule(i2, i2.root.succedent(1).asInstanceOf[LabelledFormulaOccurrence], existsx, Neg(p), true)
-    val i4 = ContractionRightRule(i3, i3.root.succedent(0), i3.root.succedent(1))
+    val ( ax, _ ) = lksk.Axiom.createDefault( FSequent( List( p ), List( p ) ), ( List( Set( Neg( p ) ) ), List( Set( p ) ) ) )
+    val i1 = lksk.ExistsSkRightRule( ax, ax.root.succedent( 0 ).asInstanceOf[LabelledFormulaOccurrence], existsx, p, true )
+    val i2 = NegRightRule( i1, i1.root.antecedent( 0 ) )
+    val i3 = lksk.ExistsSkRightRule( i2, i2.root.succedent( 1 ).asInstanceOf[LabelledFormulaOccurrence], existsx, Neg( p ), true )
+    val i4 = ContractionRightRule( i3, i3.root.succedent( 0 ), i3.root.succedent( 1 ) )
   }
 
-
   object simpleHOLProof2 {
-    val x = HOLVar("X", Ti -> To)
-    val a = HOLVar("\\alpha", Ti)
-    val u = HOLVar("u", Ti)
+    val x = HOLVar( "X", Ti -> To )
+    val a = HOLVar( "\\alpha", Ti )
+    val u = HOLVar( "u", Ti )
 
-    val p = HOLConst("P", Ti -> To)
-    val pa = Atom(p, List(a))
-    val pu = Atom(p, List(u))
-    val xatoma = Atom(x, List(a))
-    val xatomu = Atom(x, List(u))
+    val p = HOLConst( "P", Ti -> To )
+    val pa = Atom( p, List( a ) )
+    val pu = Atom( p, List( u ) )
+    val xatoma = Atom( x, List( a ) )
+    val xatomu = Atom( x, List( u ) )
 
-    val existsx = ExVar(x,xatoma)
-    val alluexistsx = AllVar(u,ExVar(x,xatomu))
+    val existsx = ExVar( x, xatoma )
+    val alluexistsx = AllVar( u, ExVar( x, xatomu ) )
 
-    val ax = Axiom(List(pa), List(pa))
-    val i1 = ExistsRightRule(ax, ax.root.succedent(0), existsx, HOLAbs(u,pu) )
-    val i2 = NegRightRule(i1, i1.root.antecedent(0))
-    val i3 = ExistsRightRule(i2, i2.root.succedent(1), existsx, HOLAbs(u, Neg(pu)))
-    val i4 = ContractionRightRule(i3, i3.root.succedent(0), i3.root.succedent(1))
-    val i5 = ForallRightRule(i4, i4.root.succedent(0), alluexistsx, a)
+    val ax = Axiom( List( pa ), List( pa ) )
+    val i1 = ExistsRightRule( ax, ax.root.succedent( 0 ), existsx, HOLAbs( u, pu ) )
+    val i2 = NegRightRule( i1, i1.root.antecedent( 0 ) )
+    val i3 = ExistsRightRule( i2, i2.root.succedent( 1 ), existsx, HOLAbs( u, Neg( pu ) ) )
+    val i4 = ContractionRightRule( i3, i3.root.succedent( 0 ), i3.root.succedent( 1 ) )
+    val i5 = ForallRightRule( i4, i4.root.succedent( 0 ), alluexistsx, a )
 
-    val proof = skolemize(i5)
+    val proof = skolemize( i5 )
   }
 
   object simpleHOLProof3 {
-    val p = HOLConst("P", Ti -> To)
-    val a = HOLVar("\\alpha", Ti)
-    val u = HOLVar("u", Ti)
+    val p = HOLConst( "P", Ti -> To )
+    val a = HOLVar( "\\alpha", Ti )
+    val u = HOLVar( "u", Ti )
 
-    val pa = Atom(p, a::Nil)
-    val pu = Atom(p, u::Nil)
-    val allpu = AllVar(u, pu)
+    val pa = Atom( p, a :: Nil )
+    val pu = Atom( p, u :: Nil )
+    val allpu = AllVar( u, pu )
 
-    val x = HOLVar("X", To)
-    val xatom = Atom(x, Nil)
-    val existsx = ExVar(x,xatom)
+    val x = HOLVar( "X", To )
+    val xatom = Atom( x, Nil )
+    val existsx = ExVar( x, xatom )
 
-    val ax = Axiom(List(pa), List(pa))
-    val i0a = ForallLeftRule(ax, ax.root.antecedent(0), allpu, a)
-    val i0b = ForallRightRule(i0a, i0a.root.succedent(0), allpu, a)
-    val i1 = ExistsRightRule(i0b, i0b.root.succedent(0), existsx, allpu)
-    val i2 = NegRightRule(i1, i1.root.antecedent(0))
-    val i3 = ExistsRightRule(i2, i2.root.succedent(1), existsx, Neg(allpu))
-    val i4 = ContractionRightRule(i3, i3.root.succedent(0), i3.root.succedent(1))
-    val proof = skolemize(i4)
+    val ax = Axiom( List( pa ), List( pa ) )
+    val i0a = ForallLeftRule( ax, ax.root.antecedent( 0 ), allpu, a )
+    val i0b = ForallRightRule( i0a, i0a.root.succedent( 0 ), allpu, a )
+    val i1 = ExistsRightRule( i0b, i0b.root.succedent( 0 ), existsx, allpu )
+    val i2 = NegRightRule( i1, i1.root.antecedent( 0 ) )
+    val i3 = ExistsRightRule( i2, i2.root.succedent( 1 ), existsx, Neg( allpu ) )
+    val i4 = ContractionRightRule( i3, i3.root.succedent( 0 ), i3.root.succedent( 1 ) )
+    val proof = skolemize( i4 )
   }
-
 
   object simpleHOLProof4 {
-    val p = HOLConst("P", Ti -> To)
-    val a = HOLVar("\\alpha", Ti)
-    val u = HOLVar("u", Ti)
+    val p = HOLConst( "P", Ti -> To )
+    val a = HOLVar( "\\alpha", Ti )
+    val u = HOLVar( "u", Ti )
 
-    val pa = Atom(p, a::Nil)
-    val pu = Atom(p, u::Nil)
-    val allpu = AllVar(u, pu)
+    val pa = Atom( p, a :: Nil )
+    val pu = Atom( p, u :: Nil )
+    val allpu = AllVar( u, pu )
 
-    val x = HOLVar("X", To)
-    val xatom = Atom(x, Nil)
-    val existsx = ExVar(x,xatom)
+    val x = HOLVar( "X", To )
+    val xatom = Atom( x, Nil )
+    val existsx = ExVar( x, xatom )
 
-    val ax = Axiom(List(pa), List(pa))
-    val i0a = ForallLeftRule(ax, ax.root.antecedent(0), allpu, a)
-    val i0b = ForallRightRule(i0a, i0a.root.succedent(0), allpu, a)
-    val i1 = ExistsRightRule(i0b, i0b.root.succedent(0), existsx, allpu)
-    val i2 = NegRightRule(i1, i1.root.antecedent(0))
-    val i2a = WeakeningLeftRule(i2, allpu)
-    val i2b = ImpRightRule(i2a, i2a.root.antecedent(0), i2a.root.succedent(1))
-    val i3 = ExistsRightRule(i2b, i2b.root.succedent(1), existsx, Imp(allpu, Neg(allpu)) )
-    val i4 = ContractionRightRule(i3, i3.root.succedent(0), i3.root.succedent(1))
-    val proof = skolemize(i4)
+    val ax = Axiom( List( pa ), List( pa ) )
+    val i0a = ForallLeftRule( ax, ax.root.antecedent( 0 ), allpu, a )
+    val i0b = ForallRightRule( i0a, i0a.root.succedent( 0 ), allpu, a )
+    val i1 = ExistsRightRule( i0b, i0b.root.succedent( 0 ), existsx, allpu )
+    val i2 = NegRightRule( i1, i1.root.antecedent( 0 ) )
+    val i2a = WeakeningLeftRule( i2, allpu )
+    val i2b = ImpRightRule( i2a, i2a.root.antecedent( 0 ), i2a.root.succedent( 1 ) )
+    val i3 = ExistsRightRule( i2b, i2b.root.succedent( 1 ), existsx, Imp( allpu, Neg( allpu ) ) )
+    val i4 = ContractionRightRule( i3, i3.root.succedent( 0 ), i3.root.succedent( 1 ) )
+    val proof = skolemize( i4 )
   }
-
-
-
 
   "LKSK Expansion Tree Extraction" should {
     "work for an hol proof with only weak quantifiers" in {
 
-      val et = extractLKSKExpansionSequent(simpleHOLProof.i4, false)
+      val et = extractLKSKExpansionSequent( simpleHOLProof.i4, false )
 
-      val inst1 : (ExpansionTree, HOLFormula) = (AtomTree(simpleHOLProof.p), simpleHOLProof.p)
-      val inst2 : (ExpansionTree, HOLFormula) = (NegTree(AtomTree(simpleHOLProof.p)), Neg(simpleHOLProof.p))
-      val cet : ExpansionTree = WeakQuantifier(simpleHOLProof.existsx, List(inst1, inst2)).asInstanceOf[ExpansionTree] //TODO: this cast is ugly
+      val inst1: ( ExpansionTree, HOLFormula ) = ( AtomTree( simpleHOLProof.p ), simpleHOLProof.p )
+      val inst2: ( ExpansionTree, HOLFormula ) = ( NegTree( AtomTree( simpleHOLProof.p ) ), Neg( simpleHOLProof.p ) )
+      val cet: ExpansionTree = WeakQuantifier( simpleHOLProof.existsx, List( inst1, inst2 ) ).asInstanceOf[ExpansionTree] //TODO: this cast is ugly
 
-      val control = ExpansionSequent(Nil, List(cet))
+      val control = ExpansionSequent( Nil, List( cet ) )
 
-      et must_==(control)
+      et must_== ( control )
     }
 
     "work for the same hol proof, automatically skolemized" in {
-      val ExpansionSequent((Nil, List(et))) = extractLKSKExpansionSequent(simpleHOLProof.proof, false)
+      val ExpansionSequent( ( Nil, List( et ) ) ) = extractLKSKExpansionSequent( simpleHOLProof.proof, false )
 
       val r = et match {
-        case WeakQuantifier(_, Seq(
-        (AtomTree(_),_),
-        (NegTree(AtomTree(_)),_))
-        ) =>
+        case WeakQuantifier( _, Seq(
+          ( AtomTree( _ ), _ ),
+          ( NegTree( AtomTree( _ ) ), _ ) )
+          ) =>
           ""
         case _ =>
-          "expansion tree "+et+" does not match expected pattern!"
+          "expansion tree " + et + " does not match expected pattern!"
       }
 
-      r must_==("")
+      r must_== ( "" )
     }
 
     "work for the same hol proof, manually skolemized" in {
-      val ExpansionSequent((Nil, List(et))) = extractLKSKExpansionSequent(simpleLKSKProof.i4, false)
+      val ExpansionSequent( ( Nil, List( et ) ) ) = extractLKSKExpansionSequent( simpleLKSKProof.i4, false )
 
       val r = et match {
-        case WeakQuantifier(_, Seq(
-        (AtomTree(_),_),
-        (NegTree(AtomTree(_)),_))
-        ) =>
+        case WeakQuantifier( _, Seq(
+          ( AtomTree( _ ), _ ),
+          ( NegTree( AtomTree( _ ) ), _ ) )
+          ) =>
           ""
         case _ =>
-          "expansion tree "+et+" does not match expected pattern!"
+          "expansion tree " + et + " does not match expected pattern!"
       }
 
-      r must_==("")
+      r must_== ( "" )
     }
 
     "work for a skolemized hol proof with strong individual quantifiers" in {
-      val ExpansionSequent((Nil, List(et))) = extractLKSKExpansionSequent(simpleHOLProof2.proof, false)
+      val ExpansionSequent( ( Nil, List( et ) ) ) = extractLKSKExpansionSequent( simpleHOLProof2.proof, false )
 
       val r = et match {
-        case SkolemQuantifier(_,sk,
-          WeakQuantifier(_, Seq(
-            (AtomTree(_),_),
-            (NegTree(AtomTree(_)),_))
-        )) =>
+        case SkolemQuantifier( _, sk,
+          WeakQuantifier( _, Seq(
+            ( AtomTree( _ ), _ ),
+            ( NegTree( AtomTree( _ ) ), _ ) )
+            ) ) =>
           ""
         case _ =>
-          "expansion tree "+et+" does not match expected pattern!"
+          "expansion tree " + et + " does not match expected pattern!"
       }
 
-      r must_==("")
+      r must_== ( "" )
     }
 
     "work for a skolemized hol proof with strong individual quantifiers inside weak ho quantifiers" in {
-      val ExpansionSequent((Nil, List(et))) = extractLKSKExpansionSequent(simpleHOLProof3.proof, false)
+      val ExpansionSequent( ( Nil, List( et ) ) ) = extractLKSKExpansionSequent( simpleHOLProof3.proof, false )
 
       val r = et match {
-        case WeakQuantifier(_, Seq(
-              (SkolemQuantifier(_,sk1,AtomTree(_)),_),
-              (NegTree( WeakQuantifier(_,Seq((AtomTree(_), sk2)))  ), _)
-            )) =>
+        case WeakQuantifier( _, Seq(
+          ( SkolemQuantifier( _, sk1, AtomTree( _ ) ), _ ),
+          ( NegTree( WeakQuantifier( _, Seq( ( AtomTree( _ ), sk2 ) ) ) ), _ )
+          ) ) =>
           ""
         case _ =>
-          "expansion tree "+et+" does not match expected pattern!"
+          "expansion tree " + et + " does not match expected pattern!"
       }
 
-      r must_==("")
+      r must_== ( "" )
     }
 
     "work for a skolemized hol proof with weakening" in {
-      val ExpansionSequent((Nil, List(et))) = extractLKSKExpansionSequent(simpleHOLProof4.proof, false)
+      val ExpansionSequent( ( Nil, List( et ) ) ) = extractLKSKExpansionSequent( simpleHOLProof4.proof, false )
 
       val r = et match {
-        case WeakQuantifier(_, Seq(
-        (SkolemQuantifier(_,sk1,AtomTree(_)),_),
-        (ImpTree(AtomTree(_), NegTree( WeakQuantifier(_,Seq((AtomTree(_), sk2)))  )), _)
-        )) =>
+        case WeakQuantifier( _, Seq(
+          ( SkolemQuantifier( _, sk1, AtomTree( _ ) ), _ ),
+          ( ImpTree( AtomTree( _ ), NegTree( WeakQuantifier( _, Seq( ( AtomTree( _ ), sk2 ) ) ) ) ), _ )
+          ) ) =>
           ""
         case _ =>
-          "expansion tree "+et+" does not match expected pattern!"
+          "expansion tree " + et + " does not match expected pattern!"
       }
 
-      r must_==("")
+      r must_== ( "" )
     }
   }
 

--- a/src/test/scala/at/logic/transformations/skolemization/SkolemizationTest.scala
+++ b/src/test/scala/at/logic/transformations/skolemization/SkolemizationTest.scala
@@ -7,7 +7,7 @@
 
 package at.logic.transformations.skolemization
 
-import at.logic.calculi.lk.base.{beSyntacticMultisetEqual, LKProof, Sequent}
+import at.logic.calculi.lk.base.{ beSyntacticMultisetEqual, LKProof, Sequent }
 
 import at.logic.language.hol._
 import at.logic.calculi.lk._
@@ -19,22 +19,22 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.lambda.symbols.StringSymbol
 import at.logic.language.lambda.types._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class SkolemizationTest extends SpecificationWithJUnit {
 
   sequential
   "Skolemization" should {
-      val x = HOLVar("x", Ti)
-      val y = HOLVar("y", Ti)
-      val f = AllVar( x, Atom(HOLConst("P", Ti -> To), x::Nil ) )
-      val s0 = StringSymbol( "s_{0}" )
-      val s1 = StringSymbol( "s_{2}" )
-      val s2 = StringSymbol( "s_{4}" )
-      val s3 = StringSymbol( "s_{6}" )
-      SkolemSymbolFactory.reset
-      val stream = SkolemSymbolFactory.getSkolemSymbols
-      val p = HOLConst("P", Ti -> To)
-      val r = HOLConst("R", Ti -> (Ti -> To))
+    val x = HOLVar( "x", Ti )
+    val y = HOLVar( "y", Ti )
+    val f = AllVar( x, Atom( HOLConst( "P", Ti -> To ), x :: Nil ) )
+    val s0 = StringSymbol( "s_{0}" )
+    val s1 = StringSymbol( "s_{2}" )
+    val s2 = StringSymbol( "s_{4}" )
+    val s3 = StringSymbol( "s_{6}" )
+    SkolemSymbolFactory.reset
+    val stream = SkolemSymbolFactory.getSkolemSymbols
+    val p = HOLConst( "P", Ti -> To )
+    val r = HOLConst( "R", Ti -> ( Ti -> To ) )
 
     "leave a formula with only weak quantifiers untouched" in {
       skolemize( f, 1, stream ) must beEqualTo( f )
@@ -42,27 +42,27 @@ class SkolemizationTest extends SpecificationWithJUnit {
 
     "introduce correctly a Skolem constant" in {
       val skfun = HOLConst( stream.head, Ti )
-      val skf = Atom( p, skfun::Nil )
+      val skf = Atom( p, skfun :: Nil )
       skolemize( f, 0, stream ) must beEqualTo( skf )
     }
 
     "handle a binary formula correctly" in {
-      val y = HOLVar(StringSymbol("y"), Ti)
-      val rxy = Atom( r, x::y::Nil )
-      val f2 = Imp(f, AllVar( x, ExVar( y, rxy ) ) )
+      val y = HOLVar( StringSymbol( "y" ), Ti )
+      val rxy = Atom( r, x :: y :: Nil )
+      val f2 = Imp( f, AllVar( x, ExVar( y, rxy ) ) )
 
       val skfun0 = HOLConst( stream.head, Ti )
-      val skfun1 = Function( HOLConst(stream.tail.head, Ti->Ti), x::Nil )
-      val skf1 = Atom( p, skfun0::Nil )
-      val skf2 = Atom( r, x::skfun1::Nil )
+      val skfun1 = Function( HOLConst( stream.tail.head, Ti -> Ti ), x :: Nil )
+      val skf1 = Atom( p, skfun0 :: Nil )
+      val skf2 = Atom( r, x :: skfun1 :: Nil )
 
       val skf = Imp( skf1, AllVar( x, skf2 ) )
       skolemize( f2, 1, stream ) must beEqualTo( skf )
 
       // now we skolemize the skolemize formula, with opposite polarity
       val skfun2 = HOLConst( stream.tail.tail.head, Ti )
-      val skfun3 = Function( HOLConst(stream.tail.head, Ti->Ti), skfun2::Nil )
-      val skf3 = Atom( r, skfun2::skfun3::Nil )
+      val skfun3 = Function( HOLConst( stream.tail.head, Ti -> Ti ), skfun2 :: Nil )
+      val skf3 = Atom( r, skfun2 :: skfun3 :: Nil )
       val skf4 = Imp( skf1, skf3 )
       skolemize( skolemize( f2, 1, stream ), 0, stream.tail ) must beEqualTo( skf4 )
     }
@@ -71,20 +71,20 @@ class SkolemizationTest extends SpecificationWithJUnit {
       val s5 = StringSymbol( "s_{5}" )
       val cs5 = HOLConst( s5, Ti )
       val alpha = HOLVar( StringSymbol( "α" ), Ti )
-      val Palpha = Atom( p, alpha::Nil )
-      val Ps0 = Atom( p, cs5::Nil )
-      val allxPx = AllVar( x, Atom( p, x::Nil ) )
-      val ax = Axiom( Palpha::Nil, Palpha::Nil  )
+      val Palpha = Atom( p, alpha :: Nil )
+      val Ps0 = Atom( p, cs5 :: Nil )
+      val allxPx = AllVar( x, Atom( p, x :: Nil ) )
+      val ax = Axiom( Palpha :: Nil, Palpha :: Nil )
       val proof = ForallRightRule(
-                    ForallLeftRule( ax,
-                                    Palpha, allxPx, alpha ),
-                    Palpha, allxPx, alpha )
+        ForallLeftRule( ax,
+          Palpha, allxPx, alpha ),
+        Palpha, allxPx, alpha )
 
-      val ax_sk = Axiom(  Ps0::Nil, Ps0::Nil  )
+      val ax_sk = Axiom( Ps0 :: Nil, Ps0 :: Nil )
       val proof_sk = ForallLeftRule( ax_sk, Ps0, allxPx, cs5 )
 
       val res = skolemize( proof )
-      res.root.toFSequent must beEqualTo (proof_sk.root.toFSequent)
+      res.root.toFSequent must beEqualTo( proof_sk.root.toFSequent )
     }
 
     "work for a cut-free proof (1)" in {
@@ -107,42 +107,41 @@ class SkolemizationTest extends SpecificationWithJUnit {
       all x.R(x,s0(x)) :- ex y. R(s1,y)
        */
 
-      val a = HOLVar("a", Ti)
-      val b = HOLVar("b", Ti)
-      val Rab = Atom( r, a::b::Nil )
-      val exyRay = ExVar( y, Atom( r, a::y::Nil ) )
-      val allxexyRxy = AllVar( x, ExVar( y, Atom( r, x::y::Nil ) ) )
-      val ax = Axiom( Rab::Nil, Rab::Nil )
-      val r1 = ExistsRightRule( ax, ax.root.succedent(0), exyRay, b )
-      val r2 = ExistsLeftRule( r1, r1.root.antecedent(0) , exyRay, b )
-      val r3 = ForallLeftRule( r2, r2.root.antecedent(0), allxexyRxy, a )
-      val proof : LKProof = ForallRightRule( r3, exyRay, allxexyRxy, a )
+      val a = HOLVar( "a", Ti )
+      val b = HOLVar( "b", Ti )
+      val Rab = Atom( r, a :: b :: Nil )
+      val exyRay = ExVar( y, Atom( r, a :: y :: Nil ) )
+      val allxexyRxy = AllVar( x, ExVar( y, Atom( r, x :: y :: Nil ) ) )
+      val ax = Axiom( Rab :: Nil, Rab :: Nil )
+      val r1 = ExistsRightRule( ax, ax.root.succedent( 0 ), exyRay, b )
+      val r2 = ExistsLeftRule( r1, r1.root.antecedent( 0 ), exyRay, b )
+      val r3 = ForallLeftRule( r2, r2.root.antecedent( 0 ), allxexyRxy, a )
+      val proof: LKProof = ForallRightRule( r3, exyRay, allxexyRxy, a )
 
-      val fs0 = HOLConst( StringSymbol("s_{0}"), Ti -> Ti )
-      val s1c = HOLConst( StringSymbol("s_{2}"), Ti)
-      val s0s1 = HOLApp( fs0,  s1c)
-      val sR = Atom( r, List(s1c,s0s1) )
-      val sax = Axiom( List(sR), List(sR) )
+      val fs0 = HOLConst( StringSymbol( "s_{0}" ), Ti -> Ti )
+      val s1c = HOLConst( StringSymbol( "s_{2}" ), Ti )
+      val s0s1 = HOLApp( fs0, s1c )
+      val sR = Atom( r, List( s1c, s0s1 ) )
+      val sax = Axiom( List( sR ), List( sR ) )
 
-      val exyRs1y = ExVar( y, Atom( r, List(s1c, y )))
-//      val exyRs1s0s1 = ExVar( y, Atom( r, List(a,y) ) )
-      val sr1 = ExistsRightRule( sax, sax.root.succedent(0), exyRs1y, s0s1 )
+      val exyRs1y = ExVar( y, Atom( r, List( s1c, y ) ) )
+      //      val exyRs1s0s1 = ExVar( y, Atom( r, List(a,y) ) )
+      val sr1 = ExistsRightRule( sax, sax.root.succedent( 0 ), exyRs1y, s0s1 )
 
-      val allxRxs0x = AllVar( x, Atom( r, List(x, HOLApp(fs0, x)) ))
-      val sr2 = ForallLeftRule( sr1, sr1.root.antecedent(0) , allxRxs0x, s1c )
+      val allxRxs0x = AllVar( x, Atom( r, List( x, HOLApp( fs0, x ) ) ) )
+      val sr2 = ForallLeftRule( sr1, sr1.root.antecedent( 0 ), allxRxs0x, s1c )
       val proof_sk = sr2
 
       SkolemSymbolFactory.reset
 
       //println("=== starting skolemization ===")
-      val skolemized_proof : LKProof = skolemize( proof )
+      val skolemized_proof: LKProof = skolemize( proof )
       //println("=== endsequent skolemized ===")
       //println(skolemized_proof.root)
       //println(proof_sk.root)
 
-      skolemized_proof.root must beSyntacticMultisetEqual (proof_sk.root)
+      skolemized_proof.root must beSyntacticMultisetEqual( proof_sk.root )
+    }
+
   }
-
-
-
-  }}
+}

--- a/src/test/scala/at/logic/transformations/skolemization/lksk/LKskcTest.scala
+++ b/src/test/scala/at/logic/transformations/skolemization/lksk/LKskcTest.scala
@@ -10,9 +10,9 @@ package at.logic.transformations.skolemization.lksk
 import at.logic.language.hol._
 import at.logic.language.lambda.symbols._
 import at.logic.calculi.occurrences._
-import at.logic.calculi.lk.base.{LKProof, Sequent}
-import at.logic.calculi.lk.{OrLeftRule, Axiom => LKAxiom}
-import at.logic.calculi.lk.{ForallLeftRule, ForallRightRule, ExistsLeftRule, ExistsRightRule}
+import at.logic.calculi.lk.base.{ LKProof, Sequent }
+import at.logic.calculi.lk.{ OrLeftRule, Axiom => LKAxiom }
+import at.logic.calculi.lk.{ ForallLeftRule, ForallRightRule, ExistsLeftRule, ExistsRightRule }
 import at.logic.calculi.lksk._
 import org.junit.runner.RunWith
 import org.specs2.mutable.SpecificationWithJUnit
@@ -20,55 +20,55 @@ import org.specs2.runner.JUnitRunner
 import at.logic.language.lambda.types._
 import at.logic.calculi.lksk.TypeSynonyms.EmptyLabel
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class LKskcTest extends SpecificationWithJUnit {
 
   "Transformation from LK to LKskc" should {
-    val x = HOLVar("x", Ti)
-    val y = HOLVar("y", Ti)
-    val c = HOLConst("c", Ti)
-    val r = HOLConst("R", Ti -> (Ti -> To))
+    val x = HOLVar( "x", Ti )
+    val y = HOLVar( "y", Ti )
+    val c = HOLConst( "c", Ti )
+    val r = HOLConst( "R", Ti -> ( Ti -> To ) )
 
     "work for a small proof with only weak quantifiers" in {
-      val Rcc = Atom(r, c::c::Nil)
-      val Rcx = Atom(r, c::x::Nil)
-      val Ryx = Atom(r, y::x::Nil)
+      val Rcc = Atom( r, c :: c :: Nil )
+      val Rcx = Atom( r, c :: x :: Nil )
+      val Ryx = Atom( r, y :: x :: Nil )
       val allxRcx = AllVar( x, Rcx )
       val allyallxRyx = AllVar( y, AllVar( x, Ryx ) )
-      val proof = ForallLeftRule( 
-                    ForallLeftRule( 
-                      LKAxiom( Rcc::Nil, Nil ),
-                    Rcc, allxRcx, c ),
-                  allxRcx, allyallxRyx, c )
-      val lkskc_proof = LKtoLKskc( proof, Set())
+      val proof = ForallLeftRule(
+        ForallLeftRule(
+          LKAxiom( Rcc :: Nil, Nil ),
+          Rcc, allxRcx, c ),
+        allxRcx, allyallxRyx, c )
+      val lkskc_proof = LKtoLKskc( proof, Set() )
 
       lkskc_proof.root.antecedent.toList.head must beLike {
-        case o : LabelledFormulaOccurrence =>
+        case o: LabelledFormulaOccurrence =>
           o.skolem_label == EmptyLabel() && o.formula == proof.root.antecedent.head.formula must_== true
       }
     }
 
     "work for a cut-free proof" in {
-      val a = HOLVar("a", Ti)
-      val b = HOLVar("b", Ti)
-      val Rab = Atom( r, a::b::Nil )
-      val exyRay = ExVar( y, Atom( r, a::y::Nil ) )
-      val allxexyRxy = AllVar( x, ExVar( y, Atom( r, x::y::Nil ) ) )
-      val ax = LKAxiom( Rab::Nil, Rab::Nil  )
+      val a = HOLVar( "a", Ti )
+      val b = HOLVar( "b", Ti )
+      val Rab = Atom( r, a :: b :: Nil )
+      val exyRay = ExVar( y, Atom( r, a :: y :: Nil ) )
+      val allxexyRxy = AllVar( x, ExVar( y, Atom( r, x :: y :: Nil ) ) )
+      val ax = LKAxiom( Rab :: Nil, Rab :: Nil )
       val r1 = ExistsRightRule( ax, Rab, exyRay, b )
       val r2 = ExistsLeftRule( r1, Rab, exyRay, b )
       val r3 = ForallLeftRule( r2, exyRay, allxexyRxy, a )
       val r4 = ForallRightRule( r3, exyRay, allxexyRxy, a )
       val lkskc_proof = LKtoLKskc( r4, Set() )
 
-      val occurrences : Set[FormulaOccurrence] = lkskc_proof.nodes.flatMap(x => x.asInstanceOf[LKProof].root.occurrences).toSet
-      val constants = occurrences.flatMap(x => subTerms(x.formula).filter(_ match { case VarOrConst(_,_) => true; case _ => false }))
-      println(constants)
+      val occurrences: Set[FormulaOccurrence] = lkskc_proof.nodes.flatMap( x => x.asInstanceOf[LKProof].root.occurrences ).toSet
+      val constants = occurrences.flatMap( x => subTerms( x.formula ).filter( _ match { case VarOrConst( _, _ ) => true; case _ => false } ) )
+      println( constants )
 
-      lkskc_proof.root.antecedent.toList.head must beLike{
-        case o : LabelledFormulaOccurrence =>
+      lkskc_proof.root.antecedent.toList.head must beLike {
+        case o: LabelledFormulaOccurrence =>
           o.skolem_label == EmptyLabel() && o.formula == r4.root.antecedent.head.formula must_== true
       }
-    } 
+    }
   }
 }

--- a/src/test/scala/at/logic/utils/ds/GraphsTest.scala
+++ b/src/test/scala/at/logic/utils/ds/GraphsTest.scala
@@ -14,23 +14,23 @@ import org.specs2.runner.JUnitRunner
 import graphs._
 import GraphImplicitConverters._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class GraphsTest extends SpecificationWithJUnit {
   "Graph" should {
     val g1: EmptyGraph[String] = ()
-    val g2: VertexGraph[String] = ("a", g1)
-    val g21: VertexGraph[String] = ("b", g2)
-    val g3: EdgeGraph[String] = ("a", "b", g21)
-    val g4: EdgeGraph[String] = ("a", "c", EdgeGraph("b", "c", VertexGraph("c", g3)))
-    val g5 = EdgeGraph("e", "f", VertexGraph("f", VertexGraph("e", EmptyGraph[String])))
-    val g6: UnionGraph[String] = UnionGraph(g4, g5)
+    val g2: VertexGraph[String] = ( "a", g1 )
+    val g21: VertexGraph[String] = ( "b", g2 )
+    val g3: EdgeGraph[String] = ( "a", "b", g21 )
+    val g4: EdgeGraph[String] = ( "a", "c", EdgeGraph( "b", "c", VertexGraph( "c", g3 ) ) )
+    val g5 = EdgeGraph( "e", "f", VertexGraph( "f", VertexGraph( "e", EmptyGraph[String] ) ) )
+    val g6: UnionGraph[String] = UnionGraph( g4, g5 )
     "check extractors" in {
-      (g2 match {
-        case EmptyGraph() => false
-        case UnionGraph(x1, x2) => false
-        case VertexGraph("a", x2) => true
-        case _ => false
-      }) must beEqualTo (true)
+      ( g2 match {
+        case EmptyGraph()           => false
+        case UnionGraph( x1, x2 )   => false
+        case VertexGraph( "a", x2 ) => true
+        case _                      => false
+      } ) must beEqualTo( true )
     }
 
     /*"maintain subgraph property with vertices" in {
@@ -57,10 +57,10 @@ class GraphsTest extends SpecificationWithJUnit {
       (g4.graph.edgeSet.size()) must beEqualTo (3)
     }*/
     "work correctly on vertices which have the same content but different equality method" in {
-      class TestA(a: String)
+      class TestA( a: String )
       val gn1 = EmptyGraph[TestA]()
-      val gn2 = VertexGraph(new TestA("t1"), gn1)
-      val gn3 = VertexGraph(new TestA("t1"), gn2)
+      val gn2 = VertexGraph( new TestA( "t1" ), gn1 )
+      val gn3 = VertexGraph( new TestA( "t1" ), gn2 )
       true
     }
   }

--- a/src/test/scala/at/logic/utils/ds/MultisetsTest.scala
+++ b/src/test/scala/at/logic/utils/ds/MultisetsTest.scala
@@ -14,27 +14,26 @@ import org.specs2.runner.JUnitRunner
 import Multisets._
 import scala.collection.immutable.HashSet
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class MultisetsTest extends SpecificationWithJUnit {
-   "Multisets" should {
-     val m1 = ((HashMultiset[Int] + 1) + 1) + 2
+  "Multisets" should {
+    val m1 = ( ( HashMultiset[Int] + 1 ) + 1 ) + 2
 
-     val c0 = HashMultiset[Int]
-     val c11 = HashMultiset[Int] + 1
-     val c12 = HashMultiset[Int] + 2
-     val c21 = (HashMultiset[Int] + 1) + 1
-     val c22 = (HashMultiset[Int] + 1) + 2
+    val c0 = HashMultiset[Int]
+    val c11 = HashMultiset[Int] + 1
+    val c12 = HashMultiset[Int] + 2
+    val c21 = ( HashMultiset[Int] + 1 ) + 1
+    val c22 = ( HashMultiset[Int] + 1 ) + 2
 
-     "compute correct combinations" in {
-       combinations(0, m1) must beEqualTo(new HashSet() + c0 )
-       combinations(1, m1) must beEqualTo(new HashSet() + c0 + c11 + c12 )
-       combinations(2, m1) must beEqualTo(new HashSet() + c0 + c11 + c12 + c21 + c22 )
-       combinations(3, m1) must beEqualTo(new HashSet() + c0 + c11 + c12 + c21 + c22 + m1 )
-     }
-     "have correct foldLeft" in {
-       m1.foldLeft(0)( (res, i) => res + i ) must beEqualTo(4)
-     }
-   }
+    "compute correct combinations" in {
+      combinations( 0, m1 ) must beEqualTo( new HashSet() + c0 )
+      combinations( 1, m1 ) must beEqualTo( new HashSet() + c0 + c11 + c12 )
+      combinations( 2, m1 ) must beEqualTo( new HashSet() + c0 + c11 + c12 + c21 + c22 )
+      combinations( 3, m1 ) must beEqualTo( new HashSet() + c0 + c11 + c12 + c21 + c22 + m1 )
+    }
+    "have correct foldLeft" in {
+      m1.foldLeft( 0 )( ( res, i ) => res + i ) must beEqualTo( 4 )
+    }
+  }
 }
-
 

--- a/src/test/scala/at/logic/utils/ds/StreamTest.scala
+++ b/src/test/scala/at/logic/utils/ds/StreamTest.scala
@@ -10,21 +10,20 @@ import org.specs2.runner.JUnitRunner
 
 import streams.Definitions._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class StreamTest extends SpecificationWithJUnit {
 
   "Stream utils" should {
-    def from(n: Int) : Stream[Int] = Stream.cons(n, from( n + 1 ) )
-    val nats = from(0)
+    def from( n: Int ): Stream[Int] = Stream.cons( n, from( n + 1 ) )
+    val nats = from( 0 )
 
-    
     "have a correct even function" in {
-      even(nats).take(10) must not (contain ( (n: Int) => n % 2 == 1 ))
-    }  
-    
+      even( nats ).take( 10 ) must not( contain( ( n: Int ) => n % 2 == 1 ) )
+    }
+
     "have a correct odd function" in {
-      odd(nats).take(10) must not (contain ( (n: Int) => n % 2 == 0 ))
-    } 
+      odd( nats ).take( 10 ) must not( contain( ( n: Int ) => n % 2 == 0 ) )
+    }
   }
-  
+
 }

--- a/src/test/scala/at/logic/utils/ds/TreesTest.scala
+++ b/src/test/scala/at/logic/utils/ds/TreesTest.scala
@@ -15,52 +15,52 @@ import trees._
 import graphs._
 import TreeImplicitConverters._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class TreesTest extends SpecificationWithJUnit {
   "Tree" should {
     "pattern match as graphs and recursively" in {
-      val lt = BinaryTree("y", LeafTree("a"), LeafTree("b"))
-      ((lt) match {
-          case EmptyGraph() => false
-          case UnionGraph(x1, x2) => false
-          case VertexGraph("y", _) => false
-          case UnaryTree(_,_) => false
-          case EdgeGraph(_, "y", UnionGraph(EdgeGraph(_, _, _),_)) => true
-          case _ => false
-      }) must beEqualTo (true)
+      val lt = BinaryTree( "y", LeafTree( "a" ), LeafTree( "b" ) )
+      ( ( lt ) match {
+        case EmptyGraph() => false
+        case UnionGraph( x1, x2 ) => false
+        case VertexGraph( "y", _ ) => false
+        case UnaryTree( _, _ ) => false
+        case EdgeGraph( _, "y", UnionGraph( EdgeGraph( _, _, _ ), _ ) ) => true
+        case _ => false
+      } ) must beEqualTo( true )
     }
     "not be created if diamoned shaped (an acyclic graph but not a tree)" in {
       "1" in {
-        val t1 = UnaryTree("3", UnaryTree("2", "1"))
-        val t2 = UnaryTree("4", "0")
-        val t3 = BinaryTree("5", t1,t2)
-        (BinaryTree("-1", t3,t1)) must throwA[IllegalArgumentException]
+        val t1 = UnaryTree( "3", UnaryTree( "2", "1" ) )
+        val t2 = UnaryTree( "4", "0" )
+        val t3 = BinaryTree( "5", t1, t2 )
+        ( BinaryTree( "-1", t3, t1 ) ) must throwA[IllegalArgumentException]
       }
-// commented out since the test should fail with our current semantics
-// on trees: vertices (i.e. labels) may be equal even though the nodes
-// themselves are different.
-//
-//      "2" in {
-//        val t1 = UnaryTree("3", UnaryTree("2", "1"))
-//        val t2 = UnaryTree("4", "0")
-//        val t3 = BinaryTree("5", t1,t2)
-//        val t4 = LeafTree("1")
-//        (BinaryTree("-1", t3,t4)) must throwA[IllegalArgumentException]
-//      }
+      // commented out since the test should fail with our current semantics
+      // on trees: vertices (i.e. labels) may be equal even though the nodes
+      // themselves are different.
+      //
+      //      "2" in {
+      //        val t1 = UnaryTree("3", UnaryTree("2", "1"))
+      //        val t2 = UnaryTree("4", "0")
+      //        val t3 = BinaryTree("5", t1,t2)
+      //        val t4 = LeafTree("1")
+      //        (BinaryTree("-1", t3,t4)) must throwA[IllegalArgumentException]
+      //      }
       "3 (pointers equality)" in {
-        val t1 = UnaryTree(new AnyRef{}, UnaryTree(new AnyRef{}, new AnyRef{}))
-        val t2 = UnaryTree(new AnyRef{}, new AnyRef{})
-        val t3 = BinaryTree(new AnyRef{}, t1,t2)
-        (BinaryTree(new AnyRef{}, t3,t1)) must throwA[IllegalArgumentException]  
+        val t1 = UnaryTree( new AnyRef {}, UnaryTree( new AnyRef {}, new AnyRef {} ) )
+        val t2 = UnaryTree( new AnyRef {}, new AnyRef {} )
+        val t3 = BinaryTree( new AnyRef {}, t1, t2 )
+        ( BinaryTree( new AnyRef {}, t3, t1 ) ) must throwA[IllegalArgumentException]
       }
     }
 
     "be created if not diamoned shaped (pointers equality)" in {
-      val t1 = UnaryTree(new AnyRef{}, UnaryTree(new AnyRef{}, new AnyRef{}))
-      val t2 = UnaryTree(new AnyRef{}, new AnyRef{})
-      val t3 = BinaryTree(new AnyRef{}, t1,t2)
-      val t4 = LeafTree(new AnyRef{})
-      (BinaryTree(new AnyRef{}, t3,t4)) must not (throwA[IllegalArgumentException])
+      val t1 = UnaryTree( new AnyRef {}, UnaryTree( new AnyRef {}, new AnyRef {} ) )
+      val t2 = UnaryTree( new AnyRef {}, new AnyRef {} )
+      val t3 = BinaryTree( new AnyRef {}, t1, t2 )
+      val t4 = LeafTree( new AnyRef {} )
+      ( BinaryTree( new AnyRef {}, t3, t4 ) ) must not( throwA[IllegalArgumentException] )
     }
     /*"be backed up by a correctly-constructed graph" in {
       val t1 = UnaryTree("d",UnaryTree("c",UnaryTree("b","a")))

--- a/src/test/scala/at/logic/utils/ds/mutable/treesTest.scala
+++ b/src/test/scala/at/logic/utils/ds/mutable/treesTest.scala
@@ -16,7 +16,7 @@ import at.logic.utils.ds.mutable.trees._
 //import at.logic.language.hol._
 import scala.util.parsing.combinator._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class treesTest extends SpecificationWithJUnit {
 
   "tree.scala" should {
@@ -27,18 +27,16 @@ class treesTest extends SpecificationWithJUnit {
       val seq3 = "-p(a)|p(b)"
       val seq4 = "p(X)|p(f(f(b)))"
 
-      var l = seq1::seq2::seq3::seq4::Nil
-    //  val root = new TreeNode[String](seq1::Nil)
-      var root = new TreeNode[String](l)
-      val f: (String) => Int = { x => x.split("a").size - 1}
-//      val t = new MyTree[String](root, f::Nil)
-//      t.createTree(root)
-//      t.print
-      val l1 = 1::2::3::Nil
-      
+      var l = seq1 :: seq2 :: seq3 :: seq4 :: Nil
+      //  val root = new TreeNode[String](seq1::Nil)
+      var root = new TreeNode[String]( l )
+      val f: ( String ) => Int = { x => x.split( "a" ).size - 1 }
+      //      val t = new MyTree[String](root, f::Nil)
+      //      t.createTree(root)
+      //      t.print
+      val l1 = 1 :: 2 :: 3 :: Nil
 
-      0 must beEqualTo (0)
-
+      0 must beEqualTo( 0 )
 
       /*
       val a = HOLConst(new ConstantSymbolA("a"), i)

--- a/src/test/scala/at/logic/utils/executionModels/NDStreamTest.scala
+++ b/src/test/scala/at/logic/utils/executionModels/NDStreamTest.scala
@@ -7,33 +7,33 @@ import org.specs2.runner.JUnitRunner
 import ndStream._
 import searchAlgorithms._
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class NDStreamTest extends SpecificationWithJUnit {
-  class MyConfiguration(val n: Int) extends Configuration[Int] {
-    def result = if (n < 1) Some(n) else None
+  class MyConfiguration( val n: Int ) extends Configuration[Int] {
+    def result = if ( n < 1 ) Some( n ) else None
     def isTerminal = result != None
   }
-  
+
   "BFSNDStream" should {
     "return None if empty" in {
-      def myFun(conf: Configuration[Int]): List[Configuration[Int]] = (for {i <- 2 to conf.asInstanceOf[MyConfiguration].n} yield new MyConfiguration(i - 1)).toList
-      val st = new NDStream(new MyConfiguration(6), myFun) with BFSAlgorithm
-      st.next must beEqualTo (None)
+      def myFun( conf: Configuration[Int] ): List[Configuration[Int]] = ( for { i <- 2 to conf.asInstanceOf[MyConfiguration].n } yield new MyConfiguration( i - 1 ) ).toList
+      val st = new NDStream( new MyConfiguration( 6 ), myFun ) with BFSAlgorithm
+      st.next must beEqualTo( None )
     }
     "return one result" in {
-      def myFun(conf: Configuration[Int]): List[Configuration[Int]] = List(new MyConfiguration(conf.asInstanceOf[MyConfiguration].n - 1) )
-      val st = new NDStream(new MyConfiguration(6), myFun) with BFSAlgorithm
-      st.next must beEqualTo (Some(0))
+      def myFun( conf: Configuration[Int] ): List[Configuration[Int]] = List( new MyConfiguration( conf.asInstanceOf[MyConfiguration].n - 1 ) )
+      val st = new NDStream( new MyConfiguration( 6 ), myFun ) with BFSAlgorithm
+      st.next must beEqualTo( Some( 0 ) )
     }
     "return six results" in {
-      def myFun(conf: Configuration[Int]): List[Configuration[Int]] = (for {i <- 1 to conf.asInstanceOf[MyConfiguration].n} yield new MyConfiguration(i - 1)).toList
-      val st = new NDStream(new MyConfiguration(6), myFun) with BFSAlgorithm
-      st.next must beEqualTo (Some(0))
-      st.next must beEqualTo (Some(0))
-      st.next must beEqualTo (Some(0))
-      st.next must beEqualTo (Some(0))
-      st.next must beEqualTo (Some(0))
-      st.next must beEqualTo (Some(0))
+      def myFun( conf: Configuration[Int] ): List[Configuration[Int]] = ( for { i <- 1 to conf.asInstanceOf[MyConfiguration].n } yield new MyConfiguration( i - 1 ) ).toList
+      val st = new NDStream( new MyConfiguration( 6 ), myFun ) with BFSAlgorithm
+      st.next must beEqualTo( Some( 0 ) )
+      st.next must beEqualTo( Some( 0 ) )
+      st.next must beEqualTo( Some( 0 ) )
+      st.next must beEqualTo( Some( 0 ) )
+      st.next must beEqualTo( Some( 0 ) )
+      st.next must beEqualTo( Some( 0 ) )
     }
   }
 }

--- a/src/test/scala/instantiateEliminationTest.scala
+++ b/src/test/scala/instantiateEliminationTest.scala
@@ -5,91 +5,91 @@ import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.runner.JUnitRunner
 
 import at.logic.language.fol._
-import at.logic.calculi.resolution.robinson.{Resolution, RobinsonResolutionProof, Paramodulation, InitialClause, Instance}
-import at.logic.calculi.lk.base.{AuxiliaryFormulas, beSyntacticMultisetEqual}
+import at.logic.calculi.resolution.robinson.{ Resolution, RobinsonResolutionProof, Paramodulation, InitialClause, Instance }
+import at.logic.calculi.lk.base.{ AuxiliaryFormulas, beSyntacticMultisetEqual }
 
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class instantiateEliminationTest extends SpecificationWithJUnit {
 
   object UNSproof {
-    val v0 = FOLVar("v0")
-    val v1 = FOLVar("v1")
-    val v2 = FOLVar("v2")
-    val a = FOLConst("a")
-    val b = FOLConst("b")
-    val c = FOLConst("c")
+    val v0 = FOLVar( "v0" )
+    val v1 = FOLVar( "v1" )
+    val v2 = FOLVar( "v2" )
+    val a = FOLConst( "a" )
+    val b = FOLConst( "b" )
+    val c = FOLConst( "c" )
 
-    val m01 = Function("multiply", v0::v1::Nil)
-    val m10 = Function("multiply", v1::v0::Nil)
-    val m02 = Function("multiply", v0::v2::Nil)
-    val m12 = Function("multiply", v1::v2::Nil)
-    val add01 = Function("add", v0::v1::Nil)
-    val am02m12 = Function("add", m02::m12::Nil)
-    val ma012 = Function("multiply", add01::v2::Nil)
-    val m2a01 = Function("multiply", v2::add01::Nil)
-   
+    val m01 = Function( "multiply", v0 :: v1 :: Nil )
+    val m10 = Function( "multiply", v1 :: v0 :: Nil )
+    val m02 = Function( "multiply", v0 :: v2 :: Nil )
+    val m12 = Function( "multiply", v1 :: v2 :: Nil )
+    val add01 = Function( "add", v0 :: v1 :: Nil )
+    val am02m12 = Function( "add", m02 :: m12 :: Nil )
+    val ma012 = Function( "multiply", add01 :: v2 :: Nil )
+    val m2a01 = Function( "multiply", v2 :: add01 :: Nil )
+
     // =(multiply(v0, v1), multiply(v1, v0))
-    val c1 = Equation(m01, m10)
+    val c1 = Equation( m01, m10 )
     // =(multiply(add(v0, v1), v2), add(multiply(v0, v2), multiply(v1, v2)))
-    val c2 = Equation(ma012, am02m12)
+    val c2 = Equation( ma012, am02m12 )
     // =(multiply(v2, add(v0, v1)), add(multiply(v0, v2), multiply(v1, v2)))
-    val c3 = Equation(m2a01, am02m12)
+    val c3 = Equation( m2a01, am02m12 )
 
-    val sub1 = Substitution(Map((v0,v2)))
-    val sub2 = Substitution(Map((v1, add01)))
-    val sub3 = Substitution(Map((v0,a), (v1,b),(v2,c)))
-    val sub4 = Substitution(Map((v0,c), (v1,a),(v2,b)))
+    val sub1 = Substitution( Map( ( v0, v2 ) ) )
+    val sub2 = Substitution( Map( ( v1, add01 ) ) )
+    val sub3 = Substitution( Map( ( v0, a ), ( v1, b ), ( v2, c ) ) )
+    val sub4 = Substitution( Map( ( v0, c ), ( v1, a ), ( v2, b ) ) )
 
-    val p1 = InitialClause(Nil, c1::Nil)
-    val p2a = Instance(p1,sub1 )
-    val p2 = Instance(p2a,sub2 )
-    val p3 = InitialClause(Nil, c2::Nil)
-    val p4 = Paramodulation(p2, p3, p2.root.succedent(0), p3.root.succedent(0), c3, Substitution())
-    val p5 = Instance(p4, sub3)
-    val p6 = InitialClause(c3::Nil, Nil)
-    val p7 = Resolution(p5,p6,p5.root.succedent(0), p6.root.antecedent(0), sub3)
+    val p1 = InitialClause( Nil, c1 :: Nil )
+    val p2a = Instance( p1, sub1 )
+    val p2 = Instance( p2a, sub2 )
+    val p3 = InitialClause( Nil, c2 :: Nil )
+    val p4 = Paramodulation( p2, p3, p2.root.succedent( 0 ), p3.root.succedent( 0 ), c3, Substitution() )
+    val p5 = Instance( p4, sub3 )
+    val p6 = InitialClause( c3 :: Nil, Nil )
+    val p7 = Resolution( p5, p6, p5.root.succedent( 0 ), p6.root.antecedent( 0 ), sub3 )
   }
 
   object UNSproof2 {
-    val v0 = FOLVar("v0")
-    val v1 = FOLVar("v1")
-    val v2 = FOLVar("v2")
+    val v0 = FOLVar( "v0" )
+    val v1 = FOLVar( "v1" )
+    val v2 = FOLVar( "v2" )
 
-    val m01 = Function("multiply", v0::v1::Nil)
-    val m10 = Function("multiply", v1::v0::Nil)
-    val m02 = Function("multiply", v0::v2::Nil)
-    val m12 = Function("multiply", v1::v2::Nil)
-    val add01 = Function("add", v0::v1::Nil)
-    val am02m12 = Function("add", m02::m12::Nil)
-    val ma012 = Function("multiply", add01::v2::Nil)
-    val m2a01 = Function("multiply", v2::add01::Nil)
-    
+    val m01 = Function( "multiply", v0 :: v1 :: Nil )
+    val m10 = Function( "multiply", v1 :: v0 :: Nil )
+    val m02 = Function( "multiply", v0 :: v2 :: Nil )
+    val m12 = Function( "multiply", v1 :: v2 :: Nil )
+    val add01 = Function( "add", v0 :: v1 :: Nil )
+    val am02m12 = Function( "add", m02 :: m12 :: Nil )
+    val ma012 = Function( "multiply", add01 :: v2 :: Nil )
+    val m2a01 = Function( "multiply", v2 :: add01 :: Nil )
+
     // =(multiply(v0, v1), multiply(v1, v0))
-    val c1 = Equation(m01, m10)
+    val c1 = Equation( m01, m10 )
     // =(multiply(add(v0, v1), v2), add(multiply(v0, v2), multiply(v1, v2)))
-    val c2 = Equation(ma012, am02m12)
+    val c2 = Equation( ma012, am02m12 )
     // =(multiply(v2, add(v0, v1)), add(multiply(v0, v2), multiply(v1, v2)))
-    val c3 = Equation(m2a01, am02m12)
+    val c3 = Equation( m2a01, am02m12 )
 
-    val sub1 = Substitution(Map((v0,v2), (v1, add01)))
+    val sub1 = Substitution( Map( ( v0, v2 ), ( v1, add01 ) ) )
 
-    val p1 = InitialClause(Nil, c1::Nil)
-    val p2 = Instance(p1,sub1 )
-    val p3 = InitialClause(Nil, c2::Nil)
-    val p4 = Paramodulation(p2, p3, p2.root.succedent(0), p3.root.succedent(0), c3, Substitution())
+    val p1 = InitialClause( Nil, c1 :: Nil )
+    val p2 = Instance( p1, sub1 )
+    val p3 = InitialClause( Nil, c2 :: Nil )
+    val p4 = Paramodulation( p2, p3, p2.root.succedent( 0 ), p3.root.succedent( 0 ), c3, Substitution() )
   }
 
   "The instance elimination algorithm " should {
     "do instance merge " in {
-      val proof = InstantiateElimination.imerge(UNSproof.p7, InstantiateElimination.emptyProofMap)._4
-      proof.root must beSyntacticMultisetEqual(UNSproof.p7.root)
+      val proof = InstantiateElimination.imerge( UNSproof.p7, InstantiateElimination.emptyProofMap )._4
+      proof.root must beSyntacticMultisetEqual( UNSproof.p7.root )
     }
 
     "do instance removal " in {
-      val mproof = InstantiateElimination.imerge(UNSproof.p7, InstantiateElimination.emptyProofMap)._4
-      mproof.root must beSyntacticMultisetEqual(UNSproof.p7.root)
-      val rproof = InstantiateElimination.remove(mproof, InstantiateElimination.emptyVarSet, InstantiateElimination.emptyProofMap)._4
-      rproof.root must beSyntacticMultisetEqual(UNSproof.p7.root)
+      val mproof = InstantiateElimination.imerge( UNSproof.p7, InstantiateElimination.emptyProofMap )._4
+      mproof.root must beSyntacticMultisetEqual( UNSproof.p7.root )
+      val rproof = InstantiateElimination.remove( mproof, InstantiateElimination.emptyVarSet, InstantiateElimination.emptyProofMap )._4
+      rproof.root must beSyntacticMultisetEqual( UNSproof.p7.root )
     }
   }
 }

--- a/src/test/scala/unfoldSchemaProofTest.scala
+++ b/src/test/scala/unfoldSchemaProofTest.scala
@@ -4,7 +4,7 @@ package at.logic.integration_tests
 import at.logic.language.schema._
 import at.logic.parsing.shlk_parsing.SHLK
 
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import java.io.File.separator
 import org.specs2.execute.Success
 import org.specs2.mutable._
@@ -12,25 +12,25 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
 // Moved this test to integration_tests because it uses an external file.
-@RunWith(classOf[JUnitRunner])
+@RunWith( classOf[JUnitRunner] )
 class UnfoldSchemaProofTest extends SpecificationWithJUnit {
-    //implicit val factory = defaultFormulaOccurrenceFactory
-    "UnfoldSchemaProofTest" should {
-      "unfold the adder.slk" in {
-        val zero = IntZero(); val one = Succ(IntZero()); val two = Succ(Succ(IntZero())); val three = Succ(Succ(Succ(IntZero())))
-        val str = new InputStreamReader(getClass.getClassLoader.getResourceAsStream("schema-adder.lks"))
-        val map = SHLK.parseProof(str)
-        val n = IntVar("n");val n1 = Succ(n);val n2 = Succ(n1);val n3 = Succ(n2);
-        val k = IntVar("k") ; val i = IntVar("i")
-        val A3 = IndexedPredicate("A", three)
-        val A = IndexedPredicate("A", i)
-        val An3 = IndexedPredicate("A", n3)
-        val An1 = IndexedPredicate("A", n1)
-        val b = BigAnd(i, A, zero, n3)
-        val subst = Substitution((k, two)::Nil)
+  //implicit val factory = defaultFormulaOccurrenceFactory
+  "UnfoldSchemaProofTest" should {
+    "unfold the adder.slk" in {
+      val zero = IntZero(); val one = Succ( IntZero() ); val two = Succ( Succ( IntZero() ) ); val three = Succ( Succ( Succ( IntZero() ) ) )
+      val str = new InputStreamReader( getClass.getClassLoader.getResourceAsStream( "schema-adder.lks" ) )
+      val map = SHLK.parseProof( str )
+      val n = IntVar( "n" ); val n1 = Succ( n ); val n2 = Succ( n1 ); val n3 = Succ( n2 );
+      val k = IntVar( "k" ); val i = IntVar( "i" )
+      val A3 = IndexedPredicate( "A", three )
+      val A = IndexedPredicate( "A", i )
+      val An3 = IndexedPredicate( "A", n3 )
+      val An1 = IndexedPredicate( "A", n1 )
+      val b = BigAnd( i, A, zero, n3 )
+      val subst = Substitution( ( k, two ) :: Nil )
 
-        Success()
-      }
+      Success()
     }
- }
+  }
+}
 


### PR DESCRIPTION
Did you noticed we actually don't format test files.
The task scalariformFormat don't format test files.
The task test:scalariformFormat need to be used to format test files.

If you consider running these two tasks is cumbersome we probably can make a custom sbt task to join them.
(FYI the defaultScalariformSettings that we disabled to avoid editor reloads run both tasks automatically)