### PR TITLE
Revert sbt-coverage version bump

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.apache.commons" % "commons-compress" % "1.9"
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
 
 // Provides an assembly task which produces a fat jar with all dependencies included.


### PR DESCRIPTION
Code coverage is broken since April 27.
It seem that commit https://github.com/gapt/gapt/commit/e4aaf9d83a00d0b1a5956f280a47ce632f6bf919 is the culprit.