### PR TITLE
[RFC] Mutable contexts.

### DIFF
--- a/core/src/main/scala/at/logic/gapt/expr/package.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/package.scala
@@ -270,10 +270,17 @@ package object expr {
      * @param args
      * @return
      */
-    def hoc( args: LambdaExpression* ): Const = le( args: _* ) match {
-      case c: Const => c
-      case expr =>
-        throw new IllegalArgumentException( s"Expression $expr cannot be read as a constant. Parse it with le." )
+    def hoc( args: LambdaExpression* ): Const = {
+      import fastparse.core.ParseError
+      import fastparse.core.Parsed._
+      require( args.isEmpty )
+      BabelParser.ConstAndNothingElse.parse( sc.parts.head ) match {
+        case Success( c, _ ) => c
+        case f: Failure =>
+          throw new IllegalArgumentException(
+            s"Cannot parse constant at ${file.value}:${line.value}:\n${ParseError( f ).getMessage}"
+          )
+      }
     }
 
     // First order parsers

--- a/core/src/main/scala/at/logic/gapt/formats/babel/BabelParser.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/babel/BabelParser.scala
@@ -39,6 +39,7 @@ object BabelParser {
   import White._
 
   val ExprAndNothingElse: P[ast.Expr] = P( "" ~ Expr ~ End )
+  val ConstAndNothingElse: P[real.Const] = P( "" ~ Const ~ End )
 
   val Expr: P[ast.Expr] = P( Lam )
 
@@ -95,17 +96,19 @@ object BabelParser {
   }
 
   val Parens: P[ast.Expr] = P( "(" ~/ Expr ~/ ")" )
-  val Atom: P[ast.Expr] = P( Parens | True | False | LitVar | LitConst | Ident )
+  val Atom: P[ast.Expr] = P( Parens | True | False | VarLiteral | ConstLiteral | Ident )
 
   val True = P( kw( "true" ) | "⊤" ).map( _ => ast.Top )
   val False = P( kw( "false" ) | "⊥" ).map( _ => ast.Bottom )
 
-  val LitVar = P( "#v(" ~/ Name ~ ":" ~ Type ~ ")" ) map {
-    case ( name, ty ) => ast.LiftBlackbox( real.Var( name, ast.toRealType( ty, Map() ) ) )
+  val Var = P( Name ~ ":" ~ Type ) map {
+    case ( name, ty ) => real.Var( name, ast.toRealType( ty, Map() ) )
   }
-  val LitConst = P( "#c(" ~/ Name ~ ":" ~ Type ~ ")" ) map {
-    case ( name, ty ) => ast.LiftBlackbox( real.Const( name, ast.toRealType( ty, Map() ) ) )
+  val Const = P( Name ~ ":" ~ Type ) map {
+    case ( name, ty ) => real.Const( name, ast.toRealType( ty, Map() ) )
   }
+  val VarLiteral = P( "#v(" ~/ Var ~ ")" ) map { ast.LiftBlackbox }
+  val ConstLiteral = P( "#c(" ~/ Const ~ ")" ) map { ast.LiftBlackbox }
 
   val Ident: P[ast.Ident] = P( Name.map( ast.Ident( _, ast.freshTypeVar() ) ) )
 

--- a/core/src/main/scala/at/logic/gapt/formats/tip/problem.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/tip/problem.scala
@@ -35,7 +35,7 @@ case class TipProblem( sorts: Seq[TBase], datatypes: Seq[TipDatatype], functions
       constants = Set() ++ functions.map { _.fun } ++
       datatypes.flatMap { _.constructors }.flatMap { c => c.projectors :+ c.constr },
       definitions = Map(),
-      typeDefs = Set() ++ sorts.map { Context.Sort } ++
+      typeDefs = Set() ++ sorts.map { Context.Sort( _ ) } ++
         datatypes.map { dt => Context.InductiveType( dt.t, dt.constructors.map { _.constr } ) }
     )
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/Context.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Context.scala
@@ -1,9 +1,11 @@
 package at.logic.gapt.proofs
 
-import at.logic.gapt.expr.{ Bottom, Const, LambdaExpression, TBase, Ti, To, Top }
+import at.logic.gapt.expr.{ Bottom, Const, FunctionType, LambdaExpression, TBase, Ti, To, Top, baseTypes, constants, freeVariables }
 import at.logic.gapt.formats.babel
 import at.logic.gapt.formats.babel.BabelSignature
 import Context._
+
+import scala.collection.mutable
 
 trait Context extends BabelSignature {
   def constant( name: String ): Option[Const]
@@ -31,11 +33,71 @@ case class FiniteContext(
   def typeDef( name: String ) = typeDefsMap get name
 }
 
+class MutableContext extends Context {
+  private val constantsMap = mutable.Map[String, Const]()
+  private val typeDefsMap = mutable.Map[String, TypeDef]()
+  private val definitionMap = mutable.Map[Const, LambdaExpression]()
+
+  def constant( name: String ) = constantsMap get name
+  def definition( const: Const ) = definitionMap get const
+  def typeDef( name: String ) = typeDefsMap get name
+
+  def +=( const: Const ): Unit = declareConst( const, unsafe = false )
+  def +=( typeDef: TypeDef ): Unit = declareTypeDef( typeDef, unsafe = false )
+  def +=( definition: ( Const, LambdaExpression ) ): Unit = declareDefinition( definition._1, definition._2 )
+
+  def declareConst( const: Const, unsafe: Boolean ) =
+    constantsMap get const.name match {
+      case Some( const_ ) => if ( const != const_ ) throw new IllegalArgumentException
+      case None =>
+        if ( !unsafe )
+          for ( t <- baseTypes( const.exptype ) )
+            require( typeDef( t.name ).isDefined )
+        constantsMap( const.name ) = const
+    }
+
+  def declareTypeDef( typeDef: TypeDef, unsafe: Boolean ) =
+    typeDefsMap get typeDef.ty.name match {
+      case Some( typeDef_ ) => if ( typeDef != typeDef_ ) throw new IllegalArgumentException
+      case None =>
+        typeDefsMap( typeDef.ty.name ) = typeDef
+        typeDef match {
+          case InductiveType( _, constructors ) =>
+            for ( c <- constructors ) declareConst( c, unsafe )
+          case Sort( _ ) =>
+        }
+    }
+
+  def declareDefinition( what: Const, by: LambdaExpression ) =
+    definitionMap get what match {
+      case Some( by_ ) => if ( by != by_ ) throw new IllegalArgumentException
+      case None =>
+        require( constant( what.name ).isEmpty )
+        require( what.exptype == by.exptype )
+        this += what
+        require( freeVariables( by ).isEmpty )
+        constants( by ) foreach +=
+    }
+}
+
 object Context {
   sealed trait TypeDef { def ty: TBase }
   case class Sort( ty: TBase ) extends TypeDef
-  case class InductiveType( ty: TBase, constructors: Seq[Const] ) extends TypeDef
+  case class InductiveType( ty: TBase, constructors: Seq[Const] ) extends TypeDef {
+    for ( constr <- constructors ) {
+      val FunctionType( ty_, _ ) = constr.exptype
+      require( ty == ty_ )
+    }
+  }
 
-  val oTypeDef = Context.InductiveType( To, Seq( Top(), Bottom() ) )
-  val iTypeDef = Context.Sort( Ti )
+  object Sort {
+    def apply( tyName: String ): Sort = Sort( TBase( tyName ) )
+  }
+  object InductiveType {
+    def apply( tyName: String, constructors: Const* ): InductiveType =
+      InductiveType( TBase( tyName ), constructors )
+  }
+
+  val oTypeDef = Context.InductiveType( "o", Top(), Bottom() )
+  val iTypeDef = Context.Sort( "i" )
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/Context.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Context.scala
@@ -20,9 +20,9 @@ trait Context extends BabelSignature {
 }
 
 case class FiniteContext(
-    constants:   Set[Const],
+    constants:   Set[Const]                   = Set(),
     definitions: Map[Const, LambdaExpression] = Map(),
-    typeDefs:    Set[Context.TypeDef]         = Set( Context.iTypeDef, Context.oTypeDef )
+    typeDefs:    Set[Context.TypeDef]         = Set( Context.oTypeDef )
 ) extends Context {
   val constantsMap = constants.map { c => c.name -> c }.toMap
   val typeDefsMap = typeDefs.map { td => td.ty.name -> td }.toMap
@@ -31,53 +31,25 @@ case class FiniteContext(
   def constant( name: String ) = constantsMap get name
   def definition( const: Const ) = definitions get const
   def typeDef( name: String ) = typeDefsMap get name
-}
 
-class MutableContext extends Context {
-  private val constantsMap = mutable.Map[String, Const]()
-  private val typeDefsMap = mutable.Map[String, TypeDef]()
-  private val definitionMap = mutable.Map[Const, LambdaExpression]()
+  def +( const: Const ): FiniteContext = {
+    require( !( constantsMap get const.name exists { _ != const } ) )
+    copy( constants = constants + const )
+  }
+  def ++( consts: Iterable[Const] ): FiniteContext =
+    consts.foldLeft( this )( _ + _ )
 
-  def constant( name: String ) = constantsMap get name
-  def definition( const: Const ) = definitionMap get const
-  def typeDef( name: String ) = typeDefsMap get name
-
-  def +=( const: Const ): Unit = declareConst( const, unsafe = false )
-  def +=( typeDef: TypeDef ): Unit = declareTypeDef( typeDef, unsafe = false )
-  def +=( definition: ( Const, LambdaExpression ) ): Unit = declareDefinition( definition._1, definition._2 )
-
-  def declareConst( const: Const, unsafe: Boolean ) =
-    constantsMap get const.name match {
-      case Some( const_ ) => if ( const != const_ ) throw new IllegalArgumentException
-      case None =>
-        if ( !unsafe )
-          for ( t <- baseTypes( const.exptype ) )
-            require( typeDef( t.name ).isDefined )
-        constantsMap( const.name ) = const
+  def +( typeDef: TypeDef ): FiniteContext = {
+    require( !( typeDefsMap get typeDef.ty.name exists { _ != typeDef } ) )
+    typeDef match {
+      case Sort( _ ) => copy( typeDefs = typeDefs + typeDef )
+      case InductiveType( _, constructors ) =>
+        require( constructors.map { _.toString } == constructors.map { _.toString }.distinct )
+        for ( const <- constructors )
+          require( !( constantsMap get const.name exists { _ != const } ) )
+        copy( typeDefs = typeDefs + typeDef, constants = constants ++ constructors )
     }
-
-  def declareTypeDef( typeDef: TypeDef, unsafe: Boolean ) =
-    typeDefsMap get typeDef.ty.name match {
-      case Some( typeDef_ ) => if ( typeDef != typeDef_ ) throw new IllegalArgumentException
-      case None =>
-        typeDefsMap( typeDef.ty.name ) = typeDef
-        typeDef match {
-          case InductiveType( _, constructors ) =>
-            for ( c <- constructors ) declareConst( c, unsafe )
-          case Sort( _ ) =>
-        }
-    }
-
-  def declareDefinition( what: Const, by: LambdaExpression ) =
-    definitionMap get what match {
-      case Some( by_ ) => if ( by != by_ ) throw new IllegalArgumentException
-      case None =>
-        require( constant( what.name ).isEmpty )
-        require( what.exptype == by.exptype )
-        this += what
-        require( freeVariables( by ).isEmpty )
-        constants( by ) foreach +=
-    }
+  }
 }
 
 object Context {

--- a/core/src/main/scala/at/logic/gapt/proofs/Context.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Context.scala
@@ -50,6 +50,14 @@ case class FiniteContext(
         copy( typeDefs = typeDefs + typeDef, constants = constants ++ constructors )
     }
   }
+
+  def +( what: Const, by: LambdaExpression ): FiniteContext = {
+    require( !definitions.contains( what ) )
+    require( freeVariables( by ).isEmpty )
+    require( constant( what.name ).isEmpty )
+    for ( c <- at.logic.gapt.expr.constants( by ) ) require( constant( c.name ) contains c )
+    copy( constants = constants + what, definitions = definitions + ( what -> by ) )
+  }
 }
 
 object Context {

--- a/core/src/main/scala/at/logic/gapt/proofs/Context.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Context.scala
@@ -34,6 +34,7 @@ case class FiniteContext(
 
   def +( const: Const ): FiniteContext = {
     require( !( constantsMap get const.name exists { _ != const } ) )
+    for ( t <- baseTypes( const.exptype ) ) require( typeDef( t.name ).isDefined )
     copy( constants = constants + const )
   }
   def ++( consts: Iterable[Const] ): FiniteContext =

--- a/examples/induction/lists.scala
+++ b/examples/induction/lists.scala
@@ -1,36 +1,21 @@
 package at.logic.gapt.examples.induction
 
 import at.logic.gapt.examples.TacticsProof
-import at.logic.gapt.proofs.{ Context, FiniteContext, Sequent }
+import at.logic.gapt.proofs.{ Context, MutableContext, Sequent }
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.gaptic._
 import at.logic.gapt.proofs.lk.extractRecSchem
 
 object lists extends TacticsProof {
 
-  implicit val context = FiniteContext(
-    constants = Set(
-      hoc"nil: list", hoc"cons: i>list>list",
-      hoc"'+': list>list>list",
-      hoc"rev: list>list"
-    ),
-    typeDefs = Set(
-      Context.iTypeDef, Context.oTypeDef,
-      Context.InductiveType(
-        TBase( "list" ),
-        Seq( hoc"nil: list", hoc"cons: i>list>list" )
-      )
-    )
-  )
+  implicit val ctx = new MutableContext
+  ctx += Context.Sort( "i" )
+  ctx += Context.InductiveType( "list", hoc"nil: list", hoc"cons: i>list>list" )
 
+  ctx += hoc"'+': list>list>list"
   val appth =
     ( "consapp" -> hof"!x!y!z cons(x,y)+z = cons(x,y+z)" ) +:
       ( "nilapp" -> hof"!x nil+x = x" ) +:
-      Sequent()
-
-  val revth =
-    ( "revcons" -> hof"!x!y rev(cons(x,y)) = rev(y)+cons(x,nil)" ) +:
-      ( "revnil" -> hof"rev(nil) = nil" ) +:
       Sequent()
 
   val appnil = Lemma( appth :+ ( "goal" -> hof"!x x+nil = x" ) ) {
@@ -51,6 +36,12 @@ object lists extends TacticsProof {
     rewrite.many ltr "nilapp"; refl
     rewrite.many ltr ( "consapp", "IHx_0" ); refl
   }
+
+  ctx += hoc"rev: list>list"
+  val revth =
+    ( "revcons" -> hof"!x!y rev(cons(x,y)) = rev(y)+cons(x,nil)" ) +:
+      ( "revnil" -> hof"rev(nil) = nil" ) +:
+      Sequent()
 
   val apprev = Lemma( ( appth ++ revth ) :+ ( "goal" -> hof"!x!y rev(x+y) = rev(y) + rev(x)" ) ) {
     include( "appnil", appnil )

--- a/examples/induction/lists.scala
+++ b/examples/induction/lists.scala
@@ -1,14 +1,14 @@
 package at.logic.gapt.examples.induction
 
 import at.logic.gapt.examples.TacticsProof
-import at.logic.gapt.proofs.{ Context, MutableContext, Sequent }
+import at.logic.gapt.proofs.{ Context, FiniteContext, Sequent }
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs.gaptic._
 import at.logic.gapt.proofs.lk.extractRecSchem
 
 object lists extends TacticsProof {
 
-  implicit val ctx = new MutableContext
+  implicit var ctx = FiniteContext()
   ctx += Context.Sort( "i" )
   ctx += Context.InductiveType( "list", hoc"nil: list", hoc"cons: i>list>list" )
 


### PR DESCRIPTION
@loewenheim Earlier this week you were talking about mutable signatures, if I remember correctly.  There are two nice things about mutable contexts that I have just noticed:
1. When adding definitions, the parser already knows about previously defined constants.
2. Because we have a (temporal) order on the declarations, we can implement some rudimentary checks, i.e. does the constant only reference known types, does the definition only expand into known constants, etc.

An example of how this could work is [here](https://github.com/gapt/gapt/compare/mutablectx?expand=1#diff-aec23f93b64de2d3e589cc6501a11f88).