### PR TITLE
Special conversion from resolution to LK for unit-equational proofs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release notes for GAPT
 
+## Version 2.3 (unreleased)
+
+* Conversion of unit-equational resolution proofs to unary LK proofs
+
 ## Version 2.2 (released on 2016-07-09)
 
 * New resolution calculus with Avatar splitting

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
@@ -7,7 +7,7 @@ import at.logic.gapt.provers.escargot.Escargot
 import scalaz._
 import Scalaz._
 
-object ExpansionProofToLK extends ExpansionProofToLK( Escargot.getLKProof( _, addWeakenings = false ) ) {
+object ExpansionProofToLK extends ExpansionProofToLK( Escargot.getAtomicLKProof ) {
   def withTheory( implicit ctx: Context ) = new ExpansionProofToLK( ctx.theory _ )
 }
 object PropositionalExpansionProofToLK extends ExpansionProofToLK( _ => None )

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticCommands.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticCommands.scala
@@ -547,6 +547,7 @@ trait TacticCommands {
    * found and inserted.
    */
   def prop = PropTactic
+  def quasiprop = QuasiPropTactic
 
   /**
    * Calls `prover9` on the current subgoal.

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/tactics/complexTactics.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/tactics/complexTactics.scala
@@ -306,6 +306,11 @@ case object PropTactic extends Tactic[Unit] {
   }
 }
 
+case object QuasiPropTactic extends Tactic[Unit] {
+  override def apply( goal: OpenAssumption ) =
+    solveQuasiPropositional( goal.conclusion ).toOption.toSuccessNel( TacticalFailure( this, Some( goal ), "search failed" ) ) map { () -> _ }
+}
+
 /**
  * Calls prover9 on the subgoal.
  */

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -164,6 +164,9 @@ object ResolutionToExpansionProof {
       case p @ AvatarAbsurd( q ) =>
         propg( p, q, _ => sequent2expansions( q.conclusion ) )
 
+      case p: Flip =>
+        prop1( p, { case ETAtom( Eq( t, s ), pol ) => ETAtom( Eq( s, t ), pol ) } )
+
       case p @ TopL( q, i ) =>
         val Seq( oc ) = p.occConnectors
         propgm2( p, q, oc.parent( _, ETTop( true ) ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
@@ -90,6 +90,11 @@ object ResolutionToLKProof {
       case DefIntro( q, i: Ant, defAtom, defn ) =>
         DefinitionLeftRule( f( q ), q.conclusion( i ), defAtom )
 
+      case p @ Flip( q, i: Ant ) =>
+        CutRule( mkSymmProof( p.s, p.t ), f( q ), q.conclusion( i ) )
+      case p @ Flip( q, i: Suc ) =>
+        CutRule( f( q ), mkSymmProof( p.t, p.s ), q.conclusion( i ) )
+
       case p: TopL    => reducef( p ) { _ => TopAxiom }
       case p: BottomR => reducef( p ) { _ => BottomAxiom }
       case p: NegL    => reducef( p ) { case Neg( l ) => NegRightRule( LogicalAxiom( l ), Ant( 0 ) ) }
@@ -174,4 +179,11 @@ object ResolutionToLKProof {
         }
     }.apply( proof, proof.conclusion.indicesSequent.map( _ == idx ) )
 
+  /** Proof of t=s :- s=t */
+  def mkSymmProof( t: LambdaExpression, s: LambdaExpression ): LKProof =
+    ProofBuilder.
+      c( ReflexivityAxiom( t ) ).
+      u( WeakeningLeftRule( _, Eq( t, s ) ) ).
+      u( EqualityRightRule( _, Ant( 0 ), Suc( 0 ), Eq( s, t ) ) ).
+      qed
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToRal.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToRal.scala
@@ -44,6 +44,8 @@ abstract class ResolutionToRal {
       RalPara( p1New, p1New.conclusion.find( _._2 == convert_formula( p1.conclusion( eq ) ) ).get.asInstanceOf[Suc],
         p2New, p2New.conclusion.find( _._2 == convert_formula( p2.conclusion( lit ) ) ).get,
         convert_context( con ), dir )
+    case Flip( p1, i1 ) =>
+      apply( Flip.simulate( p1, i1 ) )
   }
 }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProof.scala
@@ -1,0 +1,67 @@
+package at.logic.gapt.proofs.resolution
+
+import at.logic.gapt.expr.{ Eq, HOLFormula }
+import at.logic.gapt.proofs.{ Sequent, Suc }
+import at.logic.gapt.proofs.lk._
+
+object UnitResolutionToLKProof {
+
+  def apply( proof: ResolutionProof ): LKProof = {
+
+    def shouldFlip( p: ResolutionProof ): Boolean = p match {
+      case Paramod( _, _, _, q, _, _ ) => shouldFlip( q )
+      case Flip( q, _ )                => !shouldFlip( q )
+      case Input( _ )                  => false
+    }
+    def maybeFlip( atom: HOLFormula, flip: Boolean ): HOLFormula =
+      if ( flip ) {
+        val Eq( t, s ) = atom
+        Eq( s, t )
+      } else {
+        atom
+      }
+
+    var lk: LKProof = proof match {
+      case Resolution( Refl( term ), _, _, _ ) => ReflexivityAxiom( term )
+      case Resolution( left, _, right, _ ) =>
+        if ( shouldFlip( right ) ) {
+          val Sequent( Seq( Eq( t, s ) ), Seq() ) = right.conclusion
+          ResolutionToLKProof.mkSymmProof( t, s )
+        } else {
+          LogicalAxiom( left.conclusion.succedent.head )
+        }
+    }
+
+    proof.dagLike.postOrder.reverse.tail.foreach { p =>
+      p match {
+        case Refl( _ )  =>
+        case Input( _ ) =>
+        case p @ Paramod( q1, _, _, q2, i2, ctx ) =>
+          val shouldFlip2 = shouldFlip( q2 )
+          val lkAux = maybeFlip( p.rewrittenAuxFormula, shouldFlip2 )
+          if ( lk.conclusion.zipWithIndex.exists { case ( a, i ) => a == lkAux && !i.sameSideAs( i2 ) } ) {
+            val lkMain = maybeFlip( p.auxFormula, shouldFlip2 )
+            val lkEq = maybeFlip( q1.conclusion( Suc( 0 ) ), shouldFlip( q1 ) )
+            lk = WeakeningLeftRule( lk, lkEq )
+            if ( i2.isSuc )
+              lk = EqualityLeftRule( lk, lkEq, lkAux, lkMain )
+            else
+              lk = EqualityRightRule( lk, lkEq, lkAux, lkMain )
+          }
+        case Flip( _, _ ) =>
+      }
+
+      lk = ContractionMacroRule( lk )
+    }
+
+    val expectedConclusion = proof.subProofs.collect { case Input( seq ) => seq.swapped }.fold( Sequent() )( _ ++ _ )
+
+    require(
+      lk.conclusion isSubMultisetOf expectedConclusion,
+      s"$expectedConclusion\n$proof\n$lk"
+    )
+
+    lk
+  }
+
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProof.scala
@@ -1,7 +1,7 @@
 package at.logic.gapt.proofs.resolution
 
 import at.logic.gapt.expr.{ Eq, HOLFormula }
-import at.logic.gapt.proofs.{ Sequent, Suc }
+import at.logic.gapt.proofs.{ Ant, Sequent, Suc }
 import at.logic.gapt.proofs.lk._
 
 object UnitResolutionToLKProof {
@@ -24,11 +24,12 @@ object UnitResolutionToLKProof {
     var lk: LKProof = proof match {
       case Resolution( Refl( term ), _, _, _ ) => ReflexivityAxiom( term )
       case Resolution( left, _, right, _ ) =>
-        if ( shouldFlip( right ) ) {
-          val Sequent( Seq( Eq( t, s ) ), Seq() ) = right.conclusion
-          ResolutionToLKProof.mkSymmProof( t, s )
-        } else {
-          LogicalAxiom( left.conclusion.succedent.head )
+        val sucEq = maybeFlip( right.conclusion( Ant( 0 ) ), shouldFlip( right ) )
+        val antEq = maybeFlip( left.conclusion( Suc( 0 ) ), shouldFlip( left ) )
+        ( antEq, sucEq ) match {
+          case ( x, y ) if x == y => LogicalAxiom( x )
+          case ( Eq( t, s ), Eq( s_, t_ ) ) if t == t_ && s == s_ =>
+            ResolutionToLKProof.mkSymmProof( t, s )
         }
     }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
@@ -31,6 +31,9 @@ object eliminateSplitting {
         val q2 = f( p2 )
         Paramod( q1, q1.conclusion.indexOfInSuc( p1.conclusion( i1 ) ), ltr,
           q2, q2.conclusion.indexOfPol( p2.conclusion( i2 ), i2.isSuc ), ctx )
+      case p @ Flip( p1, i1 ) =>
+        val q1 = f( p1 )
+        Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
       case AvatarAbsurd( p1 ) =>
         val q1 = f( p1 )
@@ -71,6 +74,9 @@ object eliminateSplitting {
         val q2 = f( p2 )
         Paramod( q1, q1.conclusion.indexOfInSuc( p1.conclusion( i1 ) ), ltr,
           q2, q2.conclusion.indexOfPol( p2.conclusion( i2 ), i2.isSuc ), ctx )
+      case p @ Flip( p1, i1 ) =>
+        val q1 = f( p1 )
+        Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
       case AvatarComponentElim( p1, indices, AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
         Subst( f( p1 ), Substitution( vs zip newVs ) )
@@ -106,6 +112,9 @@ object eliminateSplitting {
         val q2 = f( p2 )
         Paramod( q1, q1.conclusion.indexOfInSuc( p1.conclusion( i1 ) ), ltr,
           q2, q2.conclusion.indexOfPol( p2.conclusion( i2 ), i2.isSuc ), ctx )
+      case p @ Flip( p1, i1 ) =>
+        val q1 = f( p1 )
+        Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
       case AvatarComponentIntro( AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
         Subst( proj, Substitution( projVars zip vs ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
@@ -66,6 +66,12 @@ object mapInputClauses {
             res -> ( ( res.occConnectors( 0 ) * conn1 * p.occConnectors( 0 ).inv ) + ( res.occConnectors( 1 ) * conn2 * p.occConnectors( 1 ).inv ) )
           } getOrElse { q2 -> conn2 * p.occConnectors( 1 ).inv }
         } getOrElse { q1 -> conn1 * p.occConnectors( 0 ).inv }
+      case Flip( p1, i1 ) =>
+        val ( q1, conn1 ) = doMap( p1 )
+        conn1.children( i1 ).headOption map { j1 =>
+          val res = Flip( q1, j1 )
+          res -> ( res.occConnectors.head * conn1 * p.occConnectors.head.inv )
+        } getOrElse { q1 -> conn1 * p.occConnectors.head.inv }
 
       case AvatarAbsurd( p1 ) if p1.conclusion.isEmpty =>
         val ( q1, _ ) = doMap( p1 )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/package.scala
@@ -46,6 +46,7 @@ package object resolution {
         case AvatarComponentIntro( component ) => AvatarComponentIntro( TermReplacement( component, repl ) )
         case DefIntro( q, i, defAtom, definition ) =>
           DefIntro( f( q ), i, TermReplacement( defAtom, repl ), TermReplacement( definition, repl ) )
+        case Flip( q, i )                => Flip( f( q ), i )
         case TopL( q, i )                => TopL( f( q ), i )
         case BottomR( q, i )             => BottomR( f( q ), i )
         case NegL( q, i )                => NegL( f( q ), i )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
@@ -71,6 +71,7 @@ trait ResolutionProof extends SequentProof[HOLFormula, ResolutionProof] with Dag
   def introducedDefinitions: Map[HOLAtomConst, LambdaExpression] = Map()
   /**
    * All definitions introduced by any subproof.
+   *
    * @throws Exception if inconsistent definitions are used
    */
   def definitions = {
@@ -470,8 +471,12 @@ case class ExR( subProof: ResolutionProof, idx: SequentIndex, skolemTerm: Lambda
   def mainFormulaSequent = Sequent() :+ instFormula
 }
 
+case class Flip( subProof: ResolutionProof, idx: SequentIndex ) extends PropositionalResolutionRule {
+  val Eq( t, s ) = subProof.conclusion( idx )
+  def mainFormulaSequent = if ( idx isSuc ) Sequent() :+ Eq( s, t ) else Eq( s, t ) +: Sequent()
+}
 object Flip {
-  def apply( subProof: ResolutionProof, equation: SequentIndex ): ResolutionProof = {
+  def simulate( subProof: ResolutionProof, equation: SequentIndex ): ResolutionProof = {
     val Eq( s, t ) = subProof.conclusion( equation )
     val x = rename( Var( "x", s.exptype ), freeVariables( subProof.conclusion ) )
     if ( equation isSuc ) {
@@ -486,4 +491,3 @@ object Flip {
     }
   }
 }
-

--- a/core/src/main/scala/at/logic/gapt/provers/escargot/escargot.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/escargot/escargot.scala
@@ -3,8 +3,9 @@ package at.logic.gapt.provers.escargot
 import at.logic.gapt.expr._
 import at.logic.gapt.formats.tptp.{ TptpParser, resolutionToTptp, tptpProblemToResolution }
 import at.logic.gapt.proofs._
+import at.logic.gapt.proofs.lk.LKProof
 import at.logic.gapt.proofs.resolution._
-import at.logic.gapt.provers.ResolutionProver
+import at.logic.gapt.provers.{ ResolutionProver, groundFreeVariables }
 import at.logic.gapt.provers.escargot.impl.{ EscargotState, StandardInferences }
 import at.logic.gapt.utils.logging.Logger
 
@@ -103,4 +104,12 @@ class Escargot( splitting: Boolean, equality: Boolean, propositional: Boolean ) 
     state.newlyDerived ++= cnf.map { state.InputCls }
     state.loop()
   }
+
+  def getAtomicLKProof( sequent: HOLClause ): Option[LKProof] =
+    groundFreeVariables.wrap( sequent ) { sequent =>
+      getResolutionProof( sequent.map( _.asInstanceOf[HOLAtom] ).
+        map( Sequent() :+ _, _ +: Sequent() ).elements ) map { resolution =>
+        UnitResolutionToLKProof( resolution )
+      }
+    }
 }

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -2222,6 +2222,19 @@ paramodulation; they are explicitly represented using the Subst inference.
 \end{prooftree}
 (We also allow rewriting in the antecedent, and rewriting from right to left.)
 
+\begin{multicols}{2}
+\begin{prooftree}
+  \AxiomC{$\Gamma \vdash \Delta, t=s$}
+  \RightLabel{Flip}
+  \UnaryInfC{$\Gamma \vdash \Delta, s=t$}
+\end{prooftree}
+\begin{prooftree}
+  \AxiomC{$t=s, \Gamma \vdash \Delta$}
+  \RightLabel{Flip}
+  \UnaryInfC{$s=t, \Gamma \vdash \Delta$}
+\end{prooftree}
+\end{multicols}
+
 \subsubsection*{Propositional rules}
 
 \begin{multicols}{2}

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -1286,13 +1286,14 @@ formula: at.logic.gapt.expr.FOLFormula =
 
 gapt> Escargot getResolutionProof formula
 res34: Option[at.logic.gapt.proofs.resolution.ResolutionProof] =
-Some([p46]  :-    (Resolution(p1, Suc(0), p45, Ant(0)))
-[p45] b + (c + (a + d)) = b + (c + (a + d)) :-    (Paramod(p7, Suc(0), true, p44, Ant(0), λx b + (c + (a + d)) = b + (c + x)))
-[p44] b + (c + (a + d)) = b + (c + (d + a)) :-    (Paramod(p19, Suc(0), true, p43, Ant(0), λx b + (c + (a + d)) = x))
-[p43] b + (c + (a + d)) = c + (b + (d + a)) :-    (Paramod(p20, Suc(0), true, p42, Ant(0), λx b + (c + (a + d)) = c + x))
-[p42] b + (c + (a + d)) = c + (d + (b + a)) :-    (Paramod(p21, Suc(0), true, p41, Ant(0), λx b + (c + (a + d)) = x))
-[p41] b + (c + (a + d)) = d + (c + (b + a)) :-    (Resolution(p24, Suc(0), p40, Ant(0)))
-[p40] d + (c + (b + a)) = b + (c + (a + d)) :-    (Paramod(p25, Suc(0), true, p39, Ant(0), λx x = b + ...
+Some([p39]  :-    (Resolution(p1, Suc(0), p38, Ant(0)))
+[p38] b + (c + (a + d)) = b + (c + (a + d)) :-    (Paramod(p7, Suc(0), true, p37, Ant(0), λx b + (c + (a + d)) = b + (c + x)))
+[p37] b + (c + (a + d)) = b + (c + (d + a)) :-    (Paramod(p18, Suc(0), true, p36, Ant(0), λx b + (c + (a + d)) = x))
+[p36] b + (c + (a + d)) = c + (b + (d + a)) :-    (Paramod(p19, Suc(0), true, p35, Ant(0), λx b + (c + (a + d)) = c + x))
+[p35] b + (c + (a + d)) = c + (d + (b + a)) :-    (Paramod(p20, Suc(0), true, p34, Ant(0), λx b + (c + (a + d)) = x))
+[p34] b + (c + (a + d)) = d + (c + (b + a)) :-    (Flip(p33, Ant(0)))
+[p33] d + (c + (b + a)) = b + (c + (a + d)) :-    (Paramod(p21, Suc(0), true, p32, Ant(0), λx x = b + (c + (a + d))))
+[p3...
 \end{clilisting}
 
 \subsection{Built-in tableaux prover}
@@ -1310,6 +1311,21 @@ res35: at.logic.gapt.proofs.lk.LKProof =
 
 \end{clilisting}
 
+The tableaux prover can also prove quasi-tautologies if you call it as \texttt{solveQuasiPropositional}:
+\begin{clilisting}
+gapt> solveQuasiPropositional(hof"a = b & f a = b -> a = f(f(b))").get
+res36: at.logic.gapt.proofs.lk.LKProof =
+[p13]  :- a = b ∧ f(a) = b ⊃ a = f(f(b))    (ImpRightRule(p12, Ant(0), Suc(0)))
+[p12] a = b ∧ f(a) = b :- a = f(f(b))    (AndLeftRule(p11, Ant(0), Ant(1)))
+[p11] a = b, f(a) = b :- a = f(f(b))    (ContractionLeftRule(p10, Ant(2), Ant(1)))
+[p10] f(a) = b, a = b, a = b :- a = f(f(b))    (EqualityLeftRule(p9, Ant(0), Ant(2), λx f(a) = x))
+[p9] a = b, a = b, f(a) = a :- a = f(f(b))    (WeakeningLeftRule(p8, a = b))
+[p8] a = b, f(a) = a :- a = f(f(b))    (EqualityRightRule(p7, Ant(0), Suc(0), λx a = f(f(x))))
+[p7] a = b, f(a) = a :- a = f(f(a))    (WeakeningLeftRule(p6, a = b))
+[p6] f(a) = a :- a = f(f(a))    (ContractionLeftRule(p5, Ant(1), Ant(0)))
+[p5] f(a) = a, f(a) = a :- a = f(f(a))    (EqualityRightRule(p4, Ant(0), Suc(0), λx a = f(x)))
+[p4] f(...
+\end{clilisting}
 
 \subsection{Cut-elimination (Gentzen's method)}
 
@@ -1476,17 +1492,17 @@ proven.  The deep sequent consists of instances of the shallow sequent: the
 sequent.
 \begin{clilisting}
 gapt> expansion.shallow
-res36: at.logic.gapt.proofs.Sequent[at.logic.gapt.expr.HOLFormula] = ∀x ∀y (P(x, y) ⊃ Q(x, y)) :- ∃x ∃y (¬Q(x, y) ⊃ ¬P(x, y))
+res37: at.logic.gapt.proofs.Sequent[at.logic.gapt.expr.HOLFormula] = ∀x ∀y (P(x, y) ⊃ Q(x, y)) :- ∃x ∃y (¬Q(x, y) ⊃ ¬P(x, y))
 
 gapt> expansion.deep
-res37: at.logic.gapt.proofs.Sequent[at.logic.gapt.expr.HOLFormula] =
+res38: at.logic.gapt.proofs.Sequent[at.logic.gapt.expr.HOLFormula] =
 ¬P(x, a) ∨ Q(x, a) ⊃ ¬P(b, y) ∨ Q(b, y),
 P(x, a) ⊃ Q(x, a)
 :-
 ¬Q(b, y) ⊃ ¬P(b, y)
 
 gapt> Sat4j isValid expansion.deep
-res38: Boolean = true
+res39: Boolean = true
 
 \end{clilisting}
 
@@ -1496,7 +1512,7 @@ a procedure to eliminate such cuts in expansion proofs as described
 in~\cite{Hetzl2013Expansion}:
 \begin{clilisting}
 gapt> eliminateCutsET(expansion)
-res39: at.logic.gapt.proofs.expansion.ExpansionProof =
+res40: at.logic.gapt.proofs.expansion.ExpansionProof =
 ∀x ∀y (P(x, y) ⊃ Q(x, y))
   +^{b} (∀y (P(b, y) ⊃ Q(b, y)) +^{a} (P(b, a)+ ⊃ Q(b, a)-))
 :-
@@ -1509,7 +1525,7 @@ We can also convert expansion proofs to LK; this works even in the presence of
 cuts, and also if the proof requires equational reasoning:
 \begin{clilisting}
 gapt> ExpansionProofToLK(expansion).get
-res40: at.logic.gapt.proofs.lk.LKProof =
+res41: at.logic.gapt.proofs.lk.LKProof =
 [p21] ∀x ∀y (P(x, y) ⊃ Q(x, y)) :- ∃x ∃y (¬Q(x, y) ⊃ ¬P(x, y))    (ExistsRightRule(p20, Suc(0), ∃y (¬Q(x, y) ⊃ ¬P(x, y)), b, x))
 [p20] ∀x ∀y (P(x, y) ⊃ Q(x, y)) :- ∃y (¬Q(b, y) ⊃ ¬P(b, y))    (CutRule(p9, Suc(0), p19, Ant(0)))
 [p19] ∀x ∃y (¬P(x, y) ∨ Q(x, y)) :- ∃y (¬Q(b, y) ⊃ ¬P(b, y))    (ForallLeftRule(p18, Ant(0), ∃y (¬P(x, y) ∨ Q(x, y)), b, x))
@@ -1571,46 +1587,48 @@ gapt> cutFormulas(Pi2Pigeonhole.proof) filter {containsQuantifier(_)} foreach pr
 
 gapt> val acnf = CERES(Pi2Pigeonhole.proof)
 acnf: at.logic.gapt.proofs.lk.LKProof =
-[p406] ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
+[p388] ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
 ∀x_2 ∀y_1 (x_2 <= M(x_2, y_1) ∧ y_1 <= M(x_2, y_1)),
 ∀x ∀y_1 (s(x) <= y_1 ⊃ x <= y_1)
 :-
-∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionRightRule(p405, Suc(1), Suc(0)))
-[p405] ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
+∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionRightRule(p387, Suc(1), Suc(0)))
+[p387] ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
 ∀x_2 ∀y_1 (x_2 <= M(x_2, y_1) ∧ y_1 <= M(x_2, y_1)),
 ∀x ∀y_1 (s(x) <= y_1 ⊃ x <= y_1)
 :-
 ∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1)),
-∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionLeftRule(p404, Ant(3), Ant(2)))
-[p404] ∀x_2 ∀y_1 (x_2 <= M(x_2, y_1) ∧ y_1 <= M(x_2, y_1)),
+∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionLeftRule(p386, Ant(3), Ant(2)))
+[p386] ∀x_2 ∀y_1 (x_2 <= M(x_2, y_1) ∧ y_1 <= M(x_2, y_1)),
 ∀x ∀y_1 (s(x) <= y_1 ⊃ x <= y_1),
 ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
 ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0))
 :-
 ∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1)),
-∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionLeftRule(p403, Ant(4), Ant(...
+∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionLeftRule(p385, Ant(4), Ant(...
 gapt> prooftool(acnf)
 
 gapt> val et = LKToExpansionProof(acnf)
 et: at.logic.gapt.proofs.expansion.ExpansionProofWithCut =
 ∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0))
   +^{M(
-      s(M(M(v100, v101), s(M(v100, v101)))),
-      s(M(s(M(M(v100, v101), s(M(v100, v101)))), v102)))}
+      s(M(v100, s(M(s(M(v100, v101)), v1)))),
+      s(M(s(M(v100, v101)), v1)))}
     ((f(M(
-            s(M(M(v100, v101), s(M(v100, v101)))),
-            s(M(s(M(M(v100, v101), s(M(v100, v101)))), v102)))) =
+            s(M(v100, s(M(s(M(v100, v101)), v1)))),
+            s(M(s(M(v100, v101)), v1)))) =
         0)- ∨
       (f(M(
-            s(M(M(v100, v101), s(M(v100, v101)))),
-            s(M(s(M(M(v100, v101), s(M(v100, v101)))), v102)))) =
+            s(M(v100, s(M(s(M(v100, v101)), v1)))),
+            s(M(s(M(v100, v101)), v1)))) =
         s(0))-)
-  +^{M(M(v100, v101), s(M(v100, v101)))}
-    ((f(M(M(v100, v101), s(M(v100, v101)))) = 0)- ∨
-      (f(M(M(v100, v101), s(M(v100, v101)))) = s(0))-)
-  +^{M(s(M(M(v100, v101), s(M(v100, v101)))), v102)}
-    ((f(M(s(M(M(v100, v101), s(M(v100, v101)))), v102)) = 0)- ∨
-      (f(M(s(M(M(v100, v101), s(M(v100, v...
+  +^{M(s(M(v100, s(M(v100, v101)))), s(M(v100, v101)))}
+    ((f(M(s(M(v100, s(M(v100, v101)))), s(M(v100, v101)))) = 0)- ∨
+      (f(M(s(M(v100, s(M(v100, v101)))), s(M(v100, v101)))) = s(0))-)
+  +^{M(s(M(v100, v101)), v1)}
+    ((f(M(s(M(v100, v101)), v1)) = 0)- ∨
+      (f(M(s(M(v100, v101)), v1)) = s(0))-)
+  +^{M(v100, s(M(s(M(v100, v101)), v1)))}
+    ((f(M(v100, s(M(s(...
 gapt> prooftool(et)
 
 \end{clilisting}
@@ -1765,14 +1783,14 @@ Productions:
   x2 -> s(s(0))
 
 gapt> lang.toSet subsetOf grammar.language
-res46: Boolean = true
+res47: Boolean = true
 
 \end{clilisting}
 
 You can also find minimal sub-grammars that still generate certain terms:
 \begin{clilisting}[OpenWBO.isInstalled]
 gapt> minimizeGrammar(grammar, Set(1,2,4,5) map {Numeral(_)})
-res47: at.logic.gapt.grammars.TratGrammar =
+res48: at.logic.gapt.grammars.TratGrammar =
 Axiom: x0
 Non-terminals: x0, x1, x2
 Productions:
@@ -1806,7 +1824,7 @@ P(nil:list) ∧ ∀x ∀y ∀z (P(x) ⊃ P(cons(y:nat, cons(z:nat, x): list))) �
 The built-in prover Escargot can natively solve many-sorted problems:
 \begin{clilisting}
 gapt> Escargot.getExpansionProof(problem)
-res48: Option[at.logic.gapt.proofs.expansion.ExpansionProof] =
+res49: Option[at.logic.gapt.proofs.expansion.ExpansionProof] =
 Some(
 :-
 P(nil:list)- ∧
@@ -1846,7 +1864,7 @@ P_P(f_nil) ∧
 back: at.logic.gapt.proofs.expansion.ExpansionProof => at.logic.gapt.proofs.expansion.ExpansionProof = <function1>
 
 gapt> Prover9 getExpansionProof firstOrderProblem map back
-res49: Option[at.logic.gapt.proofs.expansion.ExpansionProof] =
+res50: Option[at.logic.gapt.proofs.expansion.ExpansionProof] =
 Some(
 :-
 P(nil:list)- ∧

--- a/testing/src/main/scala/regressionTests.scala
+++ b/testing/src/main/scala/regressionTests.scala
@@ -59,6 +59,8 @@ class Prover9TestCase( f: File ) extends RegressionTestCase( f.getParentFile.get
       MiniSAT.isValid( deep ) !-- "minisat validity"
       Sat4j.getResolutionProof( deep ).isDefined !-- "Sat4j proof import"
       solvePropositional( deep ).isRight !-- "solvePropositional"
+    } else {
+      solveQuasiPropositional( deep ).isRight !-- "solveQuasiPropositional"
     }
     ExpansionProofToLK( E ).isRight !-- "expansionProofToLKProof"
     VeriT.isValid( deep ) !-- "verit validity"

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProofTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/UnitResolutionToLKProofTest.scala
@@ -1,0 +1,24 @@
+package at.logic.gapt.proofs.resolution
+
+import at.logic.gapt.expr._
+import at.logic.gapt.proofs.{ Ant, Sequent, Suc }
+import org.specs2.mutable.Specification
+
+class UnitResolutionToLKProofTest extends Specification {
+
+  "flips" in {
+    val p1 = Input( Sequent() :+ hof"a=b" )
+    val p2 = Input( hof"b=a" +: Sequent() )
+
+    UnitResolutionToLKProof( Resolution( Flip( p1, Suc( 0 ) ), p2, hof"b=a" ) ).conclusion.toImplication must_== hof"a=b -> b=a"
+    UnitResolutionToLKProof( Resolution( p1, Flip( p2, Ant( 0 ) ), hof"a=b" ) ).conclusion.toImplication must_== hof"a=b -> b=a"
+  }
+
+  "double flip" in {
+    val p1 = Input( Sequent() :+ hof"a=b" )
+    val p2 = Input( hof"a=b" +: Sequent() )
+
+    UnitResolutionToLKProof( Resolution( Flip( p1, Suc( 0 ) ), Flip( p2, Ant( 0 ) ), hof"b=a" ) ).conclusion.toImplication must_== hof"a=b -> a=b"
+  }
+
+}


### PR DESCRIPTION
This PR adds a new function `UnitResolutionToLKProof` which converts a resolution proof where each clause has at most one literal into a purely unary proof in LK.  In contrast to `ResolutionToLKProof` the conversion reverses the order of the inferences in the proof: from a top-down resolution proof we construct a bottom-up LK proof by taking the contrapositive of each inference rule.

By adding a new `Flip` inference rule, Escargot will now produce such nice resolution proofs: starting from unit clauses, all produced clauses will have at most one literal as well.  As an application, `ExpansionProofToLK` now does not introduce any cuts (except those that are included in the expansion proof).

Additionally, there is now a `solveQuasiPropositional` function providing a general-purpose interface to construct cut-free LK proofs of quasi-tautological sequents.

Fixes #534.