### PR TITLE
LK: add Skolem inferences.

### DIFF
--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
@@ -124,6 +124,10 @@ class ExpansionProofToLK(
         mapIf( solve( cuts, expSeq.updated( i, f ) ), f.shallow, false ) { ExistsLeftRule( _, sh, ev ) }
       case ( ETStrongQuantifier( sh, ev, f ), i: Suc ) =>
         mapIf( solve( cuts, expSeq.updated( i, f ) ), f.shallow, true ) { ForallRightRule( _, sh, ev ) }
+      case ( ETSkolemQuantifier( sh, skT, skD, f ), i: Ant ) =>
+        mapIf( solve( cuts, expSeq.updated( i, f ) ), f.shallow, false ) { ExistsSkLeftRule( _, skT, skD ) }
+      case ( ETSkolemQuantifier( sh, skT, skD, f ), i: Suc ) =>
+        mapIf( solve( cuts, expSeq.updated( i, f ) ), f.shallow, true ) { ForallSkRightRule( _, skT, skD ) }
     }
 
   private def tryWeakQ( cuts: Seq[ETImp], expSeq: ExpansionSequent ): Option[UnprovableOrLKProof] = {

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/DefinitionElimination.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/DefinitionElimination.scala
@@ -93,6 +93,12 @@ class DefinitionElimination private ( dmap: Map[LambdaExpression, LambdaExpressi
     case ForallRightRule( subProof, aux, eigen, quant ) =>
       ForallRightRule( apply( subProof ), aux, eigen, quant )
 
+    case ExistsSkLeftRule( subProof, aux, main, skT, skD ) =>
+      ExistsSkLeftRule( apply( subProof ), aux, apply( main ), apply( skT ), apply( skD ) )
+
+    case ForallSkRightRule( subProof, aux, main, skT, skD ) =>
+      ForallSkRightRule( apply( subProof ), aux, apply( main ), apply( skT ), apply( skD ) )
+
     //equational rules
     case proof @ EqualityLeftRule( subProof, eq, aux, con ) =>
       EqualityLeftRule( apply( subProof ), eq, aux, apply( con ).asInstanceOf[Abs] )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKProofSubstitutable.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKProofSubstitutable.scala
@@ -109,6 +109,12 @@ class LKProofSubstitutable( preserveEigenvariables: Boolean ) extends Substituta
       val Ex( newV, newF ) = substitution( p.mainFormula )
       ExistsRightRule( subProofNew, aux, betaNormalize( newF ), betaNormalize( substitution( term ) ), newV )
 
+    case p @ ExistsSkLeftRule( subProof, aux, main, skT, skD ) =>
+      ExistsSkLeftRule( applySubstitution( substitution, subProof ), aux, BetaReduction.betaNormalize( substitution( main ) ), substitution( skT ), skD )
+
+    case p @ ForallSkRightRule( subProof, aux, main, skT, skD ) =>
+      ForallSkRightRule( applySubstitution( substitution, subProof ), aux, BetaReduction.betaNormalize( substitution( main ) ), substitution( skT ), skD )
+
     case EqualityLeftRule( subProof, eq, aux, con ) =>
       val subProofNew = applySubstitution( substitution, subProof )
       EqualityLeftRule( subProofNew, eq, aux, substitution( con ).asInstanceOf[Abs] )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
@@ -114,9 +114,17 @@ object LKToExpansionProof {
       val ( subCuts, subSequent ) = extract( subProof )
       ( subCuts, subSequent.delete( aux ) :+ ETStrongQuantifier( proof.mainFormulas.head, eigen, subSequent( aux ) ) )
 
+    case ForallSkRightRule( subProof, aux, main, skT, skD ) =>
+      val ( subCuts, subSequent ) = extract( subProof )
+      ( subCuts, subSequent.delete( aux ) :+ ETSkolemQuantifier( main, skT, skD, subSequent( aux ) ) )
+
     case ExistsLeftRule( subProof, aux, eigen, _ ) =>
       val ( subCuts, subSequent ) = extract( subProof )
       ( subCuts, ETStrongQuantifier( proof.mainFormulas.head, eigen, subSequent( aux ) ) +: subSequent.delete( aux ) )
+
+    case ExistsSkLeftRule( subProof, aux, main, skT, skD ) =>
+      val ( subCuts, subSequent ) = extract( subProof )
+      ( subCuts, ETSkolemQuantifier( main, skT, skD, subSequent( aux ) ) +: subSequent.delete( aux ) )
 
     case ExistsRightRule( subProof, aux, _, t, _ ) =>
       val ( subCuts, subSequent ) = extract( subProof )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKVisitor.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKVisitor.scala
@@ -93,8 +93,14 @@ trait LKVisitor[T] {
     case p: ForallRightRule =>
       visitForallRight( p, otherArg )
 
+    case p: ForallSkRightRule =>
+      visitForallSkRight( p, otherArg )
+
     case p: ExistsLeftRule =>
       visitExistsLeft( p, otherArg )
+
+    case p: ExistsSkLeftRule =>
+      visitExistsSkLeft( p, otherArg )
 
     case p: ExistsRightRule =>
       visitExistsRight( p, otherArg )
@@ -252,9 +258,25 @@ trait LKVisitor[T] {
     ( proofNew, connector, otherArgNew )
   }
 
+  protected def visitForallSkRight( proof: ForallSkRightRule, otherArg: T ): ( LKProof, OccConnector[HOLFormula], T ) = {
+    val ( subProofNew, subConnector, otherArgNew ) = recurse( proof.subProof, otherArg )
+    val proofNew = ForallSkRightRule( subProofNew, subConnector.child( proof.aux ), proof.mainFormula, proof.skolemTerm, proof.skolemDef )
+    val connector = proofNew.getOccConnector * subConnector * proof.getOccConnector.inv
+
+    ( proofNew, connector, otherArgNew )
+  }
+
   protected def visitExistsLeft( proof: ExistsLeftRule, otherArg: T ): ( LKProof, OccConnector[HOLFormula], T ) = {
     val ( subProofNew, subConnector, otherArgNew ) = recurse( proof.subProof, otherArg )
     val proofNew = ExistsLeftRule( subProofNew, subConnector.child( proof.aux ), proof.eigenVariable, proof.quantifiedVariable )
+    val connector = proofNew.getOccConnector * subConnector * proof.getOccConnector.inv
+
+    ( proofNew, connector, otherArgNew )
+  }
+
+  protected def visitExistsSkLeft( proof: ExistsSkLeftRule, otherArg: T ): ( LKProof, OccConnector[HOLFormula], T ) = {
+    val ( subProofNew, subConnector, otherArgNew ) = recurse( proof.subProof, otherArg )
+    val proofNew = ExistsSkLeftRule( subProofNew, subConnector.child( proof.aux ), proof.mainFormula, proof.skolemTerm, proof.skolemDef )
     val connector = proofNew.getOccConnector * subConnector * proof.getOccConnector.inv
 
     ( proofNew, connector, otherArgNew )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/solve.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/solve.scala
@@ -46,47 +46,9 @@ object AtomicExpansion {
     case Ex( x, l )  => ExistsLeftRule( ExistsRightRule( apply( l ), Suc( 0 ), l, x, x ), Ant( 0 ), x, x )
   }
 
-  def apply( p: LKProof ): LKProof = p match {
-    case ReflexivityAxiom( _ ) | TopAxiom | BottomAxiom | TheoryAxiom( _ ) => p
-    case LogicalAxiom( f ) => apply( f )
-
-    //structural rules
-    case ContractionLeftRule( subProof, aux1, aux2 ) => ContractionLeftRule( apply( subProof ), aux1, aux2 )
-    case ContractionRightRule( subProof, aux1, aux2 ) => ContractionRightRule( apply( subProof ), aux1, aux2 )
-
-    case WeakeningLeftRule( subProof, main ) => WeakeningLeftRule( apply( subProof ), main )
-    case WeakeningRightRule( subProof, main ) => WeakeningRightRule( apply( subProof ), main )
-
-    case CutRule( subProof1, aux1, subProof2, aux2 ) => CutRule( apply( subProof1 ), aux1, apply( subProof2 ), aux2 )
-
-    //Unary Logical rules
-    case NegLeftRule( subProof, aux ) => NegLeftRule( apply( subProof ), aux )
-    case NegRightRule( subProof, aux ) => NegRightRule( apply( subProof ), aux )
-
-    case ImpRightRule( subProof, aux1, aux2 ) => ImpRightRule( apply( subProof ), aux1, aux2 )
-    case OrRightRule( subProof, aux1, aux2 ) => OrRightRule( apply( subProof ), aux1, aux2 )
-    case AndLeftRule( subProof, aux1, aux2 ) => AndLeftRule( apply( subProof ), aux1, aux2 )
-
-    //Binary Logical Rules
-    case ImpLeftRule( subProof1, aux1, subProof2, aux2 ) => ImpLeftRule( apply( subProof1 ), aux1, apply( subProof2 ), aux2 )
-    case OrLeftRule( subProof1, aux1, subProof2, aux2 ) => OrLeftRule( apply( subProof1 ), aux1, apply( subProof2 ), aux2 )
-    case AndRightRule( subProof1, aux1, subProof2, aux2 ) => AndRightRule( apply( subProof1 ), aux1, apply( subProof2 ), aux2 )
-
-    //Quantifier Rules
-    case ForallLeftRule( subProof, aux, formula, term, v ) => ForallLeftRule( apply( subProof ), aux, formula, term, v )
-    case ExistsRightRule( subProof, aux, formula, term, v ) => ExistsRightRule( apply( subProof ), aux, formula, term, v )
-
-    case ForallRightRule( subProof, aux, eigen, quant ) => ForallRightRule( apply( subProof ), aux, eigen, quant )
-    case ExistsLeftRule( subProof, aux, eigen, quant ) => ExistsLeftRule( apply( subProof ), aux, eigen, quant )
-
-    //equality and definitions
-    case EqualityLeftRule( subProof, eq, aux, con ) => EqualityLeftRule( apply( subProof ), eq, aux, con )
-    case EqualityRightRule( subProof, eq, aux, con ) => EqualityRightRule( apply( subProof ), eq, aux, con )
-
-    case DefinitionLeftRule( subProof, aux, main ) => DefinitionLeftRule( apply( subProof ), aux, main )
-    case DefinitionRightRule( subProof, aux, main ) => DefinitionRightRule( apply( subProof ), aux, main )
-
-    case InductionRule( cases, main ) => InductionRule( cases map { c => c.copy( apply( c.proof ) ) }, main )
-  }
+  def apply( p: LKProof ): LKProof = new LKVisitor[Unit] {
+    override def visitLogicalAxiom( proof: LogicalAxiom, otherArg: Unit ) =
+      ( AtomicExpansion( proof.A ), OccConnector( proof.endSequent ), otherArg )
+  }.apply( p, () )
 
 }

--- a/tests/src/test/scala/at/logic/gapt/proofs/lk/SolveTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/lk/SolveTest.scala
@@ -109,6 +109,14 @@ class SolveTest extends Specification with SequentMatchers {
       }
     }
 
+    "skolem quantifiers" in {
+      val formula = hof"?x!y p(x,y) -> !y?x p(x,y)"
+      val Some( skolemExpansion ) = Escargot getExpansionProof formula
+      ExpansionProofToLK( skolemExpansion ) must beLike {
+        case \/-( p ) => p.conclusion must_== ( Sequent() :+ formula )
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
This PR adds two inferences to LK: ∀sk:r and ∃sk:l (only showing one)
```
Γ :- Δ, φ(s(...))
-------------------  ∀sk:r
Γ :- Δ, ∀x φ(x)
```

 * This makes LK more symmetric to our expansion tree calculus.
 * `SomeProver.getLKProof` no longer fails on strong quantifiers.
 * `ExpansionProofToLK` can now handle all expansion trees.
 * It is now easy to compare `LKToExpansionProof(RobinsonToLK(p))` and `RobinsonToExpansionProof(p)`.
  * The difference is particularly striking when comparing the expansion proofs in the case of structural clausification.
 * It is actually remarkably little effort to add new inferences.