### PR TITLE
Ivytorobinson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,10 +102,10 @@ lazy val releaseDist = TaskKey[File]("release-dist", "Creates the release tar ba
 
 lazy val testDependencies = Seq(
   "junit" % "junit" % "4.12",
-  "org.specs2" %% "specs2-core" % "2.4.17",
-  "org.specs2" %% "specs2-matcher" % "2.4.17",
-  "org.specs2" %% "specs2-mock" % "2.4.17",
-  "org.specs2" %% "specs2-junit" % "2.4.17",
+  "org.specs2" %% "specs2-core" % "3.0.1",
+  "org.specs2" %% "specs2-matcher" % "3.0.1",
+  "org.specs2" %% "specs2-mock" % "3.0.1",
+  "org.specs2" %% "specs2-junit" % "3.0.1",
   "org.scalacheck" %% "scalacheck" % "1.12.2")
 
 def oneJvmPerTest(tests: Seq[TestDefinition]) =

--- a/src/test/scala/at/logic/provers/prover9/IvyToRobinsonTest.scala
+++ b/src/test/scala/at/logic/provers/prover9/IvyToRobinsonTest.scala
@@ -1,14 +1,16 @@
 package at.logic.parsing.ivy
 
+import org.junit.runner.RunWith
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.specification.core.Fragments
+
+import at.logic.parsing.lisp
+import at.logic.parsing.lisp.SExpressionParser
 import at.logic.utils.testing.ClasspathFileCopier
 import conversion.IvyToRobinson
-import org.junit.runner.RunWith
+
 import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
-import at.logic.parsing.lisp
-import java.io.File.separator
-import util.parsing.input.Reader
-import lisp.{ SExpressionParser }
 
 /**
  * Test for the Ivy interface.
@@ -16,114 +18,24 @@ import lisp.{ SExpressionParser }
 @RunWith( classOf[JUnitRunner] )
 class IvyToRobinsonTest extends SpecificationWithJUnit with ClasspathFileCopier {
 
-  "The Ivy Parser " should {
-    " parse the test files factor.ivy and factor2.ivy " in {
-      val result = SExpressionParser( tempCopyOfClasspathFile( "factor.ivy" ) )
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List( _ ) =>
-          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
-          val rinput = IvyToRobinson( pinput )
-
-        case _ =>
-          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
-      }
-
-      val result2 = SExpressionParser( tempCopyOfClasspathFile( "factor2.ivy" ) )
-      result2 must not beEmpty
-      val proof2 = result2.head
-      proof2 match {
-        case lisp.List( _ ) =>
-          val pinput = IvyParser.parse( proof2, IvyParser.is_ivy_variable )
-          val rinput = IvyToRobinson( pinput )
-
-        case _ =>
-          "The proof in factor.ivy must have some inferences" must beEqualTo( "failed" )
-      }
-      ok
-    }
-
-    " parse the test file manyliterals.ivy " in {
-      val result = SExpressionParser( tempCopyOfClasspathFile( "manyliterals.ivy" ) )
-      result must not beEmpty
-      val proof = result.head
-      proof match {
-        case lisp.List( _ ) =>
-          val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
-          val rinput = IvyToRobinson( pinput )
-
-        case _ =>
-          "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
-      }
-      ok
-    }
-
-    " parse the test file simple2.ivy " in {
-      skipped( "file missing" )
-      val result = SExpressionParser( tempCopyOfClasspathFile( "simple2.ivy" ) )
-      ok
-    }
-  }
-
-  " parse the test file prime1-0sk.ivy (clause set of the 0 instance of the prime proof) " in {
-    val result = SExpressionParser( tempCopyOfClasspathFile( "prime1-0sk.ivy" ) )
+  def parse( file: String ): MatchResult[Any] = {
+    val result = SExpressionParser( tempCopyOfClasspathFile( file ) )
     result must not beEmpty
     val proof = result.head
     proof match {
       case lisp.List( _ ) =>
         val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
         val rinput = IvyToRobinson( pinput )
-
+        ok
       case _ =>
-        "The proof in prime1-0sk.ivy must have some inferences" must beEqualTo( "failed" )
+        ko( s"The proof in $file must have some inferences" )
     }
-    ok
   }
 
-  " parse the test file GRA014+1.ivy " in {
-    val result = SExpressionParser( tempCopyOfClasspathFile( "GRA014+1.ivy" ) )
-    result must not beEmpty
-    val proof = result.head
-    proof match {
-      case lisp.List( _ ) =>
-        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
-        val rinput = IvyToRobinson( pinput )
-
-      case _ =>
-        "The proof in manyliterals.ivy must have some inferences" must beEqualTo( "failed" )
-    }
-    ok
+  "The Ivy Parser" should {
+    val filesToTest = Seq( "factor.ivy", "factor2.ivy", "manyliterals.ivy", "simple2.ivy", "prime1-0sk.ivy", "GRA014+1.ivy", "GEO037-2.ivy", "issue221.ivy" )
+    Fragments.foreach( filesToTest )( file => ( s"parse the test file $file" ! parse( file ) ) ^ br )
   }
 
-  " parse the test file GEO037-2.ivy " in {
-    val result = SExpressionParser( tempCopyOfClasspathFile( "GEO037-2.ivy" ) )
-    result must not beEmpty
-    val proof = result.head
-    proof match {
-      case lisp.List( _ ) =>
-        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
-        val rinput = IvyToRobinson( pinput )
-
-      case _ =>
-        "The proof in GEO037-2.ivy must have some inferences" must beEqualTo( "failed" )
-    }
-    ok
-  }
-
-  " parse the test file issue221.ivy " in {
-    val result = SExpressionParser( tempCopyOfClasspathFile( "issue221.ivy" ) )
-    result must not beEmpty
-    val proof = result.head
-    proof match {
-      case lisp.List( _ ) =>
-        val pinput = IvyParser.parse( proof, IvyParser.is_ivy_variable )
-        val rinput = IvyToRobinson( pinput )
-
-      case _ =>
-        "The proof in issue221.ivy must have some inferences" must beEqualTo( "failed" )
-    }
-    ok
-  }
 }
 


### PR DESCRIPTION
The issue with the junitxml reporter that motive the rollback from specs2 3.0 to specs2 2.4.17 seem to be fixed in 3.0.1
We can now use the new Fragments.foreach feature of specs2 3.x to remove lot of duplicate code in gapt tests.
This pull request show how this can be done using IvyToRobinsonTest as an example.