### PR TITLE
Re-enabled "apply prover9 to the tape proof clause set" test

### DIFF
--- a/src/test/scala/at/logic/gapt/integration_tests/TapeTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/TapeTest.scala
@@ -107,7 +107,6 @@ class TapeTest extends SpecificationWithJUnit {
 
     "apply prover9 to the tape proof clause set" in {
       checkForProverOrSkip
-      skipped( "Infinite loop??" )
 
       val proofdb = ( new XMLReader( new InputStreamReader( new GZIPInputStream( getClass.getClassLoader.getResourceAsStream( "tape-in.xml.gz" ) ) ) ) with XMLProofDatabaseParser ).getProofDatabase()
       proofdb.proofs.size must beEqualTo( 1 )


### PR DESCRIPTION
Was disabled at git-sha: 0e40a148021ecee5d0aa818806d7e9282edcaee4 aka svn-revision: @2070
Was fixed at git-sha: e68daf0da1b96368385eda82053e6e2262af8f2d aka svn-revision: @2214