### PR TITLE
Pretty-printing for expansion trees.

### DIFF
--- a/core/src/main/scala/at/logic/gapt/formats/babel/export.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/babel/export.scala
@@ -24,14 +24,17 @@ class BabelExporter( unicode: Boolean, sig: BabelSignature ) extends PrettyPrint
       else super.nest( doc, j )
     }
 
-  def export( expr: LambdaExpression ): String = {
-    val knownTypesFromSig = constants( expr ) flatMap { c =>
+  def knownConstantTypesFromSig( consts: Iterable[Const] ) =
+    consts flatMap { c =>
       sig( c.name ) match {
         case IsConst( ast.TypeVar( _ ) ) => None
         case IsConst( astType ) if astType == ast.liftType( c.exptype ) => Some( c.name -> c )
         case _ => None
       }
     }
+
+  def export( expr: LambdaExpression ): String = {
+    val knownTypesFromSig = knownConstantTypesFromSig( constants( expr ) )
     pretty( group( show( expr, false, Set(), knownTypesFromSig.toMap, prio.max )._1 ) )
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionTrees.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionTrees.scala
@@ -2,6 +2,7 @@ package at.logic.gapt.proofs.expansion
 
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.{ HOLPosition, instantiate }
+import at.logic.gapt.formats.babel.BabelSignature
 import at.logic.gapt.proofs.DagProof
 
 import scala.collection.mutable
@@ -13,7 +14,9 @@ trait ExpansionTree extends DagProof[ExpansionTree] {
 
   def apply( pos: HOLPosition ): Set[ExpansionTree] = getAtHOLPosition( this, pos )
 
-  override def toString = treeLike.toString
+  def toSigRelativeString( implicit sig: BabelSignature ) =
+    new ExpansionTreePrettyPrinter( sig ).export( this )
+  override def toString = toSigRelativeString
 }
 
 case class ETWeakening( formula: HOLFormula, polarity: Boolean ) extends ExpansionTree {

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
@@ -1,0 +1,75 @@
+package at.logic.gapt.proofs.expansion
+
+import at.logic.gapt.expr._
+import at.logic.gapt.formats.babel.{ BabelExporter, BabelSignature }
+
+class ExpansionTreePrettyPrinter( sig: BabelSignature ) extends BabelExporter( unicode = true, sig = sig ) {
+
+  def export( et: ExpansionTree ): String = {
+    val knownTypesFromSig = knownConstantTypesFromSig( constants( et.deep ) union constants( et.shallow ) )
+    pretty( group( show( et, knownTypesFromSig.toMap, prio.max )._1 ) )
+  }
+
+  def addPol( doc: Doc, pol: Boolean ) =
+    if ( pol ) doc <> "+" else doc <> "-"
+
+  def show( et: ExpansionTree, t0: Map[String, LambdaExpression], p: Int ): ( Doc, Map[String, LambdaExpression] ) = et match {
+    case ETTop( pol )    => ( addPol( "⊤", pol ), t0 )
+    case ETBottom( pol ) => ( addPol( "⊥", pol ), t0 )
+    case ETWeakening( f, pol ) =>
+      val ( f_, t1 ) = show( f, true, Set(), t0, prio.max )
+      ( addPol( "wk", pol ) <> "{" <> f_ <> "}", t1 )
+    case ETAtom( a, pol ) =>
+      val ( a_, t1 ) = show( a, true, Set(), t0, prio.app + 1 )
+      ( addPol( a_, pol ), t1 )
+    case ETMerge( a, b ) =>
+      val ( a_, t1 ) = show( a, t0, prio.bicond )
+      val ( b_, t2 ) = show( b, t1, prio.bicond )
+      parenIf( p, prio.bicond, a_ <+> "⊔" <@> b_ ) -> t2
+    case ETNeg( a ) =>
+      val ( a_, t1 ) = show( a, t0, prio.quantOrNeg )
+      parenIf( p, prio.quantOrNeg, "¬" <> a_ ) -> t1
+    case ETAnd( a, b ) =>
+      val ( a_, t1 ) = show( a, t0, prio.conj )
+      val ( b_, t2 ) = show( b, t1, prio.conj )
+      parenIf( p, prio.conj, a_ <+> "∧" <@> b_ ) -> t2
+    case ETOr( a, b ) =>
+      val ( a_, t1 ) = show( a, t0, prio.disj )
+      val ( b_, t2 ) = show( b, t1, prio.disj )
+      parenIf( p, prio.disj, a_ <+> "∨" <@> b_ ) -> t2
+    case ETImp( a, b ) =>
+      val ( a_, t1 ) = show( a, t0, prio.impl )
+      val ( b_, t2 ) = show( b, t1, prio.impl )
+      parenIf( p, prio.impl, a_ <+> "⊃" <@> b_ ) -> t2
+    case ETStrongQuantifier( sh, ev, child ) =>
+      val ( sh_, t1 ) = show( sh, true, Set(), t0, prio.conj )
+      val ( ev_, t2 ) = show( ev, true, Set(), t1, prio.max )
+      val ( child_, t3 ) = show( child, t2, prio.conj )
+      parenIf( p, prio.conj, sh_ <+> "+ev^{" <> ev_ <> "}" <@> child_ ) -> t3
+    case ETSkolemQuantifier( sh, skTerm, _, child ) =>
+      val ( sh_, t1 ) = show( sh, true, Set(), t0, prio.conj )
+      val ( skTerm_, t2 ) = show( skTerm, true, Set(), t1, prio.max )
+      val ( child_, t3 ) = show( child, t2, prio.conj )
+      parenIf( p, prio.conj, sh_ <+> "+sk^{" <> skTerm_ <> "}" <@> child_ ) -> t3
+    case ETWeakQuantifier( sh, insts ) =>
+      val ( sh_, t1 ) = show( sh, true, Set(), t0, prio.conj )
+      var t2 = t1
+      val insts_ = insts.toList map {
+        case ( term, child ) =>
+          val ( term_, t3 ) = show( term, true, Set(), t2, prio.max )
+          val ( child_, t4 ) = show( child, t3, prio.conj )
+          t2 = t4
+          ( pretty( term_ ), group( nest( "+^{" <> term_ <> "}" <@> child_ ) ) )
+      }
+      parenIf( p, prio.conj, vsep( sh_ +: insts_.sortBy( _._1 ).map( _._2 ) ) ) -> t2
+    case et @ ETDefinedAtom( atom, pol, _ ) =>
+      val ( sh_, t1 ) = show( et.shallow, true, Set(), t0, prio.conj )
+      val ( child_, t2 ) = show( ETAtom( atom, pol ), t1, prio.conj )
+      parenIf( p, prio.conj, sh_ <+> "+def" <@> child_ ) -> t2
+    case ETDefinition( shallow, _, child ) =>
+      val ( sh_, t1 ) = show( shallow, true, Set(), t0, prio.conj )
+      val ( child_, t2 ) = show( child, t1, prio.conj )
+      parenIf( p, prio.conj, sh_ <+> "+def" <@> child_ ) -> t2
+  }
+
+}

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -2575,7 +2575,7 @@ nodes, and cuts~\cite{Hetzl2013Expansion}.
 \begin{tabular}{r l}
 
   \cli{ETAtom} & $A$ \quad (where $A$ is a HOL atom) \\
-\cli{ETWeakening} & $\varphi$ \quad (where $\varphi$ is a formula) \\
+\cli{ETWeakening} & $\mathsf{wk}(\varphi)$ \quad (where $\varphi$ is a formula) \\
 \cli{ETTop} & $\top$ \\
 \cli{ETBottom} & $\bot$ \\
 \cli{ETNeg} & $\neg E$ \\
@@ -2591,11 +2591,11 @@ $Q x \varphi
 $ \quad (where $Q$ is a quantifier and $t_i$ terms) \\
 
 \cli{ETStrongQuantifier} &
-$Q x \varphi +^\alpha \varphi[\alpha/x]$
+$Q x \varphi +_\mathsf{ev}^\alpha \varphi[\alpha/x]$
 \quad (where $Q$ is a quantifier and $\alpha$ an eigenvariable) \\
 
 \cli{ETSkolemQuantifier} &
-$Q x \varphi +^s \varphi[s/x]$
+$Q x \varphi +_\mathsf{sk}^s \varphi[s/x]$
 \quad (where $Q$ is a quantifier and $s$ a Skolem term) \\
 \\
 


### PR DESCRIPTION
After rewriting the expansion tree section in the user manual today, I found that the current `toString` output for expansion trees is not very readable, even though I'm quite used to it by now.  So I've implemented an output that is quite a bit closer to a textbook approach, with `+^t` operators (these bind about as tightly as conjunction):
```
scala> LKToExpansionProof(examples.fol1.proof)
res13: at.logic.gapt.proofs.expansion.ExpansionProofWithCut =
∀X (X ⊃ X)
  +^{∀x ∃y (¬P(x, y) ∨ Q(x, y))}
    (∀x ∃y (¬P(x, y) ∨ Q(x, y)) +ev^{x}
        (∃y (¬P(x, y) ∨ Q(x, y)) +^{a} (¬P(x, a)- ∨ Q(x, a)+)) ⊃
      ∀x ∃y (¬P(x, y) ∨ Q(x, y))
        +^{b} (∃y (¬P(b, y) ∨ Q(b, y)) +ev^{y} (¬P(b, y)+ ∨ Q(b, y)-))),
∀x ∀y (P(x, y) ⊃ Q(x, y))
  +^{x} (∀y (P(x, y) ⊃ Q(x, y)) +^{a} (P(x, a)+ ⊃ Q(x, a)-))
:-
∃x ∃y (¬Q(x, y) ⊃ ¬P(x, y))
  +^{b} (∃y (¬Q(b, y) ⊃ ¬P(b, y)) +^{y} (¬Q(b, y)+ ⊃ ¬P(b, y)-))

scala> Escargot getExpansionProof hof"Q 0 & P 0 & !x (P x -> P (s x)) -> P ${Numeral(5)}"
res19: Option[at.logic.gapt.proofs.expansion.ExpansionProof] =
Some(
:-
(wk-{Q(0)} ∧ P(0)-) ∧
    (∀x (P(x) ⊃ P(s(x)))
      +^{0} (P(0)+ ⊃ P(s(0))-)
      +^{s(0)} (P(s(0))+ ⊃ P(s(s(0)))-)
      +^{s(s(0))} (P(s(s(0)))+ ⊃ P(s(s(s(0))))-)
      +^{s(s(s(0)))} (P(s(s(s(0))))+ ⊃ P(s(s(s(s(0)))))-)
      +^{s(s(s(s(0))))} (P(s(s(s(s(0)))))+ ⊃ P(s(s(s(s(s(0))))))-)) ⊃
  P(s(s(s(s(s(0))))))+)
```
Weakenings, definitions, merges are included just as they are in the expansion tree, so no information should be lost compared to now.

Does anybody have strong opinions on this?