### PR TITLE
Switch to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
 scala: 
 - 2.11.5
 
-script: "sbt clean coverage test testing/test:compile"
-after_success: "sbt coveralls"
+script:
+  - sbt clean coverage compile test && sbt coverageReport && sbt coverageAggregate
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 vim:spell spelllang=en:
 -->
 ## GAPT: General Architecture for Proof Theory
-[![Build Status](https://travis-ci.org/gapt/gapt.svg?branch=master)](https://travis-ci.org/gapt/gapt) [![Coverage Status](https://coveralls.io/repos/gapt/gapt/badge.svg?branch=master)](https://coveralls.io/r/gapt/gapt?branch=master)
+[![Build Status](https://travis-ci.org/gapt/gapt.svg?branch=master)](https://travis-ci.org/gapt/gapt) [![codecov.io](https://codecov.io/github/gapt/gapt/coverage.svg?branch=master)](https://codecov.io/github/gapt/gapt?branch=master)
 
 GAPT is a proof theory framework developed primarily at the Vienna University
 of Technology. GAPT contains data structures, algorithms, parsers and other

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,8 +3,7 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.apache.commons" % "commons-compress" % "1.10"
 
-addSbtPlugin( "org.scoverage" %% "sbt-scoverage" % "1.3.3" )
-addSbtPlugin( "org.scoverage" % "sbt-coveralls" % "1.0.3" )
+addSbtPlugin( "org.scoverage" %% "sbt-scoverage" % "1.3.5" )
 
 // Provides an assembly task which produces a fat jar with all dependencies included.
 addSbtPlugin( "com.eed3si9n" % "sbt-assembly" % "0.14.1" )


### PR DESCRIPTION
Coveralls hasn't been working for a while, and requires fiddling with Travis environment variables.  Codecov.io seems easier to set up in comparison, so let's try it out.

Don't merge yet--I want to see the codecov.io comment on this PR first.