### PR TITLE
Spring cleaning: Remove junit, specs2-mock, and scalacheck dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,12 +113,8 @@ lazy val testing = (project in file("testing")).
 lazy val releaseDist = TaskKey[File]("release-dist", "Creates the release tar ball.")
 
 lazy val testDependencies = Seq(
-  "junit" % "junit" % "4.12",
   "org.specs2" %% "specs2-core" % "3.5",
-  "org.specs2" %% "specs2-matcher" % "3.5",
-  "org.specs2" %% "specs2-mock" % "3.5",
-  "org.specs2" %% "specs2-junit" % "3.5",
-  "org.scalacheck" %% "scalacheck" % "1.12.2")
+  "org.specs2" %% "specs2-matcher" % "3.5")
 
 def oneJvmPerTest(tests: Seq[TestDefinition]) =
   tests map { test =>

--- a/src/test/scala/at/logic/gapt/algorithms/rewriting/TermReplacementTest.scala
+++ b/src/test/scala/at/logic/gapt/algorithms/rewriting/TermReplacementTest.scala
@@ -1,9 +1,6 @@
 package at.logic.gapt.algorithms.rewriting
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
-import org.specs2._
+import org.specs2.mutable._
 import at.logic.gapt.language.fol._
 import at.logic.gapt.proofs.resolution.robinson._
 import at.logic.gapt.expr._
@@ -11,8 +8,7 @@ import at.logic.gapt.expr._
 /**
  * Test for replacment of constant symbols by terms
  */
-@RunWith( classOf[JUnitRunner] )
-class TermReplacementTest extends SpecificationWithJUnit {
+class TermReplacementTest extends Specification {
 
   val c1 = FOLAtom( "P", FOLFunction( "g", FOLConst( "a" ) :: Nil ) :: Nil )
   val c2 = FOLAtom( "P", FOLFunction( "g", FOLVar( "x" ) :: Nil ) :: Nil )

--- a/src/test/scala/at/logic/gapt/algorithms/rewriting/definition_eliminationTest.scala
+++ b/src/test/scala/at/logic/gapt/algorithms/rewriting/definition_eliminationTest.scala
@@ -1,8 +1,6 @@
 package at.logic.gapt.algorithms.rewriting
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 import at.logic.gapt.language.fol._
 import at.logic.gapt.expr.{ StringSymbol }
 import at.logic.gapt.proofs.lk._
@@ -10,8 +8,7 @@ import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.{ beSyntacticFSequentEqual, FSequent, Sequent, LKProof }
 import at.logic.gapt.proofs.proofs.NullaryProof
 
-@RunWith( classOf[JUnitRunner] )
-class definition_eliminationTest extends SpecificationWithJUnit {
+class definition_eliminationTest extends Specification {
   object proof1 {
     val List( alphasym, betasym, xsym, ysym ) = List( "\\alpha", "\\beta", "x", "y" )
     val List( p, q, a, b, tsym ) = List( "P", "Q", "A", "B", "t" )

--- a/src/test/scala/at/logic/gapt/algorithms/rewriting/name_replacementTest.scala
+++ b/src/test/scala/at/logic/gapt/algorithms/rewriting/name_replacementTest.scala
@@ -1,8 +1,6 @@
 package at.logic.gapt.algorithms.rewriting
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 import at.logic.gapt.language.fol._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
@@ -13,8 +11,7 @@ import at.logic.gapt.utils.ds.acyclicGraphs.{ BinaryAGraph, UnaryAGraph, LeafAGr
 /**
  * Test for renaming of constant symbols
  */
-@RunWith( classOf[JUnitRunner] )
-class name_replacementTest extends SpecificationWithJUnit {
+class name_replacementTest extends Specification {
 
   val c1 = FOLAtom( "P", FOLFunction( "g", FOLConst( "a" ) :: Nil ) :: Nil )
   val c2 = FOLAtom( "P", FOLFunction( "g", FOLVar( "x" ) :: Nil ) :: Nil )

--- a/src/test/scala/at/logic/gapt/formats/calculi/xml/LKExporterTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/calculi/xml/LKExporterTest.scala
@@ -6,8 +6,6 @@ package at.logic.gapt.formats.calculi.xml
 
 import at.logic.gapt.formats.xml.{ HOLTermXMLExporter, LKExporter }
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import scala.xml.Utility.trim
 
@@ -16,8 +14,7 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr.StringSymbol
 import at.logic.gapt.expr.To
 
-@RunWith( classOf[JUnitRunner] )
-class LkExporterTest extends SpecificationWithJUnit {
+class LkExporterTest extends Specification {
 
   val exporter = new LKExporter {}
   // helper to create 0-ary predicate constants

--- a/src/test/scala/at/logic/gapt/formats/calculi/xml/SimpleXMLParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/calculi/xml/SimpleXMLParserTest.scala
@@ -6,8 +6,6 @@ package at.logic.gapt.formats.calculi.xml
 
 import at.logic.gapt.formats.simple.SimpleXMLProofParser
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import scala.xml._
 
@@ -16,8 +14,7 @@ import at.logic.gapt.language.hol._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base._
 
-@RunWith( classOf[JUnitRunner] )
-class SimpleXMLParserTest extends SpecificationWithJUnit {
+class SimpleXMLParserTest extends Specification {
   "parse correctly a simple tree" in {
     // use trivial string parser
     implicit val Parser: String => String = ( x => x )

--- a/src/test/scala/at/logic/gapt/formats/hlk/HOLFormulaParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/hlk/HOLFormulaParserTest.scala
@@ -5,10 +5,6 @@ package at.logic.gapt.formats.hlk
  */
 import at.logic.gapt.proofs.lk.base.FSequent
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mock.Mockito
-import org.mockito.Matchers._
 import java.io.IOException
 import at.logic.gapt.proofs.resolution.robinson.Formatter
 import at.logic.gapt.proofs.resolution.robinson.RobinsonResolutionProof
@@ -21,8 +17,7 @@ import org.specs2.execute.Success
 import at.logic.gapt.expr._
 import java.io.File.separator
 
-@RunWith( classOf[JUnitRunner] )
-class HOLASTParserTest extends SpecificationWithJUnit {
+class HOLASTParserTest extends Specification {
 
   "The HOL AST Parser parser" should {
     "handle conjunctions and atoms" in {

--- a/src/test/scala/at/logic/gapt/formats/hlk/HOLParserHLKTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/hlk/HOLParserHLKTest.scala
@@ -1,15 +1,12 @@
 package at.logic.gapt.formats.hlk
 
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
 /**
  * Test files for the hol parser
  */
-@RunWith( classOf[JUnitRunner] )
-class HOLParserTest extends SpecificationWithJUnit {
+class HOLParserTest extends Specification {
   "HLK HOL Parser" should {
     "Parse atoms" in {
       /*

--- a/src/test/scala/at/logic/gapt/formats/hlk/HybridLatexParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/hlk/HybridLatexParserTest.scala
@@ -6,9 +6,7 @@ import at.logic.gapt.language.hol._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.{ TA, Ti, To }
 import at.logic.gapt.utils.testing.ClasspathFileCopier
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
 /**
  * Created with IntelliJ IDEA.
@@ -17,8 +15,7 @@ import org.specs2.runner.JUnitRunner
  * Time: 3:02 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith( classOf[JUnitRunner] )
-class HybridLatexParserTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class HybridLatexParserTest extends Specification with ClasspathFileCopier {
   val p1 =
     """\AX{T,MON(h_1,\alpha)}{MON(h_1,\alpha) }
       |\AX{ NOCC(h_1,\alpha,\sigma)}{NOCC(h_1,\alpha,\sigma)}

--- a/src/test/scala/at/logic/gapt/formats/hoare/ProgramParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/hoare/ProgramParserTest.scala
@@ -2,13 +2,10 @@ package at.logic.gapt.formats.hoare
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.hoare._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 import ProgramParser._
 
-@RunWith( classOf[JUnitRunner] )
-class ProgramParserTest extends SpecificationWithJUnit {
+class ProgramParserTest extends Specification {
   "ProgramParser" should {
     "parse an assignment" in {
       parseProgram( "x := f(x)" ) must beEqualTo( Assign( "x", parseTerm( "f(x)" ) ) )

--- a/src/test/scala/at/logic/gapt/formats/ivy/IvyTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/ivy/IvyTest.scala
@@ -1,9 +1,7 @@
 package at.logic.gapt.formats.ivy
 
 import at.logic.gapt.utils.testing.ClasspathFileCopier
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable._
 import at.logic.gapt.formats.lisp
 import java.io.File.separator
 import util.parsing.input.Reader
@@ -12,8 +10,7 @@ import lisp.{ SExpressionParser }
 /**
  * Test for the Ivy interface.
  */
-@RunWith( classOf[JUnitRunner] )
-class IvyTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class IvyTest extends Specification with ClasspathFileCopier {
   def dumpreader[T]( r: Reader[T] ) = {
     var reader = r
     println( "=== dumping reader! ===" )

--- a/src/test/scala/at/logic/gapt/formats/language/simple/SimpleFOLParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/language/simple/SimpleFOLParserTest.scala
@@ -9,15 +9,12 @@ package at.logic.gapt.formats.language.simple
 
 import at.logic.gapt.formats.simple.SimpleFOLParser
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.language.fol._
 import at.logic.gapt.expr.StringSymbol
 import at.logic.gapt.formats.readers.StringReader
 
-@RunWith( classOf[JUnitRunner] )
-class SimpleFOLParserTest extends SpecificationWithJUnit {
+class SimpleFOLParserTest extends Specification {
   private class MyParser( input: String ) extends StringReader( input ) with SimpleFOLParser
 
   val var1 = FOLVar( "x1" )

--- a/src/test/scala/at/logic/gapt/formats/language/simple/SimpleHOLParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/language/simple/SimpleHOLParserTest.scala
@@ -9,16 +9,13 @@ package at.logic.gapt.formats.language.simple
 
 import at.logic.gapt.formats.simple.SimpleHOLParser
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.language.hol._
 import at.logic.gapt.expr.StringSymbol
 import at.logic.gapt.formats.readers.StringReader
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class SimpleHOLParserTest extends SpecificationWithJUnit {
+class SimpleHOLParserTest extends Specification {
   private class MyParser( input: String ) extends StringReader( input ) with SimpleHOLParser
   "SimpleHOLParser" should {
     val var1 = Var( StringSymbol( "x1" ), Ti -> ( Ti -> Ti ) )

--- a/src/test/scala/at/logic/gapt/formats/language/xml/HOLTermExporterTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/language/xml/HOLTermExporterTest.scala
@@ -9,8 +9,6 @@ package at.logic.gapt.formats.language.xml
 
 import at.logic.gapt.formats.xml.HOLTermXMLExporter
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import scala.xml._
 
@@ -26,8 +24,7 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.StringSymbol
 
-@RunWith( classOf[JUnitRunner] )
-class HOLTermExporterTest extends SpecificationWithJUnit {
+class HOLTermExporterTest extends Specification {
 
   val exporter = new HOLTermXMLExporter {}
   // helper to create 0-ary predicate constants

--- a/src/test/scala/at/logic/gapt/formats/language/xml/XMLParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/language/xml/XMLParserTest.scala
@@ -15,18 +15,15 @@ import com.sun.org.apache.xml.internal.resolver.tools.CatalogResolver
 import java.io.File.separator
 import java.io.{ FileInputStream, InputStreamReader, ByteArrayInputStream }
 import java.util.zip.GZIPInputStream
-import org.junit.runner.RunWith
 import org.specs2.matcher.Expectable
 import org.specs2.matcher.Matcher
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.xml.sax.ErrorHandler
 import org.xml.sax.helpers.XMLReaderFactory
 import scala.io.{ BufferedSource, Source }
 import scala.xml.SAXParseException
 
-@RunWith( classOf[JUnitRunner] )
-class XMLParserTest extends SpecificationWithJUnit {
+class XMLParserTest extends Specification {
 
   implicit def fo2occ( f: HOLFormula ) = factory.createFormulaOccurrence( f, Nil )
   implicit def fseq2seq( s: FSequent ) = Sequent( s._1 map fo2occ, s._2 map fo2occ )

--- a/src/test/scala/at/logic/gapt/formats/prover9/Prover9ParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/prover9/Prover9ParserTest.scala
@@ -1,12 +1,9 @@
 package at.logic.gapt.formats.prover9
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class Prover9ParserTest extends SpecificationWithJUnit {
+class Prover9ParserTest extends Specification {
   "The Prover9 language parser" should {
     "handle conjunctions and atoms" in {
       List( "p(X)", "A", "-p(y)", "-p(Y)",

--- a/src/test/scala/at/logic/gapt/formats/simple/SimpleResolutionParserTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/simple/SimpleResolutionParserTest.scala
@@ -9,15 +9,12 @@ package at.logic.gapt.formats.simple
 
 import at.logic.gapt.proofs.lk.base.FSequent
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.formats.readers.StringReader
 import at.logic.gapt.proofs.resolution._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class SimpleResolutionParserTest extends SpecificationWithJUnit {
+class SimpleResolutionParserTest extends Specification {
   //  private class MyParser(input: String) extends StringReader(input) with SimpleResolutionParserHOL
   private class MyParser2( input: String ) extends StringReader( input ) with SimpleResolutionParserFOL
 

--- a/src/test/scala/at/logic/gapt/formats/tptp/TPTPHOLExporterTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/tptp/TPTPHOLExporterTest.scala
@@ -1,14 +1,12 @@
 package at.logic.gapt.formats.tptp
 
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable._
 import org.specs2.execute.Success
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.FSequent
 
-class TPTPHOLExporterTest extends SpecificationWithJUnit {
+class TPTPHOLExporterTest extends Specification {
   "Export to TPTP thf" should {
     "handle atoms correctly" in {
       val x = Var( "x", Ti -> To )

--- a/src/test/scala/at/logic/gapt/formats/veriT/VeriTParsingTest.scala
+++ b/src/test/scala/at/logic/gapt/formats/veriT/VeriTParsingTest.scala
@@ -1,12 +1,9 @@
 package at.logic.gapt.formats.veriT
 
 import at.logic.gapt.utils.testing.ClasspathFileCopier
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class VeriTParsingTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class VeriTParsingTest extends Specification with ClasspathFileCopier {
 
   "The veriT parser" should {
     "parse correctly the simplest proof of the database" in {

--- a/src/test/scala/at/logic/gapt/integration_tests/CutIntroTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/CutIntroTest.scala
@@ -10,13 +10,10 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.formats.tptp.TPTPFOLExporter
 import at.logic.gapt.provers.basicProver.BasicProver
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import scala.collection.immutable.HashSet
 
-@RunWith( classOf[JUnitRunner] )
-class CutIntroTest extends SpecificationWithJUnit {
+class CutIntroTest extends Specification {
   private def LinearExampleTermset( n: Int ): List[FOLTerm] =
     if ( n == 0 )
       List[FOLTerm]()

--- a/src/test/scala/at/logic/gapt/integration_tests/LNPProofTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/LNPProofTest.scala
@@ -16,13 +16,10 @@ import at.logic.gapt.proofs.algorithms.skolemization.lksk.LKtoLKskc
 import java.util.zip.GZIPInputStream
 import java.io.{ FileReader, FileInputStream, InputStreamReader }
 import java.io.File.separator
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.specs2.execute.Success
 
-@RunWith( classOf[JUnitRunner] )
-class LNPProofTest extends SpecificationWithJUnit {
+class LNPProofTest extends Specification {
 
   def sequentToString( s: Sequent ) = {
     var ret = ""

--- a/src/test/scala/at/logic/gapt/integration_tests/LatticeTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/LatticeTest.scala
@@ -21,12 +21,9 @@ import at.logic.gapt.proofs.algorithms.skolemization.skolemize
 import java.io.File.separator
 import java.io.{ IOException, FileReader, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class LatticeTest extends SpecificationWithJUnit {
+class LatticeTest extends Specification {
   def checkForProverOrSkip = Prover9.isInstalled must beTrue.orSkip
 
   def sequentToString( s: Sequent ) = {

--- a/src/test/scala/at/logic/gapt/integration_tests/MiscTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/MiscTest.scala
@@ -33,13 +33,10 @@ import java.io.File.separator
 import java.io.{ FileReader, FileInputStream, InputStreamReader }
 import at.logic.gapt.proofs.occurrences._
 import at.logic.gapt.utils.testing.ClasspathFileCopier
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class MiscTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class MiscTest extends Specification with ClasspathFileCopier {
 
   // returns LKProof with end-sequent  P(s^k(0)), \ALL x . P(x) -> P(s(x)) :- P(s^n(0))
   private def LinearExampleProof( k: Int, n: Int ): LKProof = {

--- a/src/test/scala/at/logic/gapt/integration_tests/PrimeProofModuloTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/PrimeProofModuloTest.scala
@@ -33,12 +33,9 @@ import at.logic.gapt.proofs.algorithms.skolemization.skolemize
 import java.io.File.separator
 import java.io.{IOException, FileReader, FileInputStream, InputStreamReader}
 import java.util.zip.GZIPInputStream
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
-class PrimeProofTest extends SpecificationWithJUnit {
+class PrimeProofTest extends Specification {
   val box = List()
   def checkForProverOrSkip = Prover9.refute(box) must not(throwA[IOException]).orSkip
 

--- a/src/test/scala/at/logic/gapt/integration_tests/PrimeProofTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/PrimeProofTest.scala
@@ -35,12 +35,9 @@ import at.logic.gapt.provers.atp.refinements.UnitRefinement
 import java.io.File.separator
 import java.io.{ IOException, FileReader, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class PrimeProofTest extends SpecificationWithJUnit {
+class PrimeProofTest extends Specification {
   def checkForProverOrSkip = Prover9.isInstalled must beTrue.orSkip
 
   def sequentToString( s: Sequent ) = {

--- a/src/test/scala/at/logic/gapt/integration_tests/TapeTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/TapeTest.scala
@@ -34,12 +34,9 @@ import java.io.File.separator
 import java.io.{ IOException, FileInputStream, InputStreamReader }
 import java.util.zip.GZIPInputStream
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class TapeTest extends SpecificationWithJUnit {
+class TapeTest extends Specification {
   def checkForProverOrSkip = Prover9.isInstalled must beTrue.orSkip
 
   sequential

--- a/src/test/scala/at/logic/gapt/integration_tests/TreeGrammarDecompositionTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/TreeGrammarDecompositionTest.scala
@@ -7,16 +7,13 @@ import at.logic.gapt.proofs.lk.base.LKProof
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.algorithms.herbrandExtraction.extractExpansionSequent
 import at.logic.gapt.provers.maxsat.{ MaxSat4j, MaxSATSolver }
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable._
 
 /**
  * Created by spoerk on 09.10.14.
  */
 
-@RunWith( classOf[JUnitRunner] )
-class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
+class TreeGrammarDecompositionTest extends Specification {
 
   private def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"

--- a/src/test/scala/at/logic/gapt/integration_tests/nTapeTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/nTapeTest.scala
@@ -25,12 +25,9 @@ import at.logic.gapt.proofs.algorithms.skolemization.lksk.LKtoLKskc
 import at.logic.gapt.utils.testing.ClasspathFileCopier
 import at.logic.gapt.proofs.expansionTrees.{ ETAnd, ETImp, ETWeakQuantifier, ETSkolemQuantifier, ExpansionTree, ExpansionSequent }
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class nTapeTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class nTapeTest extends Specification with ClasspathFileCopier {
   def checkForProverOrSkip = Prover9.isInstalled must beTrue.orSkip
 
   def show( s: String ) = println( "+++++++++ " + s + " ++++++++++" )

--- a/src/test/scala/at/logic/gapt/integration_tests/unfoldSchemaProofTest.scala
+++ b/src/test/scala/at/logic/gapt/integration_tests/unfoldSchemaProofTest.scala
@@ -5,14 +5,11 @@ import java.io.InputStreamReader
 
 import at.logic.gapt.formats.shlk_parsing.SHLK.parseProof
 import at.logic.gapt.language.schema._
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
 // Moved this test to integration_tests because it uses an external file.
-@RunWith( classOf[JUnitRunner] )
-class UnfoldSchemaProofTest extends SpecificationWithJUnit {
+class UnfoldSchemaProofTest extends Specification {
   //implicit val factory = defaultFormulaOccurrenceFactory
   "UnfoldSchemaProofTest" should {
     "unfold the adder.slk" in {

--- a/src/test/scala/at/logic/gapt/language/fol/FirstOrderLogicTest.scala
+++ b/src/test/scala/at/logic/gapt/language/fol/FirstOrderLogicTest.scala
@@ -5,13 +5,10 @@
 package at.logic.gapt.language.fol
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class FirstOrderLogicTest extends SpecificationWithJUnit {
+class FirstOrderLogicTest extends Specification {
   "FirstOrderLogic" should {
     "construct correctly an atom formula P(x,f(y),c)" in {
       val List( p, x, y, f, c ) = List( "P", "x", "y", "f", "c" )

--- a/src/test/scala/at/logic/gapt/language/fol/algorithms/FOLMatchingAlgorithmTest.scala
+++ b/src/test/scala/at/logic/gapt/language/fol/algorithms/FOLMatchingAlgorithmTest.scala
@@ -6,12 +6,9 @@
 package at.logic.gapt.language.fol.algorithms
 
 import at.logic.gapt.expr._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class FOLMatchingAlgorithmTest extends SpecificationWithJUnit {
+class FOLMatchingAlgorithmTest extends Specification {
   "FOLMatchingAlgorithm" should {
     val x = FOLVar( "x" )
     val x1 = FOLVar( "x1" )

--- a/src/test/scala/at/logic/gapt/language/fol/algorithms/FOLUnificationAlgorithmTest.scala
+++ b/src/test/scala/at/logic/gapt/language/fol/algorithms/FOLUnificationAlgorithmTest.scala
@@ -6,12 +6,9 @@
 package at.logic.gapt.language.fol.algorithms
 
 import at.logic.gapt.expr._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class FOLUnificationAlgorithmTest extends SpecificationWithJUnit {
+class FOLUnificationAlgorithmTest extends Specification {
 
   "UnificationBasedFOLMatchingAlgorithm" should {
     "match correctly the lambda expressions f(x1, x2, c) and f(a,b,c)" in {

--- a/src/test/scala/at/logic/gapt/language/fol/algorithms/UnificationTest.scala
+++ b/src/test/scala/at/logic/gapt/language/fol/algorithms/UnificationTest.scala
@@ -3,12 +3,9 @@ package at.logic.gapt.language.fol.algorithms
 
 import at.logic.gapt.expr._
 import at.logic.gapt.language.fol.FOLSubstitution
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class UnificationTest extends SpecificationWithJUnit {
+class UnificationTest extends Specification {
 
   "FOL Unification" should {
     "unify the terms" in {

--- a/src/test/scala/at/logic/gapt/language/fol/algorithms/hol2folTest.scala
+++ b/src/test/scala/at/logic/gapt/language/fol/algorithms/hol2folTest.scala
@@ -10,12 +10,9 @@ import at.logic.gapt.expr.StringSymbol
 import at.logic.gapt.expr._
 import at.logic.gapt.formats.readers.StringReader
 import at.logic.gapt.language.fol.algorithms.{ convertHolToFol, changeTypeIn, reduceHolToFol }
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class hol2folTest extends SpecificationWithJUnit {
+class hol2folTest extends Specification {
   def imap = Map[LambdaExpression, StringSymbol]() // the scope for most tests is just the term itself
   def iid = new { var idd = 0; def nextId = { idd = idd + 1; idd } }
 

--- a/src/test/scala/at/logic/gapt/language/hol/HOLPositionTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/HOLPositionTest.scala
@@ -5,11 +5,8 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class HOLPositionTest extends SpecificationWithJUnit {
+class HOLPositionTest extends Specification {
   "HOLPositions" should {
     "be computed correctly" in {
       val x = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/language/hol/HigherOrderLogicTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/HigherOrderLogicTest.scala
@@ -5,15 +5,12 @@
 package at.logic.gapt.language.hol
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import BetaReduction._
 
-@RunWith( classOf[JUnitRunner] )
-class HigherOrderLogicTest extends SpecificationWithJUnit {
+class HigherOrderLogicTest extends Specification {
 
   "HigherOrderLogic" should {
     val c1 = Const( "a", Ti -> To )

--- a/src/test/scala/at/logic/gapt/language/hol/ReplacementsTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/ReplacementsTest.scala
@@ -6,15 +6,12 @@
 package at.logic.gapt.language.hol.replacements
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.language.hol._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class ReplacementsTest extends SpecificationWithJUnit {
+class ReplacementsTest extends Specification {
   "Replacements" should {
     "work correctly on" in {
       "Atoms" in {

--- a/src/test/scala/at/logic/gapt/language/hol/algorithms/NaiveIncompleteMatchingAlgorithmTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/algorithms/NaiveIncompleteMatchingAlgorithmTest.scala
@@ -8,12 +8,9 @@ package at.logic.gapt.language.hol.algorithms
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.language.hol.HOLSubstitution
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class NaiveIncompleteMatchingAlgorithmTest extends SpecificationWithJUnit {
+class NaiveIncompleteMatchingAlgorithmTest extends Specification {
   "NaiveIncompleteMatchingAlgorithm " should {
     "match correctly the HOL expressions P(a,x) and P(a,f(b))" in {
       val P = Const( "P", Ti -> ( Ti -> To ) )

--- a/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/ACUnificationTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/ACUnificationTest.scala
@@ -11,15 +11,12 @@ import at.logic.gapt.language.fol._
 import at.logic.gapt.expr._
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import org.specs2.matcher.Matcher
 import org.specs2.matcher.Expectable
 import org.specs2.execute.Skipped
 import org.specs2.execute.Success
 
-@RunWith(classOf[JUnitRunner])
-class ACUnificationTest extends SpecificationWithJUnit {
+class ACUnificationTest extends Specification {
   // Is parsing used only for avoinding constructing the terms???
   //val parse = (s:String) => (new StringReader(s) with SimpleFOLParser {}).getTerm().asInstanceOf[FOLTerm]
   //val parse_pred = (s:String) => (new StringReader(s) with SimpleFOLParser {}).getTerm().asInstanceOf[FOLFormula]

--- a/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/hol/HuetAlgorithmTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/hol/HuetAlgorithmTest.scala
@@ -13,8 +13,6 @@ import at.logic.gapt.expr.BetaReduction._
 import scala.collection.immutable.HashMap
 import at.logic.gapt.expr.substitutions.Substitution
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.parsing.readers.StringReader
 import at.logic.parsing.language.simple.SimpleFOLParser
 import at.logic.gapt.language.hol.algorithms.unification.hol._
@@ -32,8 +30,7 @@ import StrategyLeftRight._
 
 //private class MyParser(input: String) extends StringReader(input) with SimpleFOLParser
 
-@RunWith(classOf[JUnitRunner])
-class HuetAlgorithmTest extends SpecificationWithJUnit with org.specs2.ScalaCheck {
+class HuetAlgorithmTest extends Specification with org.specs2.ScalaCheck {
     "HuetAlgorithm" should {
 
 //       class MyParser(input: String) extends StringReader(input) with SimpleHOLParser

--- a/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/lankfordTest.scala
+++ b/src/test/scala/at/logic/gapt/language/hol/algorithms/unification/lankfordTest.scala
@@ -1,12 +1,9 @@
 package at.logic.gapt.language.hol.algorithms.unification
 
 import at.logic.gapt.language.hol.algorithms.unification
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class LankfordSolverTest extends SpecificationWithJUnit {
+class LankfordSolverTest extends Specification {
   "The Lankford Diophantine solver" should {
     "handle vectors correctly" in {
       val v1: Vector = Vector( -1, 0, 1, 0, 0, 2 )

--- a/src/test/scala/at/logic/gapt/language/lambda/BetaReductionTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/BetaReductionTest.scala
@@ -6,16 +6,13 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import BetaReduction._
 import StrategyOuterInner._
 import StrategyLeftRight._
 import ImplicitStandardStrategy._
 
-@RunWith( classOf[JUnitRunner] )
-class BetaReductionTest extends SpecificationWithJUnit {
+class BetaReductionTest extends Specification {
 
   val v = Var( "v", Ti );
   val x = Var( "x", Ti );

--- a/src/test/scala/at/logic/gapt/language/lambda/LambdaCalculusTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/LambdaCalculusTest.scala
@@ -5,14 +5,11 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import scala.collection.immutable.{ HashSet, HashMap }
 import scala.math.signum
 
-@RunWith( classOf[JUnitRunner] )
-class LambdaCalculusTest extends SpecificationWithJUnit {
+class LambdaCalculusTest extends Specification {
 
   "TypedLambdaCalculus" should {
     "make implicit conversion from String to Name" in {

--- a/src/test/scala/at/logic/gapt/language/lambda/LambdaPositionTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/LambdaPositionTest.scala
@@ -3,11 +3,8 @@ package at.logic.gapt.expr
 import LambdaPosition._
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class LambdaPositionTest extends SpecificationWithJUnit {
+class LambdaPositionTest extends Specification {
   "LambdaPositions" should {
     "be computed correctly" in {
       val x = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/language/lambda/LongNormalFormTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/LongNormalFormTest.scala
@@ -1,11 +1,8 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class EtaExpansionTest extends SpecificationWithJUnit {
+class EtaExpansionTest extends Specification {
   val v = Var( "v", Ti );
   val x = Var( "x", Ti );
   val y = Var( "y", Ti );

--- a/src/test/scala/at/logic/gapt/language/lambda/SubstitutionsTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/SubstitutionsTest.scala
@@ -5,15 +5,12 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import BetaReduction._
 import ImplicitStandardStrategy._
 import org.specs2.execute.Success
 
-@RunWith( classOf[JUnitRunner] )
-class SubstitutionsTest extends SpecificationWithJUnit {
+class SubstitutionsTest extends Specification {
 
   "Substitutions" should {
     "NOT compose the substitution {f(y)/x} and {g(y)/x}" in {

--- a/src/test/scala/at/logic/gapt/language/lambda/SymbolsTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/SymbolsTest.scala
@@ -8,11 +8,8 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class SymbolsTest extends SpecificationWithJUnit {
+class SymbolsTest extends Specification {
   "Equality between symbols" should {
     "return true if it is the same class and mixed with the same string" in {
       ( VariantSymbol( "a" ) ) must beEqualTo( VariantSymbol( "a" ) )

--- a/src/test/scala/at/logic/gapt/language/lambda/TypesTest.scala
+++ b/src/test/scala/at/logic/gapt/language/lambda/TypesTest.scala
@@ -8,12 +8,9 @@
 package at.logic.gapt.expr
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import scala.util.parsing.combinator._
 
-@RunWith( classOf[JUnitRunner] )
-class TypesTest extends SpecificationWithJUnit {
+class TypesTest extends Specification {
   "Types" should {
     "produce a binary function type ( i -> (i -> o ) )" in {
       FunctionType( To, Ti :: Ti :: Nil ) must beEqualTo( ->( Ti, ->( Ti, To ) ) )

--- a/src/test/scala/at/logic/gapt/language/schema/schemaTest.scala
+++ b/src/test/scala/at/logic/gapt/language/schema/schemaTest.scala
@@ -1,14 +1,11 @@
 package at.logic.gapt.language.schema
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import BetaReduction._
 
-@RunWith( classOf[JUnitRunner] )
-class SchemaTest extends SpecificationWithJUnit {
+class SchemaTest extends Specification {
   "Schema" should {
     val i = IntVar( "i" )
     val one = Succ( IntZero() )

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/ClauseSetsTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/ClauseSetsTest.scala
@@ -14,14 +14,11 @@ import at.logic.gapt.proofs.algorithms.ceres.projections.{ DeleteTautology, Dele
 import at.logic.gapt.proofs.algorithms.ceres.struct._
 import java.io.File.separator
 import java.io.{ FileInputStream, InputStreamReader }
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import scala.io._
 import scala.xml._
 
-@RunWith( classOf[JUnitRunner] )
-class ClauseSetsTest extends SpecificationWithJUnit {
+class ClauseSetsTest extends Specification {
 
   sequential
   "ClauseSets" should {

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/ProjectionTermTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/ProjectionTermTest.scala
@@ -14,14 +14,11 @@ import clauseSchema.ParseResSchema._
 import clauseSchema._
 import java.io.File.separator
 import java.io.{ FileInputStream, InputStreamReader }
-import org.junit.runner.RunWith
 
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class ProjectionTermTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class ProjectionTermTest extends Specification with ClasspathFileCopier {
   implicit val factory = defaultFormulaOccurrenceFactory
 
   sequential

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/SubstituteProofTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/SubstituteProofTest.scala
@@ -1,8 +1,6 @@
 package at.logic.gapt.proofs.algorithms.ceres.ACNF
 
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable._
 import at.logic.gapt.proofs.lk.base.{ FSequent, LKProof }
 import at.logic.gapt.algorithms.hlk.HybridLatexParser
 import java.io.File.separator
@@ -19,8 +17,7 @@ import at.logic.gapt.expr._
  * To change this template use File | Settings | File Templates.
  */
 /*
-@RunWith(classOf[JUnitRunner])
-class SubstituteProofTest extends SpecificationWithJUnit {
+class SubstituteProofTest extends Specification {
   "Proof substitution" should {
     val tokens = HybridLatexParser.parseFile("target" + separator + "substitutions.llk")
     val pdb = HybridLatexParser.createLKProof(tokens)

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/acnfTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/acnfTest.scala
@@ -15,12 +15,9 @@ import at.logic.gapt.proofs.algorithms.ceres.clauseSets.StandardClauseSet
 import at.logic.gapt.proofs.algorithms.ceres.projections.Projections
 import at.logic.gapt.proofs.algorithms.ceres.struct.StructCreators
 import java.io.{ FileInputStream, InputStreamReader }
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class acnfTest extends SpecificationWithJUnit {
+class acnfTest extends Specification {
   implicit val factory = defaultFormulaOccurrenceFactory
 
   args( sequential = true, skipAll = !Prover9.isInstalled )

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/clauseSchemaTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/clauseSchemaTest.scala
@@ -7,14 +7,11 @@ import at.logic.gapt.language.schema._
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import java.io.File.separator
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import scala.io._
 
-@RunWith( classOf[JUnitRunner] )
-class clauseSchemaTest extends SpecificationWithJUnit {
+class clauseSchemaTest extends Specification {
   "clauseSchemaTest" should {
     "create a correct schema clause" in {
       val k = IntVar( "k" )

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/resolutionSchemaParserTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/ceres/resolutionSchemaParserTest.scala
@@ -5,13 +5,10 @@
 //import at.logic.gapt.expr._
 //import java.io.File.separator
 //import java.io.{ FileInputStream, InputStreamReader }
-//import org.junit.runner.RunWith
-//import org.specs2.mutable.SpecificationWithJUnit
-//import org.specs2.runner.JUnitRunner
+//import org.specs2.mutable._
 //import scala.io._
 //
-//@RunWith( classOf[JUnitRunner] )
-//class resolutionSchemaParserTest extends SpecificationWithJUnit {
+//class resolutionSchemaParserTest extends Specification {
 //
 //  sequential
 //  "resolutionSchemaParserTest" should {

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/herbrandExtraction/ExtractExpansionSequentTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/herbrandExtraction/ExtractExpansionSequentTest.scala
@@ -2,8 +2,6 @@ package at.logic.gapt.proofs.algorithms.herbrandExtraction
 
 import at.logic.gapt.language.fol.Utils
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.language.hol._
 import at.logic.gapt.proofs.lk._
@@ -11,8 +9,7 @@ import at.logic.gapt.proofs.expansionTrees.{ ETStrongQuantifier, ETWeakQuantifie
 import at.logic.gapt.proofs.lk.base.LKProof
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class ExtractExpansionSequentTest extends SpecificationWithJUnit {
+class ExtractExpansionSequentTest extends Specification {
 
   def LinearExampleProof( k: Int, n: Int ): LKProof = {
     val s = "s"

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/herbrandExtraction/lksk/extractLKSKExpansionTreesTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/herbrandExtraction/lksk/extractLKSKExpansionTreesTest.scala
@@ -1,8 +1,6 @@
 package at.logic.gapt.proofs.algorithms.herbrandExtraction.lksk
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.language.hol._
 import at.logic.gapt.proofs.lk.base.FSequent
@@ -16,8 +14,7 @@ import at.logic.gapt.proofs.algorithms.skolemization.lksk.{ LKtoLKskc => skolemi
 /**
  * Created by marty on 8/7/14.
  */
-@RunWith( classOf[JUnitRunner] )
-class extractLKSKExpansionSequentTest extends SpecificationWithJUnit {
+class extractLKSKExpansionSequentTest extends Specification {
   object simpleHOLProof {
     val p = HOLAtom( Const( "P", To ), Nil )
     val x = Var( "X", To )

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/skolemization/SkolemizationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/skolemization/SkolemizationTest.scala
@@ -13,14 +13,11 @@ import at.logic.gapt.language.hol._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
 import skolemize._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr.StringSymbol
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class SkolemizationTest extends SpecificationWithJUnit {
+class SkolemizationTest extends Specification {
 
   sequential
   "Skolemization" should {

--- a/src/test/scala/at/logic/gapt/proofs/algorithms/skolemization/lksk/LKskcTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/algorithms/skolemization/lksk/LKskcTest.scala
@@ -15,14 +15,11 @@ import at.logic.gapt.proofs.lk.base.{ LKProof, Sequent }
 import at.logic.gapt.proofs.lk.{ OrLeftRule, Axiom => LKAxiom }
 import at.logic.gapt.proofs.lk.{ ForallLeftRule, ForallRightRule, ExistsLeftRule, ExistsRightRule }
 import at.logic.gapt.proofs.lksk._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lksk.TypeSynonyms.EmptyLabel
 
-@RunWith( classOf[JUnitRunner] )
-class LKskcTest extends SpecificationWithJUnit {
+class LKskcTest extends Specification {
 
   "Transformation from LK to LKskc" should {
     val x = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/expansionTrees/ExpansionTreeTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/expansionTrees/ExpansionTreeTest.scala
@@ -3,13 +3,10 @@ package at.logic.gapt.proofs.expansionTrees
 
 import at.logic.gapt.language.hol.HOLSubstitution
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.{ Ti => i, To => o }
 
-@RunWith( classOf[JUnitRunner] )
-class ExpansionTreeTest extends SpecificationWithJUnit {
+class ExpansionTreeTest extends Specification {
 
   val alpha = Var( "\\alpha", i )
   val beta = Var( "\\beta", i )

--- a/src/test/scala/at/logic/gapt/proofs/expansionTrees/algorithms/compressTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/expansionTrees/algorithms/compressTest.scala
@@ -3,12 +3,9 @@ package at.logic.gapt.proofs.expansionTrees.algorithms
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.expansionTrees._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class compressTest extends SpecificationWithJUnit {
+class compressTest extends Specification {
 
   val x = Var( ( "x" ), Ti )
   val c = Const( ( "c" ), Ti )

--- a/src/test/scala/at/logic/gapt/proofs/expansionTrees/algorithms/minimalTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/expansionTrees/algorithms/minimalTest.scala
@@ -4,12 +4,9 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.expansionTrees._
 import at.logic.gapt.provers.FailSafeProver
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class minimalExpansionSequentTest extends SpecificationWithJUnit {
+class minimalExpansionSequentTest extends Specification {
 
   val x = Var( "x", Ti )
   val c = Const( "c", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/hoare/UtilsTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/hoare/UtilsTest.scala
@@ -1,13 +1,10 @@
 package at.logic.gapt.proofs.hoare
 
 import at.logic.gapt.formats.hoare.ProgramParser
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 import ProgramParser._
 
-@RunWith( classOf[JUnitRunner] )
-class UtilsTest extends SpecificationWithJUnit {
+class UtilsTest extends Specification {
   "LoopFree" should {
     "match loop-free programs" in {
       LoopFree.unapply( parseProgram( "skip" ) ) must beSome

--- a/src/test/scala/at/logic/gapt/proofs/lk/LKTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/LKTest.scala
@@ -8,8 +8,6 @@ package at.logic.gapt.proofs.lk
 import at.logic.gapt.expr.LambdaSubstitution
 import at.logic.gapt.language.hol.HOLPosition
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import base._
@@ -25,8 +23,7 @@ import base._
  * Still missing for each rule:
  * 1) To check that all exceptions are thrown when needed
  */
-@RunWith( classOf[JUnitRunner] )
-class LKTest extends SpecificationWithJUnit {
+class LKTest extends Specification {
 
   val c1 = Var( "a", Ti -> To )
   val v1 = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/CloneLKProofTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/CloneLKProofTest.scala
@@ -2,12 +2,9 @@ package at.logic.gapt.proofs.lk.algorithms
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class CloneLKProofTest extends SpecificationWithJUnit {
+class CloneLKProofTest extends Specification {
   "withMap" should {
     val List( a, b ) = List( "a", "b" ) map ( FOLConst( _ ) )
     val List( x, y ) = List( "x", "y" ) map ( FOLVar( _ ) )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/CutFormulaExtractionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/CutFormulaExtractionTest.scala
@@ -5,12 +5,9 @@ import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.{ BinaryLKProof, Sequent }
 import at.logic.gapt.proofs.lk.{ Axiom, CutRule }
 import at.logic.gapt.proofs.occurrences.FormulaOccurrence
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class CutFormulaExtractionTest extends SpecificationWithJUnit {
+class CutFormulaExtractionTest extends Specification {
   "Substitutions" should {
     val x = Var( "x", Ti )
     val P = Const( "P", Ti -> To )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/RegularizationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/RegularizationTest.scala
@@ -5,12 +5,9 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base.FSequent
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class RegularizationTest extends SpecificationWithJUnit {
+class RegularizationTest extends Specification {
   "Regularization" should {
     "apply correctly to a simple proof (1)" in {
       val x = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SimplificationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SimplificationTest.scala
@@ -4,12 +4,9 @@ package at.logic.gapt.proofs.lk.algorithms
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.FSequent
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class SimplificationTest extends SpecificationWithJUnit {
+class SimplificationTest extends Specification {
   "Simplifications" should {
     val a = HOLAtom( Var( "a", To ) )
     val b = HOLAtom( Var( "b", To ) )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SolveTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SolveTest.scala
@@ -7,12 +7,9 @@ import at.logic.gapt.language.schema._
 import at.logic.gapt.proofs.expansionTrees.{ ExpansionSequent, toShallow, ETAtom, ETNeg, ETOr, ETStrongQuantifier, ETWeakQuantifier }
 import at.logic.gapt.proofs.lk.base.{ FSequent, beSyntacticFSequentEqual }
 import at.logic.gapt.proofs.occurrences.{ FormulaOccurrence, defaultFormulaOccurrenceFactory }
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class SolveTest extends SpecificationWithJUnit {
+class SolveTest extends Specification {
   implicit val factory = defaultFormulaOccurrenceFactory
   "SolveTest" should {
     "solve the sequents" in {

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SubstitutionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/SubstitutionTest.scala
@@ -6,12 +6,9 @@ import at.logic.gapt.expr._
 import at.logic.gapt.language.hol.HOLSubstitution
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base.FSequent
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class SubstitutionTest extends SpecificationWithJUnit {
+class SubstitutionTest extends Specification {
   "Substitutions" should {
     object proof1 {
       val x = Var( "x", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/ForgetfulResolutionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/ForgetfulResolutionTest.scala
@@ -8,12 +8,9 @@ package at.logic.gapt.proofs.lk.algorithms.cutIntroduction
 import at.logic.gapt.proofs.lk.algorithms.cutIntroduction.MinimizeSolution._
 
 import at.logic.gapt.expr._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class ForgetfulResolutionTest extends SpecificationWithJUnit {
+class ForgetfulResolutionTest extends Specification {
 
   "Forgetful Paramodulation Should" should {
 

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/GrammarTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/GrammarTest.scala
@@ -6,8 +6,6 @@
 package at.logic.gapt.proofs.lk.algorithms.cutIntroduction
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import scala.collection.immutable.HashMap
 import at.logic.gapt.expr._
 import TermsExtraction._
@@ -15,8 +13,7 @@ import ComputeGrammars._
 import Deltas._
 import types._
 
-@RunWith( classOf[JUnitRunner] )
-class GrammarTest extends SpecificationWithJUnit {
+class GrammarTest extends Specification {
 
   // On the comments of the examples below, consider A as α
 

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/TreeGrammarDecompositionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/cutIntroduction/TreeGrammarDecompositionTest.scala
@@ -1,12 +1,9 @@
 package at.logic.gapt.proofs.lk.algorithms.cutIntroduction
 
 import at.logic.gapt.expr._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class TreeGrammarDecompositionTest extends SpecificationWithJUnit {
+class TreeGrammarDecompositionTest extends Specification {
 
   /**
    * Constructs a recursively called function term with

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/interpolationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/interpolationTest.scala
@@ -5,17 +5,14 @@ import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base._
 import at.logic.gapt.proofs.occurrences._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.language.fol._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.occurrences._
 import at.logic.gapt.proofs.lk.base._
 import at.logic.gapt.proofs.lk._
 
-@RunWith( classOf[JUnitRunner] )
-class interpolationTest extends SpecificationWithJUnit {
+class interpolationTest extends Specification {
   "interpolation" should {
 
     "correctly interpolate an axiom with top" in {

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/mapTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/mapTest.scala
@@ -6,15 +6,12 @@ import at.logic.gapt.language.hol._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
 /**
  * Created by marty on 10/17/14.
  */
-@RunWith( classOf[JUnitRunner] )
-class mapTest extends SpecificationWithJUnit {
+class mapTest extends Specification {
   "map" should {
     val List( u, x, y, z ) = List( "u", "x", "y", "z" ) map ( Var( _, Ti ) )
     val List( a, b, c ) = List( "a", "b", "c" ) map ( Const( _, Ti ) )

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/subsumption/StillmanSubsumptionAlgorithmTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/subsumption/StillmanSubsumptionAlgorithmTest.scala
@@ -5,14 +5,11 @@
 
 package at.logic.gapt.proofs.lk.algorithms.subsumption
 
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.proofs.lk.base.FSequent
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class StillmanSubsumptionAlgorithmFOLTest extends SpecificationWithJUnit {
+class StillmanSubsumptionAlgorithmFOLTest extends Specification {
   import at.logic.gapt.language.fol._
   "StillmanSubsumptionAlgorithmFOL" should {
     val P = "P"
@@ -122,8 +119,7 @@ class StillmanSubsumptionAlgorithmFOLTest extends SpecificationWithJUnit {
   }
 }
 
-@RunWith( classOf[JUnitRunner] )
-class StillmanSubsumptionAlgorithmHOLTest extends SpecificationWithJUnit {
+class StillmanSubsumptionAlgorithmHOLTest extends Specification {
   import at.logic.gapt.language.hol._
   import at.logic.gapt.expr._
   "StillmanSubsumptionAlgorithmHOL" should {

--- a/src/test/scala/at/logic/gapt/proofs/lk/algorithms/subsumption/managers/FeatureVectorIndexingManagerTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lk/algorithms/subsumption/managers/FeatureVectorIndexingManagerTest.scala
@@ -6,17 +6,14 @@
 /* 
 package at.logic.gapt.proofs.lk.algorithms.subsumption.managers
 
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.utils.ds.mutable.trees._
 import at.logic.calculi.lk.base.FSequent
 import at.logic.gapt.proofs.lk.algorithms.subsumption._
 import at.logic.gapt.language.fol._
 
-@RunWith(classOf[JUnitRunner])
-class FeatureVectorIndexingManagerTest extends SpecificationWithJUnit {
+class FeatureVectorIndexingManagerTest extends Specification {
 
   "tree.scala" should {
     "create correctly a tree" in {

--- a/src/test/scala/at/logic/gapt/proofs/lksk/LKskTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lksk/LKskTest.scala
@@ -6,8 +6,6 @@
 package at.logic.gapt.proofs.lksk
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.expr._
 import at.logic.gapt.expr._
@@ -16,8 +14,7 @@ import at.logic.gapt.proofs.lk.{ OrLeftRule, Axiom => LKAxiom, _ }
 import TypeSynonyms._
 import at.logic.gapt.proofs.occurrences.FOFactory
 
-@RunWith( classOf[JUnitRunner] )
-class LKskTest extends SpecificationWithJUnit {
+class LKskTest extends Specification {
   val c1 = Var( "a", Ti -> To )
   val v1 = Var( "x", Ti )
   val f1 = HOLAtom( c1, v1 :: Nil )

--- a/src/test/scala/at/logic/gapt/proofs/lksk/algorithms/SubstitutionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/lksk/algorithms/SubstitutionTest.scala
@@ -6,12 +6,9 @@ import at.logic.gapt.language.hol.HOLSubstitution
 import at.logic.gapt.proofs.lk.base.FSequent
 import at.logic.gapt.proofs.lksk.TypeSynonyms._
 import at.logic.gapt.proofs.lksk._
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class SubstitutionTest extends SpecificationWithJUnit {
+class SubstitutionTest extends Specification {
   "Substitutions" should {
     val f = Const( "f", Ti -> Ti )
     val y = Var( "y", Ti )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/RalResolutionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/RalResolutionTest.scala
@@ -6,15 +6,12 @@ import at.logic.gapt.proofs.lksk.LabelledSequent
 import at.logic.gapt.proofs.lksk.TypeSynonyms.{ Label, EmptyLabel }
 import at.logic.gapt.language.hol._
 import at.logic.gapt.expr.{ Ti, To }
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
 /**
  * Created by marty on 9/10/14.
  */
-@RunWith( classOf[JUnitRunner] )
-class RalResolutionTest extends SpecificationWithJUnit {
+class RalResolutionTest extends Specification {
   "Ral resolution" should {
     "work on simple proofs" in {
       val x = Var( "X", To )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
@@ -7,16 +7,13 @@ package at.logic.gapt.proofs.resolution
 
 import at.logic.gapt.language.fol.FOLSubstitution
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.proofs.resolution.robinson._
 import at.logic.gapt.proofs.occurrences._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base._
 
-@RunWith( classOf[JUnitRunner] )
-class ResolutionTest extends SpecificationWithJUnit {
+class ResolutionTest extends Specification {
 
   "Paramodulation rule in Robinson Resolution" should {
     "be created correctly" in {

--- a/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/CNFTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/CNFTest.scala
@@ -2,12 +2,9 @@ package at.logic.gapt.proofs.resolution.algorithms
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.resolution.FClause
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class CNFTest extends SpecificationWithJUnit {
+class CNFTest extends Specification {
   "the computation of CNFp(f)" should {
     "be {|- Pa,Qa, Qa|-} for f = (Pa ∨ Qa) ∧ ¬Qa" in {
       val Pa = FOLAtom( "P", FOLConst( "a" ) :: Nil )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/PCNFTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/PCNFTest.scala
@@ -4,15 +4,12 @@ import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base.FSequent
 import at.logic.gapt.proofs.resolution.FClause
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
 // we compare toStrings as proofs have only pointer equality. This needs to be changed by allowing syntaxEquals in graphs and vertices should
 // have syntaxEquals as well
 
-@RunWith( classOf[JUnitRunner] )
-class projectionsTest extends SpecificationWithJUnit {
+class projectionsTest extends Specification {
   "PCNF" should {
     "create the projection of" in {
       val Pa = FOLAtom( "P", FOLConst( "a" ) :: Nil )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/ResolutionToLKTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/ResolutionToLKTest.scala
@@ -5,17 +5,14 @@ import at.logic.gapt.language.fol.FOLSubstitution
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.lk.base._
 import at.logic.gapt.proofs.resolution.robinson._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
 import scala.collection.immutable.Map.{ Map1, Map2 }
 
 // we compare toStrings as proofs have only pointer equality. This needs to be changed by allowing syntaxEquals in graphs and vertices should
 // have syntaxEquals as well
 
-@RunWith( classOf[JUnitRunner] )
-class ResolutionToLKTest extends SpecificationWithJUnit {
+class ResolutionToLKTest extends Specification {
 
   object UNSproof {
     val v0 = FOLVar( "v0" )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/fixDerivationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/fixDerivationTest.scala
@@ -5,12 +5,9 @@ import at.logic.gapt.language.fol.FOLSubstitution
 import at.logic.gapt.proofs.lk.base.FSequent
 import at.logic.gapt.proofs.resolution._
 import at.logic.gapt.proofs.resolution.robinson._
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class FixDerivationTest extends SpecificationWithJUnit {
+class FixDerivationTest extends Specification {
   "fixDerivation" should {
     "not say that p :- is derivable from p :- p, r by symmetry" in {
       val p = FOLAtom( "p", Nil )

--- a/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/instantiateEliminationTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/resolution/algorithms/instantiateEliminationTest.scala
@@ -4,12 +4,9 @@ import at.logic.gapt.expr._
 import at.logic.gapt.language.fol.FOLSubstitution
 import at.logic.gapt.proofs.lk.base.beSyntacticMultisetEqual
 import at.logic.gapt.proofs.resolution.robinson.{ Resolution, Paramodulation, Instance, InitialClause }
-import org.junit.runner.RunWith
-import org.specs2.mutable.SpecificationWithJUnit
-import org.specs2.runner.JUnitRunner
+import org.specs2.mutable._
 
-@RunWith( classOf[JUnitRunner] )
-class instantiateEliminationTest extends SpecificationWithJUnit {
+class instantiateEliminationTest extends Specification {
 
   object UNSproof {
     val v0 = FOLVar( "v0" )

--- a/src/test/scala/at/logic/gapt/proofs/shlk/SLKTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/shlk/SLKTest.scala
@@ -5,9 +5,7 @@
 
 package at.logic.gapt.proofs.shlk
 
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.specs2.execute.Success
 
 import at.logic.gapt.expr._
@@ -17,8 +15,7 @@ import at.logic.gapt.proofs.lk.Axiom
 import at.logic.gapt.proofs.occurrences._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class SLKTest extends SpecificationWithJUnit {
+class SLKTest extends Specification {
   implicit val factory = defaultFormulaOccurrenceFactory
 
   "The calculus SLK" should {

--- a/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/BussGeneratorAutoPropTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/BussGeneratorAutoPropTest.scala
@@ -5,14 +5,11 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.algorithms.solve
 import at.logic.gapt.proofs.lk.base.FSequent
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
 // Seems like this is testing auto-propositional for HOL... why is it here?
-@RunWith( classOf[JUnitRunner] )
-class BussGeneratorAutoPropTest extends SpecificationWithJUnit {
+class BussGeneratorAutoPropTest extends Specification {
   "BussGeneratorAutoPropTest" should {
     "continue autopropositional" in {
 

--- a/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/SimpleSLKParserTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/SimpleSLKParserTest.scala
@@ -12,13 +12,10 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr.To
 import at.logic.gapt.language.schema._
 import at.logic.gapt.proofs.lk._
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class SimpleSLKParserTest extends SpecificationWithJUnit {
+class SimpleSLKParserTest extends Specification {
   "SimpleSLKParser" should {
 
     sequential

--- a/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/sFOparserCNTTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/sFOparserCNTTest.scala
@@ -12,13 +12,10 @@ import at.logic.gapt.expr._
 import at.logic.gapt.language.schema._
 import at.logic.gapt.proofs.lk._
 import at.logic.gapt.proofs.occurrences.FormulaOccurrence
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class sFOparserCNTTest extends SpecificationWithJUnit {
+class sFOparserCNTTest extends Specification {
   "sFOparserCNT" should {
 
     sequential

--- a/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/sFOparserTest.scala
+++ b/src/test/scala/at/logic/gapt/proofs/shlk/algorithms/sFOparserTest.scala
@@ -12,13 +12,10 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr._
 import at.logic.gapt.language.schema._
 import at.logic.gapt.proofs.lk._
-import org.junit.runner.RunWith
 import org.specs2.execute.Success
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class sFOparserTest extends SpecificationWithJUnit {
+class sFOparserTest extends Specification {
 
   sequential
   "sFOparser" should {

--- a/src/test/scala/at/logic/gapt/provers/atp/ProverTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/atp/ProverTest.scala
@@ -6,8 +6,6 @@ package at.logic.gapt.provers.atp
 import at.logic.gapt.language.fol.algorithms.FOLUnificationAlgorithm
 import at.logic.gapt.language.schema.SchemaAtom
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.expr._
 import at.logic.gapt.provers.atp.commands.base.{ BranchCommand, Command }
@@ -25,8 +23,7 @@ import at.logic.gapt.proofs.lk.algorithms.subsumption.StillmanSubsumptionAlgorit
 private class MyParser( str: String ) extends StringReader( str ) with SimpleResolutionParserFOL
 private object MyProver extends Prover[Clause]
 
-@RunWith( classOf[JUnitRunner] )
-class ProverTest extends SpecificationWithJUnit {
+class ProverTest extends Specification {
 
   def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 

--- a/src/test/scala/at/logic/gapt/provers/atp/RobinsonTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/atp/RobinsonTest.scala
@@ -5,16 +5,13 @@ import at.logic.gapt.provers.atp.commands.robinson.ParamodulationCommand
 import org.specs2.mutable._
 import at.logic.gapt.proofs.resolution.robinson._
 import at.logic.gapt.expr._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.proofs.lk.base.FSequent
 import at.logic.gapt.formats.prover9.Prover9TermParser.parseFormula
 import at.logic.gapt.proofs.resolution.{ ResolutionProof, Clause }
 import at.logic.gapt.provers.atp.commands.sequents._
 import at.logic.gapt.provers.atp.commands.base._
 
-@RunWith( classOf[JUnitRunner] )
-class RobinsonTest extends SpecificationWithJUnit {
+class RobinsonTest extends Specification {
   "ParamodulationCommand" should {
     "applying paramodulation command on two res.proofs" in {
       "failing replay command for prime0" in {

--- a/src/test/scala/at/logic/gapt/provers/maxsat/MaxSATTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/maxsat/MaxSATTest.scala
@@ -6,14 +6,11 @@ package at.logic.gapt.provers.maxsat
 
 import at.logic.gapt.models.{ Interpretation, MapBasedInterpretation }
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.proofs.resolution._
 import at.logic.gapt.expr._
 
-@RunWith( classOf[JUnitRunner] )
-class MaxSATTest extends SpecificationWithJUnit {
+class MaxSATTest extends Specification {
   val box: List[FClause] = List()
 
   /*

--- a/src/test/scala/at/logic/gapt/provers/minisat/MiniSATTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/minisat/MiniSATTest.scala
@@ -8,8 +8,6 @@ import java.io.IOException
 
 import at.logic.gapt.models.Interpretation
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.resolution._
@@ -74,8 +72,7 @@ object SATProblems {
   }
 }
 
-@RunWith( classOf[JUnitRunner] )
-class MiniSATTest extends SpecificationWithJUnit {
+class MiniSATTest extends Specification {
   args( skipAll = !( new MiniSATProver ).isInstalled )
 
   "MiniSAT" should {

--- a/src/test/scala/at/logic/gapt/provers/prover9/IvyToRobinsonTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/prover9/IvyToRobinsonTest.scala
@@ -5,17 +5,14 @@ import org.specs2.specification.core.Fragments
 
 import at.logic.gapt.utils.testing.ClasspathFileCopier
 import conversion.IvyToRobinson
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable._
 import at.logic.gapt.formats.lisp
 import lisp.{ SExpressionParser }
 
 /**
  * Test for the Ivy interface.
  */
-@RunWith( classOf[JUnitRunner] )
-class IvyToRobinsonTest extends SpecificationWithJUnit with ClasspathFileCopier {
+class IvyToRobinsonTest extends Specification with ClasspathFileCopier {
 
   def parse( file: String ): MatchResult[Any] = {
     val result = SExpressionParser( tempCopyOfClasspathFile( file ) )

--- a/src/test/scala/at/logic/gapt/provers/prover9/Prover9Test.scala
+++ b/src/test/scala/at/logic/gapt/provers/prover9/Prover9Test.scala
@@ -12,12 +12,9 @@ import at.logic.gapt.proofs.resolution.robinson.{ Formatter, RobinsonResolutionP
 import at.logic.gapt.formats.readers.StringReader
 
 import at.logic.gapt.utils.testing.ClasspathFileCopier
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class Prover9Test extends SpecificationWithJUnit with ClasspathFileCopier {
+class Prover9Test extends Specification with ClasspathFileCopier {
   def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 
   implicit def fo2occ( f: FOLFormula ) = factory.createFormulaOccurrence( f, Nil )

--- a/src/test/scala/at/logic/gapt/provers/prover9/ReplayTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/prover9/ReplayTest.scala
@@ -21,19 +21,14 @@ import at.logic.gapt.provers.prover9.commands.Prover9InitCommand
 import java.io.File.separator
 import java.io.IOException
 
-import org.junit.runner.RunWith
-import org.mockito.Matchers._
-import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import at.logic.gapt.formats.prover9.Prover9TermParser.parseFormula
 import at.logic.gapt.provers.prover9.commands.Prover9InitCommand
 import scala.Some
 import at.logic.gapt.provers.atp.commands.sequents.SetTargetClause
 import at.logic.gapt.provers.atp.commands.base.SetStreamCommand
 
-@RunWith( classOf[JUnitRunner] )
-class ReplayTest extends SpecificationWithJUnit {
+class ReplayTest extends Specification {
   def parse( str: String ): FOLFormula = ( new StringReader( str ) with SimpleFOLParser getTerm ).asInstanceOf[FOLFormula]
 
   implicit def fo2occ( f: FOLFormula ) = factory.createFormulaOccurrence( f, Nil )

--- a/src/test/scala/at/logic/gapt/provers/sat4j/Sat4JTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/sat4j/Sat4JTest.scala
@@ -6,13 +6,10 @@ package at.logic.gapt.provers.sat4j
 
 import at.logic.gapt.expr._
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.provers.minisat.SATProblems
 
-@RunWith( classOf[JUnitRunner] )
-class Sat4JTest extends SpecificationWithJUnit {
+class Sat4JTest extends Specification {
   "Sat4J" should {
     "find a model for an atom" in {
       ( new Sat4j ).solve( SATProblems.getProblem1() ) must beLike {

--- a/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
@@ -5,14 +5,11 @@
 package at.logic.gapt.provers.vampire
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.FSequent
 
-@RunWith( classOf[JUnitRunner] )
-class VampireTest extends SpecificationWithJUnit {
+class VampireTest extends Specification {
 
   args( skipAll = !Vampire.isInstalled() )
 

--- a/src/test/scala/at/logic/gapt/provers/veriT/VeriTProverTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/veriT/VeriTProverTest.scala
@@ -6,12 +6,9 @@ package at.logic.gapt.provers.veriT
 
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.lk.base.FSequent
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith( classOf[JUnitRunner] )
-class VeriTProverTest extends SpecificationWithJUnit {
+class VeriTProverTest extends Specification {
 
   val veriT = new VeriTProver()
 

--- a/src/test/scala/at/logic/gapt/utils/ds/GraphsTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/ds/GraphsTest.scala
@@ -8,14 +8,11 @@
 package at.logic.gapt.utils.ds
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import graphs._
 import GraphImplicitConverters._
 
-@RunWith( classOf[JUnitRunner] )
-class GraphsTest extends SpecificationWithJUnit {
+class GraphsTest extends Specification {
   "Graph" should {
     val g1: EmptyGraph[String] = ()
     val g2: VertexGraph[String] = ( "a", g1 )

--- a/src/test/scala/at/logic/gapt/utils/ds/MultisetsTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/ds/MultisetsTest.scala
@@ -8,14 +8,11 @@
 package at.logic.gapt.utils.ds
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import Multisets._
 import scala.collection.immutable.HashSet
 
-@RunWith( classOf[JUnitRunner] )
-class MultisetsTest extends SpecificationWithJUnit {
+class MultisetsTest extends Specification {
   "Multisets" should {
     val m1 = ( ( HashMultiset[Int] + 1 ) + 1 ) + 2
 

--- a/src/test/scala/at/logic/gapt/utils/ds/StreamTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/ds/StreamTest.scala
@@ -5,13 +5,10 @@
 package at.logic.gapt.utils.ds
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import streams.Definitions._
 
-@RunWith( classOf[JUnitRunner] )
-class StreamTest extends SpecificationWithJUnit {
+class StreamTest extends Specification {
 
   "Stream utils" should {
     def from( n: Int ): Stream[Int] = Stream.cons( n, from( n + 1 ) )

--- a/src/test/scala/at/logic/gapt/utils/ds/TreesTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/ds/TreesTest.scala
@@ -8,15 +8,12 @@
 package at.logic.gapt.utils.ds
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import trees._
 import graphs._
 import TreeImplicitConverters._
 
-@RunWith( classOf[JUnitRunner] )
-class TreesTest extends SpecificationWithJUnit {
+class TreesTest extends Specification {
   "Tree" should {
     "pattern match as graphs and recursively" in {
       val lt = BinaryTree( "y", LeafTree( "a" ), LeafTree( "b" ) )

--- a/src/test/scala/at/logic/gapt/utils/ds/mutable/treesTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/ds/mutable/treesTest.scala
@@ -8,16 +8,13 @@
 package at.logic.gapt.utils.ds.mutable
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import at.logic.gapt.utils.ds.mutable.trees._
 //import at.logic.calculi.lk.base._
 //import at.logic.gapt.language.hol._
 import scala.util.parsing.combinator._
 
-@RunWith( classOf[JUnitRunner] )
-class treesTest extends SpecificationWithJUnit {
+class treesTest extends Specification {
 
   "tree.scala" should {
     "create correctly a tree" in {

--- a/src/test/scala/at/logic/gapt/utils/executionModels/NDStreamTest.scala
+++ b/src/test/scala/at/logic/gapt/utils/executionModels/NDStreamTest.scala
@@ -1,14 +1,11 @@
 package at.logic.gapt.utils.executionModels
 
 import org.specs2.mutable._
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
 
 import ndStream._
 import searchAlgorithms._
 
-@RunWith( classOf[JUnitRunner] )
-class NDStreamTest extends SpecificationWithJUnit {
+class NDStreamTest extends Specification {
   class MyConfiguration( val n: Int ) extends Configuration[Int] {
     def result = if ( n < 1 ) Some( n ) else None
     def isTerminal = result != None


### PR DESCRIPTION
As far as I can tell, these are no longer needed.
 * specs2-mock and scalacheck were only used in imports
 * junit was only used in the maven build.

Any objections to removing them?