### PR TITLE
travis: Compile extended testing code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ jdk:
 scala: 
 - 2.11.5
 
-script: "sbt clean coverage test"
+script: "sbt clean coverage test testing/test:compile"
 after_success: "sbt coveralls"
 


### PR DESCRIPTION
In #303, the specs2 upgrade broke the extended testing code, but travis didn't complain.  This changes the travis configuration to compile (but not run) the `testing/` directory as well.