### PR TITLE
New Vampire interface

### DIFF
--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -228,6 +228,7 @@ functionality of these systems will not be available.
 \item Prover9 (\url{http://www.cs.unm.edu/~mccune/mace4/download/}) - make sure
   the commands \texttt{prover9} and \texttt{prooftrans} are available.
 \item E theorem prover (\url{http://eprover.org/})
+\item Vampire 4.0 (\url{http://www.vprover.org/})
 \item LeanCoP (\url{http://leancop.de/})
 \item VeriT (\url{http://www.verit-solver.org/})
 \item Z3 (\url{https://github.com/Z3Prover/z3})
@@ -604,8 +605,9 @@ res21: Option[at.logic.gapt.proofs.expansionTrees.ExpansionSequent] = Some(Atom(
 
 \end{clilisting}
 
-All of the above works with E prover as well, we will just show
-\cli{getLKProof} as an example:
+All of the above works with E prover (\cli{EProver}) and Vampire
+(\cli{Vampire}) as well, we will just show \cli{EProver.getLKProof} as an
+example:
 \begin{clilisting}[EProver.isInstalled]
 gapt> EProver getLKProof sequent
 res22: Option[at.logic.gapt.proofs.lk.LKProof] =

--- a/src/main/resources/gapt-cli-prelude.scala
+++ b/src/main/resources/gapt-cli-prelude.scala
@@ -26,6 +26,7 @@ import at.logic.gapt.provers.inductionProver._
 import at.logic.gapt.provers.prover9._
 import at.logic.gapt.provers.maxsat._
 import at.logic.gapt.provers.eprover._
+import at.logic.gapt.provers.vampire._
 import at.logic.gapt.provers.veriT._
 import at.logic.gapt.provers.smtlib._
 import at.logic.gapt.prooftool.prooftool

--- a/src/main/scala/at/logic/gapt/expr/StillmanSubsumptionAlgorithm.scala
+++ b/src/main/scala/at/logic/gapt/expr/StillmanSubsumptionAlgorithm.scala
@@ -55,8 +55,8 @@ object StillmanSubsumptionAlgorithmHOL extends SubsumptionAlgorithm {
 
   def ST( ls1: Seq[LambdaExpression], ls2: Seq[LambdaExpression], sub: Substitution, restrictedDomain: List[Var] ): Option[Substitution] =
     ls1 match {
-      case Nil => Some( sub ) // first list is exhausted
-      case x :: ls =>
+      case Seq() => Some( sub ) // first list is exhausted
+      case Seq( x, ls @ _* ) =>
         val sx = sub( x );
         //TODO: the original algorithm uses backtracking, this does not. check if this implementation is incomplete
         val nsubs = ls2.flatMap( t =>

--- a/src/main/scala/at/logic/gapt/provers/vampire/vampire.scala
+++ b/src/main/scala/at/logic/gapt/provers/vampire/vampire.scala
@@ -21,7 +21,10 @@ class Vampire extends ResolutionProver with ExternalProgram {
       case ( renaming, cnf ) =>
         val labelledCNF = cnf.zipWithIndex.map { case ( clause, index ) => s"formula$index" -> clause.asInstanceOf[FOLClause] }.toMap
         val tptpIn = toTPTP( labelledCNF )
-        val output = runProcess.withTempInputFile( Seq( "vampire", "-p", "tptp" ), tptpIn ).split( "\n" )
+        val output = runProcess.withTempInputFile( Seq(
+          "vampire", "-p", "tptp",
+          "--splitting", "off"
+        ), tptpIn ).split( "\n" )
         if ( output.head startsWith "Refutation" ) {
           val sketch = TptpProofParser.parse( output.drop( 1 ).takeWhile( !_.startsWith( "---" ) ).mkString( "\n" ) )._2
           RefutationSketchToRobinson( sketch, backgroundProver ) map { resProof =>

--- a/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
+++ b/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
@@ -1,5 +1,6 @@
 package at.logic.gapt.provers.vampire
 
+import at.logic.gapt.expr.fol.{ naive, thresholds }
 import at.logic.gapt.expr.hol.univclosure
 import at.logic.gapt.proofs.resolution.inputClauses
 import at.logic.gapt.proofs.{ HOLClause, Sequent, SequentMatchers, HOLSequent }
@@ -110,6 +111,13 @@ class VampireTest extends Specification with SequentMatchers {
       Vampire.getRobinsonProof( cnf ) must beLike {
         case Some( p ) => inputClauses( p ) must contain( atMost( cnf.toSet[HOLClause] ) )
       }
+    }
+
+    "large cnf" in {
+      val Seq( x, y, z ) = Seq( "x", "y", "z" ) map { FOLVar( _ ) }
+      val as = ( 0 to 2 ) map { i => All( x, Ex( y, FOLAtom( s"a$i", x, y, z ) ) ) }
+      val endSequent = Sequent() :+ ( All( z, thresholds.exactly oneOf as ) <-> All( z, naive.exactly oneOf as ) )
+      Vampire getRobinsonProof endSequent must beSome
     }
   }
 


### PR DESCRIPTION
* Works with the CASC version of Vampire 4.0.
* Supports proof import
* Uses the same installation check as eprover, prover9, etc. and should hence also work on Windows