### PR TITLE
Expansion tree definition elimination

### DIFF
--- a/core/src/main/scala/at/logic/gapt/algorithms/rewriting/TermReplacement.scala
+++ b/core/src/main/scala/at/logic/gapt/algorithms/rewriting/TermReplacement.scala
@@ -76,8 +76,13 @@ object TermReplacement {
       case Resolution( q1, l1, q2, l2 ) => Resolution( f( q1 ), l1, f( q2 ), l2 )
       case Paramodulation( q1, l1, q2, l2, pos, dir ) =>
         Paramodulation( f( q1 ), l1, f( q2 ), l2, pos, dir )
-      case Splitting( q0, c1, q1, q2 ) =>
-        Splitting( f( q0 ), c1 map { TermReplacement( _, repl ) }, f( q1 ), f( q2 ) )
+      case Splitting( q0, c1, c2, q1, q2 ) =>
+        Splitting(
+          f( q0 ),
+          c1 map { TermReplacement( _, repl ) },
+          c2 map { TermReplacement( _, repl ) },
+          f( q1 ), f( q2 )
+        )
     } )
 
     f( proof )

--- a/core/src/main/scala/at/logic/gapt/expr/package.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/package.scala
@@ -110,6 +110,17 @@ package object expr {
   }
 
   /**
+   * Testifies that a pair of substitutable objects is substitutable (by applying the substitution to each element).
+   */
+  implicit def SubstitutablePair[S <: Substitution, T1, U1, T2, U2](
+    implicit
+    ev1: Substitutable[S, T1, U1],
+    ev2: Substitutable[S, T2, U2]
+  ): Substitutable[S, ( T1, T2 ), ( U1, U2 )] = new Substitutable[S, ( T1, T2 ), ( U1, U2 )] {
+    override def applySubstitution( sub: S, pair: ( T1, T2 ) ): ( U1, U2 ) = ( ev1.applySubstitution( sub, pair._1 ), ev2.applySubstitution( sub, pair._2 ) )
+  }
+
+  /**
    * Testifies that type `FOLTerm` is closed under `FOLSub`.
    *
    */

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
@@ -14,6 +14,9 @@ object ExpansionProofWithEqualityToLK extends ExpansionProofToLK( withEquality =
 class ExpansionProofToLK( withEquality: Boolean ) extends SolveUtils {
   type Error = ( Seq[ETImp], ExpansionSequent )
 
+  def apply( expansionProof: ExpansionProof ): UnprovableOrLKProof =
+    apply( ExpansionProofWithCut( expansionProof ) )
+
   def apply( expansionProofWithCut: ExpansionProofWithCut ): UnprovableOrLKProof =
     solve( expansionProofWithCut.cuts, expansionProofWithCut.expansionSequent ).
       map { WeakeningMacroRule( _, expansionProofWithCut.shallow ) }

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
@@ -296,10 +296,7 @@ object eliminateDefsET {
     if ( !pureFolWithoutEq ) {
       val newNegRepl = ETMerge( definedFormula, false, insts.values.map { _._2 }.map { generalizeET( _, definedFormula ) } )
       val newPosRepl = ETMerge( definedFormula, true, insts.values.map { _._1 }.map { generalizeET( _, definedFormula ) } )
-      insts = insts map {
-        case ( as, _ ) =>
-          as -> ( Substitution( vs zip as )( newPosRepl ), Substitution( vs zip as )( newNegRepl ) )
-      }
+      insts = insts map { case ( as, _ ) => as -> Substitution( vs zip as )( newPosRepl -> newNegRepl ) }
     }
 
     def replm: PartialFunction[LambdaExpression, LambdaExpression] = {

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
@@ -1,7 +1,9 @@
 package at.logic.gapt.proofs.expansion
 
+import at.logic.gapt.algorithms.rewriting.TermReplacement
 import at.logic.gapt.expr._
 import at.logic.gapt.proofs._
+import at.logic.gapt.expr.hol.HOLPosition
 
 import scala.collection.mutable
 
@@ -29,17 +31,16 @@ object linearizeStrictPartialOrder {
   }
 }
 
-case class ExpansionProofWithCut( cuts: Seq[ETImp], expansionSequent: Sequent[ExpansionTree] ) {
+case class ExpansionProof( expansionSequent: Sequent[ExpansionTree] ) {
   for ( ( tree, index ) <- expansionSequent.zipWithIndex ) require( tree.polarity == index.isSuc )
-  for ( cut @ ETImp( cut1, cut2 ) <- cuts ) {
-    require( !cut.polarity )
-    require( cut1.shallow == cut2.shallow )
-  }
 
   {
     val evs = mutable.Set[Var]()
     val fvs = freeVariables( shallow )
-    for ( tree <- cuts ++: expansionSequent; ETStrongQuantifier( _, ev, _ ) <- tree.treeLike.postOrder ) {
+    for {
+      tree <- expansionSequent
+      ETStrongQuantifier( _, ev, _ ) <- tree.treeLike.postOrder
+    } {
       require( !evs.contains( ev ), s"duplicate eigenvariable $ev" )
       require( !fvs.contains( ev ), s"eigenvariable $ev is free in shallow sequent" )
       evs += ev
@@ -47,9 +48,9 @@ case class ExpansionProofWithCut( cuts: Seq[ETImp], expansionSequent: Sequent[Ex
   }
 
   def shallow = expansionSequent.shallow
-  def deep = cuts.map { _.deep } ++: expansionSequent.deep
+  def deep = expansionSequent.deep
 
-  def subProofs = expansionSequent.elements.toSet ++ cuts flatMap { _.subProofs }
+  val subProofs = expansionSequent.elements flatMap { _.subProofs } toSet
   val eigenVariables = for ( ETStrongQuantifier( _, ev, _ ) <- subProofs ) yield ev
 
   val dependencyRelation = for {
@@ -60,38 +61,69 @@ case class ExpansionProofWithCut( cuts: Seq[ETImp], expansionSequent: Sequent[Ex
   } yield evInTerm -> ev
   val Right( linearizedDependencyRelation ) = linearizeStrictPartialOrder( eigenVariables, dependencyRelation )
 
-  def toExpansionProof: ExpansionProof = {
-    require( cuts isEmpty )
+  override def toString = expansionSequent.toString
+}
+
+case class ExpansionProofWithCut( expansionWithCutAxiom: ExpansionProof ) {
+  import ExpansionProofWithCut._
+  def expansionSequent = expansionWithCutAxiom.expansionSequent filter { _.shallow != cutAxiom }
+  def eigenVariables = expansionWithCutAxiom.eigenVariables
+  def deep = expansionWithCutAxiom.deep
+  def shallow = expansionSequent map { _.shallow }
+  def subProofs = expansionWithCutAxiom.subProofs
+
+  val cuts = for {
+    cutAxiomExpansion <- expansionWithCutAxiom.expansionSequent.antecedent
+    if cutAxiomExpansion.shallow == cutAxiom
+    cut <- expansionWithCutAxiom.expansionSequent( Ant( 0 ) )( HOLPosition( 1 ) )
+    cut1 <- cut( HOLPosition( 1 ) )
+    cut2 <- cut( HOLPosition( 2 ) )
+  } yield ETImp( cut1, cut2 )
+
+  def toExpansionProof = {
+    require( cuts.isEmpty )
     ExpansionProof( expansionSequent )
   }
+
+  override def toString = expansionWithCutAxiom.toString
+}
+object ExpansionProofWithCut {
+  val cutAxiom = hof"∀X (X ⊃ X)"
+  def apply( expansionSequentWithCutAxiom: ExpansionSequent ): ExpansionProofWithCut =
+    ExpansionProofWithCut( ExpansionProof( expansionSequentWithCutAxiom ) )
+  def apply( cuts: Seq[ETImp], expansionSequent: Sequent[ExpansionTree] ): ExpansionProofWithCut =
+    apply(
+      ETWeakQuantifier.withMerge(
+        ExpansionProofWithCut.cutAxiom,
+        for ( cut @ ETImp( cut1, cut2 ) <- cuts ) yield cut1.shallow -> cut
+      ) +: expansionSequent
+    )
 }
 
-class ExpansionProof( expansionSequent: Sequent[ExpansionTree] ) extends ExpansionProofWithCut( Seq(), expansionSequent )
-object ExpansionProof {
-  def apply( expansionSequent: Sequent[ExpansionTree] ) = new ExpansionProof( expansionSequent )
-  def unapply( expansionProof: ExpansionProof ) = Some( expansionProof.expansionSequent )
-}
-
-private[expansion] object expansionProofSubstitution extends ClosedUnderSub[ExpansionProofWithCut] {
-  override def applySubstitution( subst: Substitution, expansionProof: ExpansionProofWithCut ): ExpansionProofWithCut =
+private[expansion] object expansionProofSubstitution extends ClosedUnderSub[ExpansionProof] {
+  override def applySubstitution( subst: Substitution, expansionProof: ExpansionProof ): ExpansionProof =
     if ( subst.domain intersect expansionProof.eigenVariables nonEmpty ) {
       applySubstitution( Substitution( subst.map -- expansionProof.eigenVariables ), expansionProof )
     } else {
       val substWithRenaming = subst compose Substitution(
         rename( expansionProof.eigenVariables intersect subst.range, expansionProof.eigenVariables union subst.range )
       )
-      ExpansionProofWithCut( substWithRenaming( expansionProof.cuts ) map { _.asInstanceOf[ETImp] }, substWithRenaming( expansionProof.expansionSequent ) )
+      ExpansionProof( substWithRenaming( expansionProof.expansionSequent ) )
     }
+}
+private[expansion] object expansionProofWithCutSubstitution extends ClosedUnderSub[ExpansionProofWithCut] {
+  override def applySubstitution( subst: Substitution, expansionProofWithCut: ExpansionProofWithCut ): ExpansionProofWithCut =
+    ExpansionProofWithCut( subst( expansionProofWithCut.expansionWithCutAxiom ) )
 }
 
 object eliminateMerges {
   def apply( expansionProof: ExpansionProofWithCut ): ExpansionProofWithCut =
-    elim( expansionProof.cuts, expansionProof.expansionSequent )
+    new ExpansionProofWithCut( apply( expansionProof.expansionWithCutAxiom ) )
 
   def apply( expansionProof: ExpansionProof ): ExpansionProof =
-    apply( expansionProof: ExpansionProofWithCut ).toExpansionProof
+    elim( expansionProof.expansionSequent )
 
-  private def elim( cuts: Seq[ETImp], expansionSequent: Sequent[ExpansionTree] ): ExpansionProofWithCut = {
+  private def elim( expansionSequent: Sequent[ExpansionTree] ): ExpansionProof = {
     var needToMergeAgain = false
     var eigenVarSubst = Substitution()
 
@@ -159,15 +191,13 @@ object eliminateMerges {
         }
     }
 
-    val mergedCuts = cuts.groupBy { _.shallow }.values.toList.map { ETMerge( _ ) }.map { merge }
     val mergedSequent = expansionSequent map merge
 
     if ( !needToMergeAgain ) {
-      ExpansionProofWithCut( mergedCuts map { _.asInstanceOf[ETImp] }, mergedSequent )
-    } else elim(
-      mergedCuts map { eigenVarSubst( _ ) } map { _.asInstanceOf[ETImp] },
-      mergedSequent map { eigenVarSubst( _ ) }
-    )
+      ExpansionProof( mergedSequent )
+    } else {
+      elim( mergedSequent map { eigenVarSubst( _ ) } )
+    }
   }
 }
 
@@ -198,15 +228,18 @@ object eliminateCutsET {
           yield renaming compose Substitution( eigenVariable -> term )
 
       eliminateMerges( ExpansionProofWithCut(
-        ( for ( ( subst, ( term, instance ) ) <- substs zip instances.toSeq ) yield subst(
-          if ( instance.polarity ) ETImp( instance, child ) else ETImp( child, instance )
-        ).asInstanceOf[ETImp] )
-          ++ ( for ( c <- rest; s <- substs ) yield s( c ).asInstanceOf[ETImp] ),
+        ( for ( ( ( subst, renaming ), ( term, instance ) ) <- substs zip renamings zip instances.toSeq ) yield {
+          if ( instance.polarity ) ETImp( renaming( instance ), subst( child ) )
+          else ETImp( subst( child ), renaming( instance ) )
+        } ) ++ ( for ( c <- rest; s <- substs ) yield s( c ).asInstanceOf[ETImp] ),
         for ( tree <- expansionSequent ) yield ETMerge( substs.map { _( tree ) } )
       ) )
     }
 
     ( cut1, cut2 ) match {
+      case ( _: ETMerge, _ )                    => eliminateMerges( addCuts( ETImp( cut1, cut2 ) ) )
+      case ( _, _: ETMerge )                    => eliminateMerges( addCuts( ETImp( cut1, cut2 ) ) )
+
       case ( _: ETWeakening, _ )                => addCuts()
       case ( _, _: ETWeakening )                => addCuts()
       case ( _: ETAtom, _: ETAtom )             => addCuts()
@@ -222,5 +255,88 @@ object eliminateCutsET {
         quantifiedCut( instances, eigenVariable, child )
     }
 
+  }
+}
+
+object eliminateDefsET {
+  object DefinitionFormula {
+    def unapply( f: HOLFormula ) = f match {
+      case All.Block( vs, And( Imp( Apps( d1: Const, vs1 ), r1 ),
+        Imp( r2, Apps( d2, vs2 ) ) ) ) if d1 == d2 && r1 == r2 && vs == vs1 && vs == vs2 =>
+        Some( ( vs, d1, r2 ) )
+      case _ => None
+    }
+  }
+
+  def apply( ep: ExpansionProof, pureFolWithoutEq: Boolean ): ExpansionProofWithCut =
+    ep.shallow.find { case DefinitionFormula( _, _, _ ) => true case _ => false } match {
+      case Some( idx ) => apply( apply( ep, idx, pureFolWithoutEq ), pureFolWithoutEq )
+      case None        => ExpansionProofWithCut( ep )
+    }
+  def apply( ep: ExpansionProof, idx: SequentIndex, pureFolWithoutEq: Boolean ): ExpansionProof = {
+    val ETWeakQuantifierBlock( DefinitionFormula( vs, definitionConst, definedFormula ), insts0 ) = ep.expansionSequent( idx )
+    val negReplPos = HOLPosition( 1, 2 )
+    val posReplPos = HOLPosition( 2, 1 )
+    var insts = insts0 mapValues {
+      case et =>
+        ETMerge( et.shallow( posReplPos ).asInstanceOf[HOLFormula], true, getAtHOLPosition( et, posReplPos ) ) ->
+          ETMerge( et.shallow( negReplPos ).asInstanceOf[HOLFormula], false, getAtHOLPosition( et, negReplPos ) )
+    }
+
+    val rest = ep.expansionSequent.delete( idx )
+    val usesites = rest.elements.flatMap { _.subProofs }.
+      collect { case ETDefinedAtom( Apps( d, args ), pol, _ ) => ( args, pol ) }.toSet
+    insts = Map() ++
+      usesites.map { _._1 }.map { as =>
+        val ras = Substitution( vs zip as )( definedFormula )
+        as -> ( ETWeakening( ras, true ), ETWeakening( ras, false ) )
+      } ++
+      insts
+
+    if ( !pureFolWithoutEq ) {
+      val newNegRepl = ETMerge( definedFormula, false, insts.values.map { _._2 }.map { generalizeET( _, definedFormula ) } )
+      val newPosRepl = ETMerge( definedFormula, true, insts.values.map { _._1 }.map { generalizeET( _, definedFormula ) } )
+      insts = insts map {
+        case ( as, _ ) =>
+          as -> ( Substitution( vs zip as )( newPosRepl ), Substitution( vs zip as )( newNegRepl ) )
+      }
+    }
+
+    def replm: PartialFunction[LambdaExpression, LambdaExpression] = {
+      case Apps( `definitionConst`, as ) => Substitution( vs zip as )( definedFormula )
+    }
+    def replf( f: HOLFormula ): HOLFormula = TermReplacement( f, replm )
+    def repl( et: ExpansionTree ): ExpansionTree = et match {
+      case ETMerge( a, b )                  => ETMerge( repl( a ), repl( b ) )
+      case ETWeakening( sh, pol )           => ETWeakening( replf( sh ), pol )
+
+      case ETTop( _ ) | ETBottom( _ )       => et
+      case ETNeg( ch )                      => ETNeg( repl( ch ) )
+      case ETAnd( l, r )                    => ETAnd( repl( l ), repl( r ) )
+      case ETOr( l, r )                     => ETOr( repl( l ), repl( r ) )
+      case ETImp( l, r )                    => ETImp( repl( l ), repl( r ) )
+      case ETWeakQuantifier( sh, is )       => ETWeakQuantifier( replf( sh ), is mapValues repl )
+      case ETStrongQuantifier( sh, ev, ch ) => ETStrongQuantifier( replf( sh ), ev, repl( ch ) )
+      case ETSkolemQuantifier( sh, st, ch ) => ETSkolemQuantifier( replf( sh ), st, repl( ch ) )
+
+      case ETDefinedAtom( Apps( `definitionConst`, as ), pol, _ ) =>
+        if ( pol ) insts( as )._1 else insts( as )._2
+      case ETAtom( Apps( f, _ ), _ ) if f != definitionConst => et
+    }
+
+    for ( ( _, ( pos, neg ) ) <- insts ) {
+      require( !constants( pos.deep ).contains( definitionConst ) )
+      require( !constants( neg.deep ).contains( definitionConst ) )
+    }
+
+    val newCuts = ETWeakQuantifier.withMerge(
+      ExpansionProofWithCut.cutAxiom,
+      insts.values.map { case ( pos, neg ) => pos.shallow -> ETImp( pos, neg ) }
+    )
+
+    val newES = ( newCuts +: ep.expansionSequent.delete( idx ).map { repl } ).
+      groupBy { _.shallow }.map { _._2 }.map { ETMerge( _ ) }
+
+    ExpansionProof( newES )
   }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/package.scala
@@ -17,5 +17,6 @@ package object expansion {
   }
 
   implicit val expansionTreesAreClosedUnderAdmissibleSubstitutions: ClosedUnderSub[ExpansionTree] = expansionTreeSubstitution
-  implicit val expansionProofsAreClosedUnderSubstitution: ClosedUnderSub[ExpansionProofWithCut] = expansionProofSubstitution
+  implicit val expansionProofsAreClosedUnderSubstitution: ClosedUnderSub[ExpansionProof] = expansionProofSubstitution
+  implicit val expansionProofsWithCutAreClosedUnderSubstitution: ClosedUnderSub[ExpansionProofWithCut] = expansionProofWithCutSubstitution
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/termExtraction.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/termExtraction.scala
@@ -248,6 +248,9 @@ object FOLInstanceTermEncoding {
     encoding.encode( expansionSequent ).map( _.asInstanceOf[FOLTerm] ) -> encoding
   }
 
+  def apply( expansionProof: ExpansionProof ): ( Set[FOLTerm], InstanceTermEncoding ) =
+    apply( expansionProof.expansionSequent )
+
   def apply( expansionProof: ExpansionProofWithCut ): ( Set[FOLTerm], InstanceTermEncoding ) =
     apply( eliminateCutsET( expansionProof ).expansionSequent )
 

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
@@ -1,7 +1,7 @@
 package at.logic.gapt.proofs.lk
 
-import at.logic.gapt.expr.hol.containsQuantifierOnLogicalLevel
-import at.logic.gapt.expr.{ Eq, HOLAtom }
+import at.logic.gapt.expr.hol.{ containsQuantifierOnLogicalLevel, instantiate }
+import at.logic.gapt.expr.{ All, And, Const, Eq, HOLAtom, To, Var, freeVariables, rename }
 import at.logic.gapt.proofs.Sequent
 import at.logic.gapt.proofs.expansion._
 
@@ -16,11 +16,12 @@ object LKToExpansionProof {
    * @return The expansion proof Ex(π).
    */
   def apply( proof: LKProof ): ExpansionProofWithCut = {
-    val ( cuts, expansionSequent ) = extract( regularize( AtomicExpansion( proof ) ) )
-    eliminateMerges( ExpansionProofWithCut( cuts, expansionSequent ) )
+    val ( theory, expansionSequent ) = extract( regularize( AtomicExpansion( proof ) ) )
+    val theory_ = theory.groupBy { _.shallow }.values.toSeq.map { ETMerge( _ ) }
+    eliminateMerges( ExpansionProofWithCut( theory_ ++: expansionSequent ) )
   }
 
-  private def extract( proof: LKProof ): ( Seq[ETImp], Sequent[ExpansionTree] ) = proof match {
+  private def extract( proof: LKProof ): ( Seq[ExpansionTree], Sequent[ExpansionTree] ) = proof match {
 
     // Axioms
     case LogicalAxiom( atom: HOLAtom ) => Seq() -> Sequent( Seq( ETAtom( atom, false ) ), Seq( ETAtom( atom, true ) ) )
@@ -53,7 +54,10 @@ object LKToExpansionProof {
     case c @ CutRule( leftSubProof, aux1, rightSubProof, aux2 ) =>
       val ( leftCuts, leftSequent ) = extract( leftSubProof )
       val ( rightCuts, rightSequent ) = extract( rightSubProof )
-      val newCut = ETImp( leftSequent( aux1 ), rightSequent( aux2 ) )
+      val newCut = ETWeakQuantifier(
+        ExpansionProofWithCut.cutAxiom,
+        Map( c.cutFormula -> ETImp( leftSequent( aux1 ), rightSequent( aux2 ) ) )
+      )
       val cuts = if ( containsQuantifierOnLogicalLevel( c.cutFormula ) )
         newCut +: ( leftCuts ++ rightCuts )
       else leftCuts ++ rightCuts

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
@@ -1652,6 +1652,8 @@ case class InductionCase( proof: LKProof, constructor: Const,
     require( hyp.isAnt && proof.endSequent.isDefinedAt( hyp ) )
   }
 
+  val term = constructor( eigenVars: _* )
+
   require( conclusion.isSuc && proof.endSequent.isDefinedAt( conclusion ) )
 }
 
@@ -1678,7 +1680,7 @@ case class InductionRule( cases: Seq[InductionCase], mainFormula: HOLFormula ) e
     ( c.hypotheses, c.hypVars ).zipped foreach { ( hyp, eigen ) =>
       require( c.proof.endSequent( hyp ) == Substitution( quant -> eigen )( qfFormula ) )
     }
-    require( c.proof.endSequent( c.conclusion ) == Substitution( quant -> c.constructor( c.eigenVars: _* ) )( qfFormula ) )
+    require( c.proof.endSequent( c.conclusion ) == Substitution( quant -> c.term )( qfFormula ) )
   }
   require( freeVariables( contexts.flatMap( _.elements ) :+ mainFormula ) intersect cases.flatMap( _.eigenVars ).toSet isEmpty )
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/RobinsonToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/RobinsonToExpansionProof.scala
@@ -105,17 +105,17 @@ object groundInstancesFromResolutionProof {
             case ( clause, instSubst ) =>
               clause -> instSubst.mapValues { subst( _ ) }
           }
-        case node @ Splitting( splittingClause, part1, case1, case2 ) =>
-          val addInstFrom1 = getInst( case1 ) filter { inst => node.addInputClauses1 exists { _ multiSetEquals inst._1 } } map { _._2 }
-          val addInstFrom2 = getInst( case2 ) filter { inst => node.addInputClauses2 exists { _ multiSetEquals inst._1 } } map { _._2 }
+        case node @ Splitting( splittingClause, part1, part2, case1, case2 ) =>
+          val addInstFrom1 = getInst( case1 ) filter { inst => node.addInputClauses1 contains inst._1 } map { _._2 }
+          val addInstFrom2 = getInst( case2 ) filter { inst => node.addInputClauses2 contains inst._1 } map { _._2 }
           val addInstances = for {
             subst1 <- addInstFrom1
             subst2 <- addInstFrom2
             subst = Substitution( subst1 ++ subst2 )
             ( cls, inst ) <- getInst( splittingClause )
           } yield cls -> inst.mapValues { subst( _ ) }
-          val inst1 = getInst( case1 ).filterNot { inst => node.addInputClauses1 exists { _ multiSetEquals inst._1 } }
-          val inst2 = getInst( case2 ).filterNot { inst => node.addInputClauses2 exists { _ multiSetEquals inst._1 } }
+          val inst1 = getInst( case1 ).filterNot { inst => node.addInputClauses1 contains inst._1 }
+          val inst2 = getInst( case2 ).filterNot { inst => node.addInputClauses2 contains inst._1 }
           inst1 union inst2 union addInstances
         case _ => node.immediateSubProofs flatMap getInst toSet
       } )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/RobinsonToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/RobinsonToExpansionProof.scala
@@ -2,17 +2,18 @@ package at.logic.gapt.proofs.resolution
 
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.structuralCNF.{ ProjectionFromEndSequent, Definition, Justification }
-import at.logic.gapt.expr.hol.{ instantiate, CNFn, univclosure }
+import at.logic.gapt.expr.hol.{ CNFp, instantiate, CNFn, univclosure }
 import at.logic.gapt.proofs._
 import at.logic.gapt.proofs.expansion._
 import at.logic.gapt.proofs.lk.{ DefinitionElimination, LKToExpansionProof }
+import at.logic.gapt.provers.sat.Sat4j
 
 import scala.collection.mutable
 
 object RobinsonToExpansionProof {
 
   def apply( p: ResolutionProof, es: HOLSequent,
-             justifications: Set[( HOLClause, Justification )],
+             justifications: Map[HOLClause, Justification],
              definitions:    Map[HOLAtomConst, LambdaExpression] ): ExpansionProof =
     expansionProofFromInstances( groundInstancesFromResolutionProof( p ), es, justifications, definitions,
       pureFOLwithoutEquality = !containsEquationalReasoning( p ) )
@@ -31,96 +32,61 @@ object RobinsonToExpansionProof {
         } yield e
         just = ProjectionFromEndSequent( exp, i )
       } yield clause -> just
-    apply( p, es, justifications toSet, Map() )
+    apply( p, es, justifications.toMap, Map() )
   }
 
   def apply( p: ResolutionProof ): ExpansionProof =
     apply( p, p.inputClauses.map { _.toFormula }.map { univclosure( _ ) } ++: Sequent() )
 }
 
-/** Requires unipolar definitions. */
 object expansionProofFromInstances {
-  // In the case without equality, whenever we encounter a defined atom in an expansion of the end-sequent, we can
-  // insert at that point all the expansions from the defining clauses where the defined atom matches literally.
-  //
-  // We can think of this operation as ad-hoc resolving the clauses from the end-sequent with the clauses from the
-  // definitions.  This is sound since we only have unipolar definitions (and ground resolution).
-  //
-  // With equality however, you can resolve literals that are not literally equal.  In this case we want to insert
-  // *all* the expansions from the defining clauses, even if they do not match.  To make this possible, we change the
-  // instances of the clauses from the definitions to match the ones from the end-sequent, "mating" them.
-  private def mateInstances( substs: Map[HOLClause, Set[Substitution]], justifications: Set[( HOLClause, Justification )] ): Map[HOLClause, Set[Substitution]] = {
-    val todo = mutable.Set[( HOLClause, Substitution )]()
+  def apply[S <: Substitution](
+    substs: Map[HOLClause, Set[S]], es: HOLSequent,
+    justifications:         Map[HOLClause, Justification],
+    definitions:            Map[HOLAtomConst, LambdaExpression],
+    pureFOLwithoutEquality: Boolean                             = false
+  ): ExpansionProof = {
 
-    for {
-      ( defClause, Definition( defAtom @ Apps( defAtomC: HOLAtomConst, defArgs ), _ ) ) <- justifications
-      if substs isDefinedAt defClause
-      ( useClause, useSubsts ) <- substs
-      if useClause != defClause
-      Apps( `defAtomC`, useArgs ) <- useClause.elements
-      defSubst <- substs( defClause )
-      useSubst <- useSubsts
-      newDefSubst = Substitution( defSubst.map ++ ( defArgs.map { _.asInstanceOf[Var] } zip ( useArgs map { useSubst( _ ) } ) ) )
-      if !substs( defClause ).contains( newDefSubst )
-    } todo += ( defClause -> newDefSubst )
-
-    if ( todo isEmpty )
-      substs
-    else
-      mateInstances(
-        for ( ( clause, clauseSubsts ) <- substs )
-          yield clause -> ( clauseSubsts union todo.filter { _._1 == clause }.map { _._2 } ),
-        justifications
-      )
-  }
-
-  def apply[S <: Substitution]( substitutions: Map[HOLClause, Set[S]], es: HOLSequent,
-                                justifications:         Set[( HOLClause, Justification )],
-                                definitions:            Map[HOLAtomConst, LambdaExpression],
-                                pureFOLwithoutEquality: Boolean                             = false ): ExpansionProof = {
-
-    val substs = if ( !pureFOLwithoutEquality && definitions.nonEmpty )
-      mateInstances( substitutions mapValues { _.toSet }, justifications )
-    else
-      substitutions
-
-    val defElim = DefinitionElimination( definitions.toMap )
-    val defAtomExpansion = mutable.Map[( HOLAtom, Boolean ), ExpansionTree]()
-    def elimDefs( et: ExpansionTree, shallow: HOLFormula ): ExpansionTree = ( et, shallow ) match {
-      case ( ETTop( pol ), _ )    => ETTop( pol )
-      case ( ETBottom( pol ), _ ) => ETBottom( pol )
-      case ( ETDefinedAtom( atom @ Apps( abbrev: HOLAtomConst, args ), pol, _ ), _ ) =>
-        defAtomExpansion.getOrElseUpdate(
-          atom -> pol,
-          ETMerge( ( for {
-            ( clause, Definition( defAtom, expansionWithDefs ) ) <- justifications
-            if substs isDefinedAt clause
-            subst <- substs( clause )
-            if subst( defAtom ) == atom
-          } yield elimDefs( subst( expansionWithDefs ), shallow ) ) + ETWeakening( shallow, pol ) )
-        )
-      case ( ETAtom( _, _ ), _ )                => et
-      case ( ETNeg( t1 ), Neg( sh1 ) )          => ETNeg( elimDefs( t1, sh1 ) )
-      case ( ETAnd( t1, t2 ), And( sh1, sh2 ) ) => ETAnd( elimDefs( t1, sh1 ), elimDefs( t2, sh2 ) )
-      case ( ETOr( t1, t2 ), Or( sh1, sh2 ) )   => ETOr( elimDefs( t1, sh1 ), elimDefs( t2, sh2 ) )
-      case ( ETImp( t1, t2 ), Imp( sh1, sh2 ) ) => ETImp( elimDefs( t1, sh1 ), elimDefs( t2, sh2 ) )
-      case ( ETSkolemQuantifier( f, st, selection ), _ ) =>
-        ETSkolemQuantifier( shallow, st, elimDefs( selection, instantiate( shallow, st ) ) )
-      case ( ETWeakQuantifier( f, instances ), _ ) =>
-        ETWeakQuantifier( shallow, for ( ( term, inst ) <- instances ) yield term -> elimDefs( inst, instantiate( shallow, term ) ) )
-      case ( ETWeakening( f, pol ), _ ) => ETWeakening( shallow, pol )
-    }
-
-    eliminateMerges( ExpansionProof(
+    val endSequentETs =
       for ( ( formula, idx ) <- es.zipWithIndex ) yield ETMerge(
-        ( for {
+        formula, idx isSuc,
+        for {
           ( clause, ProjectionFromEndSequent( projWithDefs, `idx` ) ) <- justifications
           if substs isDefinedAt clause
           subst <- substs( clause )
-        } yield elimDefs( subst( projWithDefs.elements.head ), formula ) )
-          + ETWeakening( formula, idx isSuc )
+        } yield subst( projWithDefs.elements.head )
       )
+
+    val defETs = for ( ( defConst, definingFormula ) <- definitions ) yield for {
+      ( clause, Definition( defAtom @ Apps( `defConst`, vs ), expansion ) ) <- justifications
+      if substs isDefinedAt clause
+    } yield {
+      val defET =
+        if ( expansion.polarity )
+          ETAnd(
+            ETWeakening( defAtom --> expansion.shallow, false ),
+            ETImp( expansion, ETAtom( defAtom, false ) )
+          )
+        else
+          ETAnd(
+            ETImp( ETAtom( defAtom, true ), expansion ),
+            ETWeakening( expansion.shallow --> defAtom, false )
+          )
+      ETWeakQuantifierBlock(
+        All.Block( vs.map { _.asInstanceOf[Var] }, defAtom <-> expansion.shallow ),
+        vs.size, for ( subst <- substs( clause ) ) yield subst( vs -> defET )
+      )
+    }
+    val mergedDefETs = defETs.filter { _.nonEmpty }.map { ETMerge( _ ) }.toSeq
+
+    val expansionProofWithDef = eliminateMerges( ExpansionProof( mergedDefETs ++: endSequentETs ) )
+
+    eliminateCutsET( eliminateDefsET(
+      expansionProofWithDef,
+      pureFOLwithoutEquality,
+      definitions.keySet
     ) )
+
   }
 }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
@@ -5,19 +5,13 @@ import at.logic.gapt.proofs._
 
 object eliminateSplitting {
   def apply( p: ResolutionProof ): ResolutionProof = p match {
-    case Splitting( splittingClause, part1, case1, case2 ) =>
-      justOne( Splitting( splittingClause, part1, apply( case1 ), apply( case2 ) ) )
+    case Splitting( splittingClause, part1, part2, case1, case2 ) =>
+      justOne( Splitting( splittingClause, part1, part2, apply( case1 ), apply( case2 ) ) )
     case _ => p
   }
 
   def justOne( split: Splitting ): ResolutionProof = {
-    val splittingClause: ResolutionProof = split.splittingClause
-    val part1 = split.part1
-    val subProof1 = split.case1
-    val subProof2 = split.case2
-    require( part1 isSubMultisetOf splittingClause.conclusion )
-    val part2 = splittingClause.conclusion diff part1
-    require( freeVariables( part1 ) intersect freeVariables( part2 ) isEmpty )
+    val Splitting( splittingClause, part1, part2, subProof1, subProof2 ) = split
 
     val nameGen = rename.awayFrom(
       splittingClause.subProofs union subProof1.subProofs union subProof2.subProofs
@@ -26,7 +20,7 @@ object eliminateSplitting {
 
     val projections1 = for ( ( a, i ) <- part1.zipWithIndex if freeVariables( a ).isEmpty )
       yield mapInputClauses.withOccConn( subProof1, factorEverything = true ) {
-      case clause if clause multiSetEquals part1 =>
+      case clause if clause == part1 =>
         TautologyClause( a ) -> OccConnector( a +: Clause() :+ a, clause,
           if ( i isSuc ) Seq() +: Sequent() :+ Seq( i )
           else Seq( i ) +: Sequent() :+ Seq() )
@@ -38,7 +32,7 @@ object eliminateSplitting {
     val renamedPart1OccConn = OccConnector( part1, Substitution( part2renaming )( splittingClause.conclusion ).map { _.asInstanceOf[HOLAtom] },
       for ( ( a, i ) <- part1.zipWithIndex ) yield Seq( splittingClause.conclusion.indexOfPol( a, i.isSuc ) ) )
     val renamedDerivationOfPart2 = mapInputClauses.withOccConn( subProof1, factorEverything = true ) { clause =>
-      if ( clause multiSetEquals part1 ) {
+      if ( clause == part1 ) {
         renamedSplittingClause -> renamedPart1OccConn.inv
       } else {
         InputClause( clause ) -> OccConnector( clause )
@@ -48,7 +42,7 @@ object eliminateSplitting {
     require( derivationOfPart2.conclusion isSubMultisetOf part2 )
 
     val finalProof = mapInputClauses( subProof2, factorEarly = true ) { clause =>
-      if ( clause multiSetEquals part2 ) {
+      if ( clause == part2 ) {
         derivationOfPart2
       } else {
         projections1.find( _.conclusion isSubsetOf clause ).map( projections1( _ ) ).getOrElse( InputClause( clause ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
@@ -6,7 +6,7 @@ import at.logic.gapt.proofs._
 object eliminateSplitting {
   def apply( p: ResolutionProof ): ResolutionProof = p match {
     case Splitting( splittingClause, part1, case1, case2 ) =>
-      justOne( Splitting( splittingClause, part1, apply( case2 ), apply( case2 ) ) )
+      justOne( Splitting( splittingClause, part1, apply( case1 ), apply( case2 ) ) )
     case _ => p
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
@@ -74,7 +74,7 @@ object mapInputClauses {
             res -> ( ( res.occConnectors( 0 ) * conn1 * p.occConnectors( 0 ).inv ) + ( res.occConnectors( 1 ) * conn2 * p.occConnectors( 1 ).inv ) )
           } getOrElse { q2 -> conn2 * p.occConnectors( 1 ).inv }
         } getOrElse { q1 -> conn1 * p.occConnectors( 0 ).inv }
-      case p @ Splitting( p0, c1, p1, p2 ) =>
+      case p @ Splitting( p0, c1, c2, p1, p2 ) =>
         val ( q0, _ ) = doMap( p0 )
         val q1 = mapInputClauses.withOccConn( p1, factorEverything ) { cls =>
           if ( p.addInputClauses1 contains cls ) InputClause( cls ) -> OccConnector( cls ) else f( cls )
@@ -82,7 +82,7 @@ object mapInputClauses {
         val q2 = mapInputClauses.withOccConn( p2, factorEverything ) { cls =>
           if ( p.addInputClauses2 contains cls ) InputClause( cls ) -> OccConnector( cls ) else f( cls )
         }
-        Splitting( q0, c1, q1, q2 ) -> OccConnector( HOLClause() )
+        Splitting( q0, c1, c2, q1, q2 ) -> OccConnector( HOLClause() )
     } ) )
 
     doMap( proof )._1

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
@@ -307,11 +307,12 @@ object Paramodulation {
  * </pre>
  */
 case class Splitting(
-    splittingClause: ResolutionProof, part1: HOLClause,
+    splittingClause: ResolutionProof,
+    part1:           HOLClause, part2: HOLClause,
     case1: ResolutionProof, case2: ResolutionProof
 ) extends ResolutionProof {
-  val part2 = splittingClause.conclusion diff part1
-
+  require( splittingClause.conclusion isSubMultisetOf ( part1 ++ part2 ) )
+  require( freeVariables( part1 ) intersect freeVariables( part2 ) isEmpty )
   require( case1.conclusion.isEmpty )
   require( case2.conclusion.isEmpty )
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/simplifyResolutionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/simplifyResolutionProof.scala
@@ -37,8 +37,8 @@ object simplifyResolutionProof {
             } getOrElse q4
           } getOrElse q3
       }
-      case p @ Splitting( splittingClause, part1, case1, case2 ) =>
-        Splitting( simplified( splittingClause ), part1, simplified( case1 ), simplified( case2 ) )
+      case p @ Splitting( splittingClause, part1, part2, case1, case2 ) =>
+        Splitting( simplified( splittingClause ), part1, part2, simplified( case1 ), simplified( case2 ) )
     } ) ensuring { res => res.conclusion == res.conclusion.distinct && res.conclusion.isSubMultisetOf( p.conclusion ) }
 
     simplified( proof )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/utils.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/utils.scala
@@ -5,7 +5,7 @@ object numberOfLogicalInferencesRes {
     p.subProofs.count {
       case Resolution( _, _, _, _ )           => true
       case Paramodulation( _, _, _, _, _, _ ) => true
-      case Splitting( _, _, _, _ )            => true
+      case Splitting( _, _, _, _, _ )         => true
       case _                                  => false
     }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
@@ -438,6 +438,9 @@ class Sequent[+A]( val antecedent: Seq[A], val succedent: Seq[A] ) {
   }
 
   def withFilter( p: A => Boolean ): Sequent[A] = filter( p )
+
+  def groupBy[B]( f: A => B ): Sequent[( B, Seq[A] )] =
+    Sequent( antecedent groupBy f toSeq, succedent groupBy f toSeq )
 }
 
 object Sequent {

--- a/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
@@ -106,7 +106,7 @@ object RefutationSketchToRobinson {
           splittingClause <- solve( s.splittingClause )
           case1 <- solve( s.case1 )
           case2 <- solve( s.case2 )
-        } yield Splitting( splittingClause, s.part1, case1, case2 )
+        } yield Splitting( splittingClause, s.part1, s.part2, case1, case2 )
     } )
     solve( sketch ) map { simplifyResolutionProof( _ ) }
   }

--- a/core/src/main/scala/at/logic/gapt/prooftool/ProofToolViewer.scala
+++ b/core/src/main/scala/at/logic/gapt/prooftool/ProofToolViewer.scala
@@ -45,8 +45,8 @@ object prooftool {
       case p: SequentProof[_, _] =>
         def renderer( x: T forSome { type T } ) = x.toString //TODO: have a better default
         new SequentProofViewer( name, p, renderer ).showFrame()
-      case ep: ExpansionProofWithCut => new ExpansionSequentViewer( name, ep.cuts ++: ep.expansionSequent ).showFrame()
-      case es: ExpansionSequent      => new ExpansionSequentViewer( name, es ).showFrame()
+      case ep: ExpansionProofWithCut => apply( ep.expansionWithCutAxiom, name )
+      case ep: ExpansionProof        => new ExpansionSequentViewer( name, ep.expansionSequent ).showFrame()
       case p: lkOld.base.LKProof     => new OldLKViewer( name, p ).showFrame()
       case p: TreeProof[_]           => new TreeProofViewer( name, p ).showFrame()
       case p: Proof[_]               => new ResolutionProofViewer( name, p ).showFrame()

--- a/core/src/main/scala/at/logic/gapt/provers/ResolutionProver.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/ResolutionProver.scala
@@ -62,8 +62,6 @@ abstract class ResolutionProver extends OneShotProver {
 
   def getRobinsonProof( seq: Traversable[HOLClause] ): Option[ResolutionProof]
 
-  override def getExpansionProofWithCut( seq: HOLSequent ): Option[ExpansionProofWithCut] =
-    getExpansionProof( seq )
   override def getExpansionProof( seq: HOLSequent ): Option[ExpansionProof] =
     withGroundVariables2( seq ) { seq =>
       val ( cnf, justs, defs ) = structuralCNF( seq, generateJustifications = true, propositional = false )

--- a/core/src/main/scala/at/logic/gapt/provers/leancop/leancop.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/leancop/leancop.scala
@@ -17,9 +17,9 @@ class LeanCoP extends OneShotProver with ExternalProgram {
   val nLine = sys.props( "line.separator" )
 
   override def isValid( s: HOLSequent ): Boolean =
-    getExpansionProofWithCut( s ).isDefined
+    getExpansionProof( s ).isDefined
 
-  override def getExpansionProofWithCut( s: HOLSequent ): Option[ExpansionProofWithCut] =
+  override def getExpansionProof( s: HOLSequent ): Option[ExpansionProof] =
     withRenamedConstants( s ) { seq =>
       require( seq.succedent.size == 1 )
 

--- a/core/src/main/scala/at/logic/gapt/provers/provers.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/provers.scala
@@ -51,17 +51,11 @@ trait Prover {
   def getExpansionSequent( seq: HOLSequent ): Option[ExpansionSequent] =
     getExpansionProof( seq ) map { _.expansionSequent }
 
-  def getExpansionProofWithCut( formula: HOLFormula ): Option[ExpansionProofWithCut] =
-    getExpansionProofWithCut( Sequent() :+ formula )
-
-  def getExpansionProofWithCut( seq: HOLSequent ): Option[ExpansionProofWithCut] =
-    getLKProof( seq ) map { LKToExpansionProof( _ ) }
-
   def getExpansionProof( formula: HOLFormula ): Option[ExpansionProof] =
     getExpansionProof( Sequent() :+ formula )
 
   def getExpansionProof( seq: HOLSequent ): Option[ExpansionProof] =
-    getExpansionProofWithCut( seq ) map { eliminateCutsET( _ ) }
+    getLKProof( seq ) map { LKToExpansionProof( _ ) } map { eliminateCutsET( _ ) }
 
   /**
    * Starts an incremental proving session.

--- a/core/src/main/scala/at/logic/gapt/provers/veriT/VeriT.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/veriT/VeriT.scala
@@ -43,7 +43,7 @@ class VeriT extends OneShotProver with ExternalProgram {
    * taking the quantified equality axioms from the proof returned by veriT and
    * merging them with the original end-sequent.
    */
-  override def getExpansionProofWithCut( s: HOLSequent ): Option[ExpansionProofWithCut] = withGroundVariables2( s ) { s =>
+  override def getExpansionProof( s: HOLSequent ): Option[ExpansionProof] = withGroundVariables2( s ) { s =>
     val ( smtBenchmark, _, renaming ) = SmtLibExporter( s )
     val output = runProcess( Seq( "veriT", "--proof=-", "--proof-version=1" ), smtBenchmark )
 
@@ -70,8 +70,8 @@ class VeriT extends OneShotProver with ExternalProgram {
     p
   }
 
-  def addEquationalAxioms( epwc: ExpansionProofWithCut ): Option[ExpansionProofWithCut] =
-    for ( ExpansionProofWithCut( Seq(), veritExpansion ) <- getExpansionProofWithCut( epwc.deep ) ) yield {
+  def addEquationalAxioms( epwc: ExpansionProof ): Option[ExpansionProof] =
+    for ( ExpansionProof( veritExpansion ) <- getExpansionProof( epwc.deep ) ) yield {
       val equationalAxioms = veritExpansion filter { t => containsQuantifier( t.shallow ) } map { t =>
         freeVariables( t.shallow ).foldLeft( t )( ( t_, fv ) => ETWeakQuantifier( All( fv, t_.shallow ), Map( fv -> t_ ) ) )
       }

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
@@ -93,7 +93,7 @@ class ResolutionTest extends Specification {
     val splCls = c1
     val case1 = Resolution( InputClause( Clause() :+ hoa"p" ), Suc( 0 ), c2, Ant( 0 ) )
     val case2 = Resolution( InputClause( Clause() :+ hoa"q" ), Suc( 0 ), c3, Ant( 0 ) )
-    val proof = Splitting( splCls, Clause() :+ hoa"p", case1, case2 )
+    val proof = Splitting( splCls, Clause() :+ hoa"p", Clause() :+ hoa"q", case1, case2 )
     proof.conclusion must beEmpty
   }
 

--- a/tests/src/test/scala/at/logic/gapt/provers/spass/SpassTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/provers/spass/SpassTest.scala
@@ -63,6 +63,13 @@ class SpassTest extends Specification with SequentMatchers with SatMatchers {
       SPASS getRobinsonProof cnf must beLike { case Some( p ) => cnf must contain( atLeast( p.inputClauses ) ) }
       SPASS getExpansionProof formula must beLike { case Some( p ) => p.deep must beValidSequent }
     }
+
+    "bug with quantified splitting" in {
+      val Seq( x, y, z ) = Seq( "x", "y", "z" ) map { FOLVar( _ ) }
+      val as = 0 to 2 map { i => All( x, Ex( y, FOLAtom( s"a$i", x, y, z ) ) ) }
+      val formula = All( z, thresholds.exactly oneOf as ) <-> All( z, naive.exactly oneOf as )
+      SPASS getExpansionProof formula must beLike { case Some( p ) => p.deep must beValidSequent }
+    }
   }
 
 }


### PR DESCRIPTION
Definitions refer to abbreviated/renamed/defined subformulas in a structural clausification.  That is, instead of applying distributivity and obtain exponentially-sized CNFs, we replace some subformulas by fresh atoms.  The resulting CNF then contains clauses of the abbreviated formula, and in addition clauses that axiomatize the definition.

This PR implements the elimination of these definition axioms in expansion proofs.  A definition consists of an expansion of `∀x D(x) <-> φ` in the antecedent, where φ is the abbreviated subformula and x a vector of variables.  If φ does not contain D and its expansion does not contain strong quantifier nodes, then we can always eliminate the definition.  (This needs a bit of massaging in the case of equality though.)

In addition, ExpansionProofWithCut is now a wrapper around an ExpansionProof with an extra expansion tree in the antecedent: namely an expansion of `∀X (X ⊃ X)`.  This considerably simplifies the implementation, and fixes a bug in the dependency relation computation as well.