### PR TITLE
Sat4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,8 @@ lazy val root = (project in file(".")).
       "jline" % "jline" % "2.12.1",
       "org.scala-lang.modules" %% "scala-swing" % "1.0.1",
       "com.itextpdf" % "itextpdf" % "5.5.5",
-      "org.scilab.forge" % "jlatexmath" % "1.0.2")
+      "org.scilab.forge" % "jlatexmath" % "1.0.2",
+      "org.ow2.sat4j" % "org.ow2.sat4j.core" % "2.3.5")
   )
 
 import scalariform.formatter.preferences._

--- a/src/main/scala/at/logic/algorithms/cutIntroduction/CutIntroduction.scala
+++ b/src/main/scala/at/logic/algorithms/cutIntroduction/CutIntroduction.scala
@@ -340,8 +340,8 @@ object CutIntroduction extends at.logic.utils.logging.Logger {
         numCuts = getStatistics( smallestProof ).cuts
         canonicalSolutionSize = sorted.head._3
         minimizedSolutionSize = sorted.head._4
-	improvingSolutionTime = sorted.head._5
-	buildProofTime = sorted.head._6
+        improvingSolutionTime = sorted.head._5
+        buildProofTime = sorted.head._6
         rulesLKProofWithCut = rulesNumber( smallestProof )
         quantRulesWithCut = quantRulesNumber( smallestProof )
         if ( verbose ) println( "\nMinimized cut formula: " + ehs.cutFormulas.head + "\n" )

--- a/src/main/scala/at/logic/parsing/language/dimacs/DIMACSExporter.scala
+++ b/src/main/scala/at/logic/parsing/language/dimacs/DIMACSExporter.scala
@@ -34,7 +34,7 @@ class DIMACSExporter( val clauses: List[FClause] ) {
       sb.toString()
     }
 
-  def getDIMACSString() : String = {
+  def getDIMACSString(): String = {
     val sb = new StringBuilder()
 
     sb.append( "p cnf " + atom_map.size + " " + clauses.size + nl )
@@ -50,30 +50,30 @@ class DIMACSExporter( val clauses: List[FClause] ) {
     sb.toString()
   }
 
-  def getInterpretation( dimacs_out : String ) = {
-    val lines = dimacs_out.split(nl)
-    val res =  if ( lines(0).equals( "SAT" ) ) {
-        Some( lines(1).split( " " ).
-          filter( lit => !lit.equals( "" ) && !lit.charAt( 0 ).equals( '0' ) ).
-          map( lit =>
-            if ( lit.charAt( 0 ) == '-' ) {
-              // negative literal
-              ( getAtom( lit.substring( 1 ).toInt ).get, false )
-            } else {
-              // positive literal
-              ( getAtom( lit.toInt ).get, true )
-            } )
-          .toSet.toMap )
-      } else {
-        // unsatisfiable
-        None
-      }
+  def getInterpretation( dimacs_out: String ) = {
+    val lines = dimacs_out.split( nl )
+    val res = if ( lines( 0 ).equals( "SAT" ) ) {
+      Some( lines( 1 ).split( " " ).
+        filter( lit => !lit.equals( "" ) && !lit.charAt( 0 ).equals( '0' ) ).
+        map( lit =>
+          if ( lit.charAt( 0 ) == '-' ) {
+            // negative literal
+            ( getAtom( lit.substring( 1 ).toInt ).get, false )
+          } else {
+            // positive literal
+            ( getAtom( lit.toInt ).get, true )
+          } )
+        .toSet.toMap )
+    } else {
+      // unsatisfiable
+      None
+    }
 
-      res match {
+    res match {
       case Some( model ) => Some( new MapBasedInterpretation( model ) )
       case None          => None
     }
 
-    }
-
   }
+
+}

--- a/src/main/scala/at/logic/provers/FailSafeProver.scala
+++ b/src/main/scala/at/logic/provers/FailSafeProver.scala
@@ -1,0 +1,13 @@
+package at.logic.provers
+
+import at.logic.provers.minisat.MiniSATProver
+import at.logic.provers.sat4j.Sat4jProver
+
+object FailSafeProver {
+  val minisatInstalled = ( new MiniSATProver ).isInstalled()
+
+  def getProver(): Prover = {
+    if ( minisatInstalled ) new MiniSATProver else new Sat4jProver
+  }
+
+}

--- a/src/main/scala/at/logic/provers/basicProver/BasicProver.scala
+++ b/src/main/scala/at/logic/provers/basicProver/BasicProver.scala
@@ -3,9 +3,9 @@ package at.logic.provers.basicProver
 
 import at.logic.algorithms.lk.LKProver
 import at.logic.provers.Prover
-import at.logic.provers.minisat.MiniSATProver
 import at.logic.language.hol.HOLFormula
 import at.logic.calculi.lk.base.{ FSequent, LKProof }
+import at.logic.provers.FailSafeProver
 
 class BasicProver extends Prover {
 
@@ -16,9 +16,9 @@ class BasicProver extends Prover {
     new LKProver( cleanStructuralRules = false ).getLKProof( seq )
 
   override def isValid( seq: FSequent ): Boolean =
-    new MiniSATProver().isValid( seq )
+    FailSafeProver.getProver().isValid( seq )
 
   override def isValid( f: HOLFormula ): Boolean = {
-    new MiniSATProver().isValid( f )
+    FailSafeProver.getProver().isValid( f )
   }
 }

--- a/src/main/scala/at/logic/provers/sat4j/Sat4j.scala
+++ b/src/main/scala/at/logic/provers/sat4j/Sat4j.scala
@@ -1,0 +1,143 @@
+/**
+ * Interface to Sat4j solver.
+ */
+
+package at.logic.provers.sat4j
+
+import at.logic.language.fol.FOLFormula
+import at.logic.language.hol._
+import at.logic.calculi.resolution._
+import at.logic.algorithms.resolution.{ CNFp, TseitinCNF }
+
+import java.io._
+import java.lang.StringBuilder
+
+import at.logic.calculi.lk.base.FSequent
+
+import at.logic.provers.Prover
+
+import at.logic.models._
+
+import at.logic.parsing.language.dimacs.DIMACSExporter
+
+import scala.collection.immutable.HashMap
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.FileWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+import org.sat4j.minisat.SolverFactory
+import org.sat4j.reader.DimacsReader
+import org.sat4j.reader.Reader
+import org.sat4j.specs.ContradictionException
+import org.sat4j.specs.IProblem
+import org.sat4j.specs.ISolver
+
+// Call Sat4j to solve quantifier-free HOLFormulas.
+class Sat4j extends at.logic.utils.logging.Stopwatch {
+
+  var atom_map: Map[HOLFormula, Int] = new HashMap[HOLFormula, Int]
+
+  // Checks if f is valid using Sat4j.
+  def isValid( f: HOLFormula ) = solve( Neg( f ) ) match {
+    case Some( _ ) => false
+    case None      => true
+  }
+
+  // Returns a model of the formula obtained from the Sat4j SAT solver.
+  // Returns None if unsatisfiable.
+  def solve( f: HOLFormula ): Option[Interpretation] = {
+    start()
+    val cnf = f match {
+      case f1: FOLFormula => TseitinCNF( f1 )._1
+      case _              => CNFp( f )
+    }
+    lap( "CNF done" )
+    val int = solve( cnf )
+    lap( "Solving done" )
+    int
+  }
+
+  // Returns a model of the set of clauses obtained from the Sat4j SAT solver.
+  // Returns None if unsatisfiable.
+  def solve( clauses: List[FClause] ): Option[Interpretation] =
+    {
+      val dimacs = new DIMACSExporter( clauses )
+
+      val sat4j_in = dimacs.getDIMACSString()
+      trace( "Generated Sat4j input: " )
+      trace( sat4j_in );
+
+      val temp_in = File.createTempFile( "agito_sat4j_in", ".sat" )
+      temp_in.deleteOnExit()
+
+      val temp_out = File.createTempFile( "agito_sat4j_out", ".sat" )
+      temp_out.deleteOnExit()
+
+      val out = new BufferedWriter( new FileWriter( temp_in ) )
+      out.append( sat4j_in )
+      out.close()
+
+      // run Sat4j
+
+      debug( "Starting sat4j..." );
+      val sat4jSolver: ISolver = SolverFactory.newDefault()
+      val reader: Reader = new DimacsReader( sat4jSolver )
+      val writer = new BufferedWriter( new OutputStreamWriter(
+        new FileOutputStream( temp_out ), "UTF-8" ) )
+      try {
+        val problem: IProblem = reader.parseInstance( temp_in.getAbsolutePath() )
+        if ( problem.isSatisfiable() ) {
+          writer.write( "SAT\n" )
+          val model = problem.model()
+          val sb = new StringBuffer()
+          for ( i <- 0 until model.length ) {
+            sb.append( model( i ) )
+            sb.append( " " );
+          }
+          sb.append( "0\n" );
+          writer.write( sb.toString )
+        } else {
+          writer.write( "UNSAT\n" )
+        }
+      } catch {
+        case e: ContradictionException => {
+          writer.write( "UNSAT\n" )
+        }
+      } finally {
+        writer.close()
+        sat4jSolver.reset
+      }
+      debug( "Sat4j finished." )
+      // parse sat4j output and construct map
+      val sat = scala.io.Source.fromFile( temp_out ).mkString;
+
+      trace( "Sat4j result: " + sat )
+
+      dimacs.getInterpretation( sat )
+    }
+
+}
+
+class Sat4jProver extends Prover with at.logic.utils.logging.Logger {
+  def getLKProof( seq: FSequent ): Option[at.logic.calculi.lk.base.LKProof] =
+    throw new Exception( "Sat4j does not produce proofs!" )
+
+  override def isValid( f: HOLFormula ): Boolean = {
+    val sat = new Sat4j()
+    sat.isValid( f )
+  }
+
+  override def isValid( seq: FSequent ): Boolean = {
+    val sat = new Sat4j()
+    trace( "calling Sat4j.isValid( " + Imp( And( seq.antecedent.toList ), Or( seq.succedent.toList ) ) + ")" )
+    sat.isValid( Imp( And( seq.antecedent.toList ), Or( seq.succedent.toList ) ) )
+  }
+
+}

--- a/src/test/scala/at/logic/algorithms/expansionTrees/minimalTest.scala
+++ b/src/test/scala/at/logic/algorithms/expansionTrees/minimalTest.scala
@@ -5,7 +5,7 @@ import at.logic.language.lambda.types.{ Ti => i, To => o, -> }
 import at.logic.calculi.expansionTrees._
 import at.logic.calculi.lk.base.FSequent
 import at.logic.algorithms.expansionTrees._
-import at.logic.provers.minisat.MiniSATProver
+import at.logic.provers.FailSafeProver
 import org.specs2.mutable._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
@@ -46,11 +46,9 @@ class minimalExpansionSequentTest extends SpecificationWithJUnit {
         ExVar( x, AtomHOL( P, x :: Nil ) ),
         List( ( Atom( AtomHOL( P, d :: Nil ) ), d ) ) ) ) ) ) ).map( compressQuantifiers.apply )
 
-  args( skipAll = !( new MiniSATProver ).isInstalled() )
-
   "Minimal expansion trees" should {
     "be computed correctly by the smart algorithm" in {
-      minESeq mustEqual minimalExpansionSequents( eSeq, new MiniSATProver )
+      minESeq mustEqual minimalExpansionSequents( eSeq, FailSafeProver.getProver() )
     }
   }
 }

--- a/src/test/scala/at/logic/integration_tests/CutIntroTest.scala
+++ b/src/test/scala/at/logic/integration_tests/CutIntroTest.scala
@@ -47,7 +47,6 @@ class CutIntroTest extends SpecificationWithJUnit {
 
   "CutIntroduction" should {
     "extract and decompose the termset of the linear example proof (n = 4)" in {
-      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
       val proof = LinearExampleProof( 0, 4 )
 
       val termset = TermsExtraction( proof )

--- a/src/test/scala/at/logic/integration_tests/MiscTest.scala
+++ b/src/test/scala/at/logic/integration_tests/MiscTest.scala
@@ -21,7 +21,7 @@ import at.logic.parsing.language.tptp.TPTPFOLExporter
 import at.logic.parsing.language.xml.XMLParser._
 import at.logic.parsing.readers.XMLReaders._
 import at.logic.parsing.veriT.VeriTParser
-import at.logic.provers.minisat.MiniSATProver
+import at.logic.provers.FailSafeProver
 import at.logic.provers.prover9.{ Prover9, Prover9Prover }
 import at.logic.provers.veriT.VeriTProver
 import at.logic.transformations.ReductiveCutElim
@@ -85,7 +85,6 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
 //    */
 
     "perform cut introduction on an example proof" in {
-      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
       val p = LinearExampleProof( 0, 7 )
       CutIntroduction.one_cut_one_quantifier( p, false )
       Success()
@@ -131,8 +130,6 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
     }
 
     "introduce a cut and eliminate it via Gentzen in the LinearExampleProof (n = 4)" in {
-      if ( !( new MiniSATProver ).isInstalled() ) skipped( "MiniSAT is not installed" )
-
       val p = LinearExampleProof( 0, 4 )
       val pi = CutIntroduction.one_cut_one_quantifier( p, false )
       val pe = ReductiveCutElim.eliminateAllByUppermost( pi, steps = false )
@@ -181,10 +178,8 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
       proofPrime.isDefined must beTrue
     }
 
-    "load veriT proofs pi and verify the validity of Deep(pi) using MiniSAT" in {
-      val minisat = new MiniSATProver()
-      if ( !minisat.isInstalled() ) skipped( "MiniSAT is not installed" )
-
+    "load veriT proofs pi and verify the validity of Deep(pi) using minisat or sat4j" in {
+      val minisat = FailSafeProver.getProver()
       for ( i <- List( 0, 1, 3 ) ) { // Tests 2 and 4 take comparatively long.
         val p = VeriTParser.getExpansionProof( tempCopyOfClasspathFile( s"test${i}.verit" ) ).get
         val seq = ETtoDeep( p )
@@ -194,9 +189,8 @@ class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
       ok
     }
 
-    "load Prover9 proof without equality reasoning, extract expansion tree E, verify deep formula of E using minisat" in {
-      val minisat = new MiniSATProver()
-      if ( !minisat.isInstalled() ) skipped( "MiniSAT is not installed" )
+    "load Prover9 proof without equality reasoning, extract expansion tree E, verify deep formula of E using minisat or sat4j" in {
+      val minisat = FailSafeProver.getProver()
       if ( !Prover9.isInstalled() ) skipped( "Prover9 is not installed" )
 
       val testFilePath = tempCopyOfClasspathFile( "PUZ002-1.out" )


### PR DESCRIPTION
This pull request add a non intrusive fallback to minisat with an embedded Sat4j.
A maybe too verbose warning will tell you each time the Sat4j fallback is used.
The objective is to make minisat installation not mandatory.
If this pull request is accepted, the documentation should probably be modified accordingly.