### PR TITLE
vampire: support version 4.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ## Version 2.3 (unreleased)
 
 * Conversion of unit-equational resolution proofs to unary LK proofs
+* Support for Vampire 4.1
 
 ## Version 2.2 (released on 2016-07-09)
 

--- a/core/src/main/scala/at/logic/gapt/formats/tptp/TptpParser.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/tptp/TptpParser.scala
@@ -34,7 +34,7 @@ class TptpParser( val input: ParserInput ) extends Parser {
   def and_formula_part = rule { ( "&" ~ Ws ~ unitary_formula ).+ ~> ( ( a: HOLFormula, as: Seq[HOLFormula] ) => And.leftAssociative( a +: as: _* ) ) }
   def unitary_formula: Rule1[HOLFormula] = rule { quantified_formula | unary_formula | atomic_formula | "(" ~ Ws ~ logic_formula ~ ")" ~ Ws }
   def quantified_formula = rule { fol_quantifier ~ "[" ~ Ws ~ variable_list ~ "]" ~ Ws ~ ":" ~ Ws ~ unitary_formula ~> ( ( q: QuantifierHelper, vs, m ) => q.Block( vs, m ) ) }
-  def variable_list = rule { variable.+.separatedBy( Comma ) }
+  def variable_list = rule { ( variable ~ ( ":" ~ Ws ~ name ).? ~> ( ( a, b ) => a ) ).+.separatedBy( Comma ) }
   def unary_formula = rule { "~" ~ Ws ~ unitary_formula ~> ( Neg( _ ) ) }
 
   def atomic_formula = rule { defined_prop | infix_formula | plain_atomic_formula | ( distinct_object ~> ( FOLAtom( _ ) ) ) }

--- a/core/src/main/scala/at/logic/gapt/formats/tptp/tptpProofParser.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/tptp/tptpProofParser.scala
@@ -2,7 +2,7 @@ package at.logic.gapt.formats.tptp
 
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.{ CNFn, CNFp, univclosure }
-import at.logic.gapt.proofs.resolution.{ AvatarComponent, AvatarGroundComp, AvatarNonGroundComp }
+import at.logic.gapt.proofs.resolution.{ AvatarDefinition, AvatarGroundComp, AvatarNonGroundComp }
 import at.logic.gapt.proofs.sketch._
 import at.logic.gapt.proofs.{ FOLClause, HOLClause, Sequent }
 
@@ -57,7 +57,7 @@ object TptpProofParser {
     }
 
     val memo = mutable.Map[String, Seq[RefutationSketch]]()
-    val splDefs = mutable.Map[( FOLAtom, Boolean ), AvatarComponent]()
+    val splDefs = mutable.Map[( FOLAtom, Boolean ), AvatarDefinition]()
     val splAtoms = mutable.Set[FOLAtom]()
     def filterVampireSplits( clause: FOLClause ): FOLClause = clause.filterNot( splAtoms )
     def convertAvatarDefinition( defn: HOLFormula, splAtom: FOLAtom ): Seq[RefutationSketch] = {

--- a/core/src/main/scala/at/logic/gapt/formats/tptp/tptpProofParser.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/tptp/tptpProofParser.scala
@@ -4,7 +4,7 @@ import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.{ CNFn, CNFp, univclosure }
 import at.logic.gapt.proofs.resolution.{ AvatarComponent, AvatarGroundComp, AvatarNonGroundComp }
 import at.logic.gapt.proofs.sketch._
-import at.logic.gapt.proofs.{ FOLClause, Sequent }
+import at.logic.gapt.proofs.{ FOLClause, HOLClause, Sequent }
 
 import scala.collection.mutable
 
@@ -57,32 +57,34 @@ object TptpProofParser {
     }
 
     val memo = mutable.Map[String, Seq[RefutationSketch]]()
-    val splDefs = mutable.Set[AvatarComponent]()
-    def filterVampireSplits( clause: FOLClause ): FOLClause =
-      clause.filter {
-        case FOLAtom( name, Seq() ) if name startsWith "$spl" => false
-        case _ => true
+    val splDefs = mutable.Map[( FOLAtom, Boolean ), AvatarComponent]()
+    val splAtoms = mutable.Set[FOLAtom]()
+    def filterVampireSplits( clause: FOLClause ): FOLClause = clause.filterNot( splAtoms )
+    def convertAvatarDefinition( defn: HOLFormula, splAtom: FOLAtom ): Seq[RefutationSketch] = {
+      val All.Block( vs, clauseDisj ) = defn
+      splAtoms += splAtom
+      val comps = defn match {
+        case splAtom @ FOLAtom( _, _ ) if freeVariables( splAtom ).isEmpty =>
+          Seq( false, true ) map { AvatarGroundComp( splAtom, _ ) }
+        case Neg( splAtom @ FOLAtom( _, _ ) ) if freeVariables( splAtom ).isEmpty =>
+          Seq( false, true ) map { AvatarGroundComp( splAtom, _ ) }
+        case _ =>
+          Seq( AvatarNonGroundComp( splAtom, AvatarNonGroundComp.DefinitionFormula.canonize( defn ) ) )
       }
+      comps map { comp =>
+        splDefs( ( splAtom, comp.assertion.succedent.nonEmpty ) ) = comp
+        SketchComponentIntro( comp )
+      }
+    }
     def convert( stepName: String ): Seq[RefutationSketch] = memo.getOrElseUpdate( stepName, steps( stepName ) match {
-      case AnnotatedFormula( "fof", _, "plain", And( Imp( defn @ All.Block( vs, clauseDisj ), Neg( splAtom: FOLAtom ) ), _ ), TptpTerm( "introduced", TptpTerm( "sat_splitting_component" ), _ ) +: _ ) =>
-        val comps = defn match {
-          case splAtom @ FOLAtom( _, _ ) if freeVariables( splAtom ).isEmpty =>
-            Seq( false, true ) map { AvatarGroundComp( splAtom, _ ) }
-          case Neg( splAtom @ FOLAtom( _, _ ) ) if freeVariables( splAtom ).isEmpty =>
-            Seq( false, true ) map { AvatarGroundComp( splAtom, _ ) }
-          case _ =>
-            Seq( AvatarNonGroundComp( splAtom, AvatarNonGroundComp.DefinitionFormula.canonize( defn ) ) )
-        }
-        comps map { comp =>
-          splDefs += comp
-          SketchComponentIntro( comp )
-        }
+      case AnnotatedFormula( "fof", _, "plain", And( Imp( defn, Neg( splAtom: FOLAtom ) ), _ ), TptpTerm( "introduced", TptpTerm( "sat_splitting_component" ), _ ) +: _ ) =>
+        convertAvatarDefinition( defn, splAtom )
       case AnnotatedFormula( "fof", _, "plain", Bottom(), ( justification @ TptpTerm( "inference", TptpTerm( "sat_splitting_refutation" ), _, _ ) ) +: _ ) =>
         val sketchParents = getParents( justification ) flatMap convert
         val splitParents = sketchParents map { parent0 =>
           var parent = parent0
           while ( parent.conclusion.nonEmpty ) {
-            val ( comp, subst ) = splDefs.view.
+            val ( comp, subst ) = splDefs.values.view.
               flatMap { d => clauseSubsumption( d.clause, parent.conclusion ) filter { _.isInjectiveRenaming } map { d -> _ } }.
               headOption.getOrElse {
                 throw new IllegalArgumentException( parent.conclusion.toString )
@@ -96,6 +98,27 @@ object TptpProofParser {
           parent
         }
         Seq( SketchSplitCombine( splitParents ) )
+      case AnnotatedFormula( "fof", _, "plain", And( Imp( splAtom: FOLAtom, defn ), _ ), TptpTerm( "introduced", FOLVar( "AVATAR_definition" ), _ ) +: _ ) =>
+        convertAvatarDefinition( defn, splAtom )
+      case AnnotatedFormula( "fof", _, "plain", disj, ( justification @ TptpTerm( "inference", FOLVar( "AVATAR_split_clause" ), _, _ ) ) +: _ ) =>
+        val Seq( assertion ) = CNFp.toClauseList( disj )
+        val Seq( splittedClause, _* ) = getParents( justification ) flatMap convert
+
+        var p = splittedClause
+        for {
+          ( splAtom: FOLAtom, i ) <- assertion.zipWithIndex
+          comp <- splDefs.get( ( splAtom, i.isSuc ) )
+          subst <- clauseSubsumption( comp.clause, p.conclusion )
+        } p = SketchComponentElim( p, comp match {
+          case comp @ AvatarNonGroundComp( _, _, vars ) =>
+            comp.copy( vars = subst( vars ).map( _.asInstanceOf[Var] ) )
+          case AvatarGroundComp( _, _ ) => comp
+        } )
+
+        require( p.conclusion.isEmpty, s"$assertion\n$splittedClause\n$splDefs" )
+        Seq( p )
+      case AnnotatedFormula( "fof", _, "plain", Bottom(), ( justification @ TptpTerm( "inference", FOLVar( "AVATAR_sat_refutation" ), _, _ ) ) +: _ ) =>
+        Seq( SketchSplitCombine( getParents( justification ).flatMap( convert ) ) )
       case AnnotatedFormula( "fof", _, "conjecture", _, TptpTerm( "file", _, TptpTerm( label ) ) +: _ ) =>
         labelledCNF( label ) map SketchAxiom
       case AnnotatedFormula( _, _, _, axiom: FOLFormula, TptpTerm( "file", _, TptpTerm( label ) ) +: _ ) =>

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -133,10 +133,10 @@ object ResolutionToExpansionProof {
         propg_( p, q1, _.map( es => es._1 -> oc1.parent( es._2 ).updated( i1, ETAtom( es._1( q1.conclusion( i1 ) ).asInstanceOf[HOLAtom], false ) ) ) )
         propg( p, q2, _.map( es => es._1 -> oc2.parent( es._2 ).updated( i2, replaceWithContext( es._2( p.mainIndices.head ), es._1( ctx ).asInstanceOf[Abs], es._1( p.t ) ) ) ) )
 
-      case p @ AvatarComponentElim( q, indices, AvatarGroundComp( atom, pol ) ) =>
+      case p @ AvatarSplit( q, indices, AvatarGroundComp( atom, pol ) ) =>
         val Seq( oc ) = p.occConnectors
         propg( p, q, _.map( _.map2( es => oc.parent( es, ETAtom( atom, !pol ) ) ) ) )
-      case p @ AvatarComponentElim( q, indices, comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
+      case p @ AvatarSplit( q, indices, comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
         val renaming = Substitution( for ( v <- freeVariables( comp.clause ) ) yield v -> nameGen.fresh( v ) )
         splitDefn( splAtom ) = definition
         splitCutL( splAtom ) ::= ETStrongQuantifierBlock(
@@ -149,11 +149,11 @@ object ResolutionToExpansionProof {
           case ( Seq( et ), _ ) => et
           case ( Seq(), idx )   => ETAtom( renaming( q.conclusion( idx ) ).asInstanceOf[HOLAtom], idx.isAnt )
         } ) )
-      case p @ AvatarComponentIntro( AvatarGroundComp( _, _ ) ) =>
+      case p @ AvatarComponent( AvatarGroundComp( _, _ ) ) =>
         clear( p )
-      case p @ AvatarComponentIntro( AvatarNegNonGroundComp( _, _, _, _ ) ) =>
+      case p @ AvatarComponent( AvatarNegNonGroundComp( _, _, _, _ ) ) =>
         clear( p )
-      case p @ AvatarComponentIntro( AvatarNonGroundComp( splAtom, definition, vars ) ) =>
+      case p @ AvatarComponent( AvatarNonGroundComp( splAtom, definition, vars ) ) =>
         splitDefn( splAtom ) = definition
         splitCutR( splAtom ) ::= ETWeakQuantifierBlock(
           definition, vars.size,
@@ -161,7 +161,7 @@ object ResolutionToExpansionProof {
             yield s( vars ) -> es.toDisjunction( false )
         )
         clear( p )
-      case p @ AvatarAbsurd( q ) =>
+      case p @ AvatarContradiction( q ) =>
         propg( p, q, _ => sequent2expansions( q.conclusion ) )
 
       case p: Flip =>

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
@@ -57,20 +57,20 @@ object ResolutionToLKProof {
         else
           ParamodulationRightRule( f( q1 ), q1.conclusion( i1 ), f( q2 ), q2.conclusion( i2 ), ctx )
 
-      case p @ AvatarAbsurd( q ) => f( q )
-      case AvatarComponentIntro( comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
+      case p @ AvatarContradiction( q ) => f( q )
+      case AvatarComponent( comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
         val \/-( p1 ) = solvePropositional( comp.disjunction +: comp.clause )
         val p2 = ForallLeftBlock( p1, definition, vars )
         val p3 = DefinitionLeftRule( p2, definition, splAtom )
         p3
-      case AvatarComponentIntro( AvatarGroundComp( atom, _ ) ) => LogicalAxiom( atom )
-      case AvatarComponentIntro( comp @ AvatarNegNonGroundComp( splAtom, definition, vars, idx ) ) =>
+      case AvatarComponent( AvatarGroundComp( atom, _ ) ) => LogicalAxiom( atom )
+      case AvatarComponent( comp @ AvatarNegNonGroundComp( splAtom, definition, vars, idx ) ) =>
         val \/-( p1 ) = solvePropositional( comp.clause :+ comp.disjunction )
         val p2 = ForallRightBlock( p1, definition, vars )
         val p3 = DefinitionRightRule( p2, definition, splAtom )
         p3
-      case AvatarComponentElim( q, indices, AvatarGroundComp( _, _ ) ) => f( q )
-      case p @ AvatarComponentElim( q, _, comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
+      case AvatarSplit( q, indices, AvatarGroundComp( _, _ ) ) => f( q )
+      case p @ AvatarSplit( q, _, comp @ AvatarNonGroundComp( splAtom, definition, vars ) ) =>
         var p_ = f( q )
         for ( a <- comp.clause.antecedent ) p_ = NegRightRule( p_, a )
         def mkOr( lits: HOLFormula ): Unit =

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/eliminateSplitting.scala
@@ -6,13 +6,13 @@ import at.logic.gapt.proofs.HOLSequent
 import scala.collection.mutable
 
 /**
- * Eliminate [[AvatarComponentElim]], [[AvatarComponentIntro]], [[AvatarAbsurd]]
+ * Eliminate [[AvatarSplit]], [[AvatarComponent]], [[AvatarContradiction]]
  * splitting inferences from a resolution proof.
  */
 object eliminateSplitting {
 
   def apply( p: ResolutionProof ): ResolutionProof = {
-    if ( !p.subProofs.exists { _.isInstanceOf[AvatarAbsurd] } ) return p
+    if ( !p.subProofs.exists { _.isInstanceOf[AvatarContradiction] } ) return p
     nonGroundSplits( groundSplits( p ) )
   }
 
@@ -35,20 +35,20 @@ object eliminateSplitting {
         val q1 = f( p1 )
         Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
-      case AvatarAbsurd( p1 ) =>
+      case AvatarContradiction( p1 ) =>
         val q1 = f( p1 )
-        if ( q1.assertions.isEmpty ) q1 else AvatarAbsurd( q1 )
-      case AvatarComponentIntro( AvatarGroundComp( atom, _ ) )          => Taut( atom )
-      case AvatarComponentElim( p1, indices, AvatarGroundComp( _, _ ) ) => f( p1 )
-      case AvatarComponentElim( p1, indices, comp ) =>
-        AvatarComponentElim( f( p1 ), comp )
+        if ( q1.assertions.isEmpty ) q1 else AvatarContradiction( q1 )
+      case AvatarComponent( AvatarGroundComp( atom, _ ) )       => Taut( atom )
+      case AvatarSplit( p1, indices, AvatarGroundComp( _, _ ) ) => f( p1 )
+      case AvatarSplit( p1, indices, comp ) =>
+        AvatarSplit( f( p1 ), comp )
       case _ => p
     } ) )
     f( p )
   }
 
   private def project( p: ResolutionProof, splAtom: HOLAtom ): ( ResolutionProof, Seq[Var], HOLSequent ) = {
-    val ngc = p.subProofs.collect { case AvatarComponentElim( _, _, comp @ AvatarNonGroundComp( `splAtom`, _, _ ) ) => comp }.head
+    val ngc = p.subProofs.collect { case AvatarSplit( _, _, comp @ AvatarNonGroundComp( `splAtom`, _, _ ) ) => comp }.head
     val newVs = ngc.vars map rename( ngc.vars, freeVariables( p.subProofs.flatMap( _.conclusion.elements ) ) )
     val newClause = Substitution( ngc.vars zip newVs )( ngc.clause )
 
@@ -78,10 +78,10 @@ object eliminateSplitting {
         val q1 = f( p1 )
         Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
-      case AvatarComponentElim( p1, indices, AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
+      case AvatarSplit( p1, indices, AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
         Subst( f( p1 ), Substitution( vs zip newVs ) )
-      case AvatarComponentElim( p1, indices, comp ) =>
-        AvatarComponentElim( f( p1 ), comp )
+      case AvatarSplit( p1, indices, comp ) =>
+        AvatarSplit( f( p1 ), comp )
       case _ => p
     } ) )
 
@@ -116,10 +116,10 @@ object eliminateSplitting {
         val q1 = f( p1 )
         Flip( q1, q1.conclusion.indexOfPol( p1.conclusion( i1 ), i1.isSuc ) )
       case Subst( p1, subst ) => Subst( f( p1 ), subst )
-      case AvatarComponentIntro( AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
+      case AvatarComponent( AvatarNonGroundComp( `splAtom`, _, vs ) ) =>
         Subst( proj, Substitution( projVars zip vs ) )
-      case AvatarComponentElim( p1, indices, comp ) =>
-        AvatarComponentElim( f( p1 ), comp )
+      case AvatarSplit( p1, indices, comp ) =>
+        AvatarSplit( f( p1 ), comp )
       case _ => p
     } ) )
     f( p )
@@ -128,34 +128,34 @@ object eliminateSplitting {
   private def nonGroundSplits( p: ResolutionProof ): ResolutionProof = {
     val memo = mutable.Map[ResolutionProof, ResolutionProof]()
     def f( p: ResolutionProof ): ResolutionProof = memo.getOrElseUpdate( p, p match {
-      case AvatarAbsurd( p1 ) => AvatarAbsurd( Factor( p1 ) )
+      case AvatarContradiction( p1 ) => AvatarContradiction( Factor( p1 ) )
       case Resolution( p1, i1, p2, i2 ) =>
         val splAtom = p1.conclusion( i1 ).asInstanceOf[HOLAtom]
         ( f( p1 ), f( p2 ) ) match {
-          case ( Factor.Block( AvatarAbsurd( q1 ) ), Factor.Block( AvatarAbsurd( q2 ) ) ) =>
+          case ( Factor.Block( AvatarContradiction( q1 ) ), Factor.Block( AvatarContradiction( q2 ) ) ) =>
             if ( q1.assertions.succedent.contains( splAtom ) ) {
               val ( proj, projVars, projClause ) = project( q1, splAtom )
               val repld = replace( q2, splAtom, proj, projVars, projClause )
-              Factor( if ( repld.assertions.nonEmpty ) AvatarAbsurd( repld ) else repld )
+              Factor( if ( repld.assertions.nonEmpty ) AvatarContradiction( repld ) else repld )
             } else {
-              AvatarAbsurd( Factor( Resolution.maybe( Factor( q1 ), Factor( q2 ), splAtom ) ) )
+              AvatarContradiction( Factor( Resolution.maybe( Factor( q1 ), Factor( q2 ), splAtom ) ) )
             }
-          case ( Factor.Block( AvatarAbsurd( q1 ) ), q2 ) =>
-            AvatarAbsurd( Factor( Resolution.maybe( Factor( q1 ), q2, splAtom ) ) )
-          case ( q1, Factor.Block( AvatarAbsurd( q2 ) ) ) =>
-            AvatarAbsurd( Factor( Resolution.maybe( q1, Factor( q2 ), splAtom ) ) )
+          case ( Factor.Block( AvatarContradiction( q1 ) ), q2 ) =>
+            AvatarContradiction( Factor( Resolution.maybe( Factor( q1 ), q2, splAtom ) ) )
+          case ( q1, Factor.Block( AvatarContradiction( q2 ) ) ) =>
+            AvatarContradiction( Factor( Resolution.maybe( q1, Factor( q2 ), splAtom ) ) )
           case ( q1, q2 ) =>
             Factor( Resolution.maybe( q1, q2, splAtom ) )
         }
       case Factor( p1, i1, i2 ) => f( p1 )
       case _ =>
-        require( !p.subProofs.exists { _.isInstanceOf[AvatarAbsurd] } )
+        require( !p.subProofs.exists { _.isInstanceOf[AvatarContradiction] } )
         p
     } )
 
     f( p ) match {
-      case AvatarAbsurd( q ) => q
-      case q                 => q
+      case AvatarContradiction( q ) => q
+      case q                        => q
     }
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/mapInputClauses.scala
@@ -73,13 +73,13 @@ object mapInputClauses {
           res -> ( res.occConnectors.head * conn1 * p.occConnectors.head.inv )
         } getOrElse { q1 -> conn1 * p.occConnectors.head.inv }
 
-      case AvatarAbsurd( p1 ) if p1.conclusion.isEmpty =>
+      case AvatarContradiction( p1 ) if p1.conclusion.isEmpty =>
         val ( q1, _ ) = doMap( p1 )
-        val res = AvatarAbsurd( q1 )
+        val res = AvatarContradiction( q1 )
         res -> OccConnector.guessInjection( p.conclusion, res.conclusion )
-      case AvatarComponentElim( p1, indices, comp ) =>
+      case AvatarSplit( p1, indices, comp ) =>
         val ( q1, conn1 ) = doMap( p1 )
-        val res = AvatarComponentElim( q1, comp )
+        val res = AvatarSplit( q1, comp )
         res -> res.occConnectors.head * conn1 * p.occConnectors.head.inv
 
       // FIXME: support for propositional part

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
@@ -45,11 +45,11 @@ import scala.collection.mutable
  *     [[DefIntro]] and [[Taut]] is used to introduce definitions for subformulas.
  *   <li> [[Resolution]], [[Paramod]], [[Subst]]. [[Factor]], [[Refl]], [[Taut]] for the
  *     refutation of the resulting clauses.  Clauses are split by successively
- *     applying [[AvatarComponentElim]], reducing the clause to an empty clause.
- *     The clause components can then be used using [[AvatarComponentIntro]].
+ *     applying [[AvatarSplit]], reducing the clause to an empty clause.
+ *     The clause components can then be used using [[AvatarComponent]].
  *   <li> Each empty clause of a splitting branch is followed by an
- *     [[AvatarAbsurd]] inference, moving the assertion back to the clause.
- *   <li> A [[Resolution]] refutation of the [[AvatarAbsurd]] clauses.
+ *     [[AvatarContradiction]] inference, moving the assertion back to the clause.
+ *   <li> A [[Resolution]] refutation of the [[AvatarContradiction]] clauses.
  * </ol>
  *
  * Substitutions are not absorbed into resolution, factoring, and

--- a/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
@@ -55,11 +55,11 @@ case class SketchInference( conclusion: FOLClause, from: Seq[RefutationSketch] )
   override def productElement( n: Int ) = if ( n == 0 ) conclusion else from( n - 1 )
 }
 
-case class SketchComponentIntro( component: AvatarComponent ) extends RefutationSketch {
+case class SketchComponentIntro( component: AvatarDefinition ) extends RefutationSketch {
   def immediateSubProofs = Seq()
   def conclusion = component.clause.map( _.asInstanceOf[FOLAtom] )
 }
-case class SketchComponentElim( subProof: RefutationSketch, component: AvatarComponent ) extends RefutationSketch {
+case class SketchComponentElim( subProof: RefutationSketch, component: AvatarDefinition ) extends RefutationSketch {
   def immediateSubProofs = Seq( subProof )
   val conclusion = subProof.conclusion diff component.clause
 }
@@ -111,14 +111,14 @@ object RefutationSketchToResolution {
         import Validation.FlatMap._
         Applicative[ErrorOr].traverse( cases.toList )( solve ).flatMap { solvedCases =>
           solvedCases.find( p => p.conclusion.isEmpty && p.assertions.isEmpty ).
-            orElse( Sat4j.getResolutionProof( solvedCases.map( AvatarAbsurd( _ ) ) ) ).
+            orElse( Sat4j.getResolutionProof( solvedCases.map( AvatarContradiction( _ ) ) ) ).
             map( _.success ).getOrElse( UnprovableSketchInference( s ).failureNel )
         }
       case SketchComponentElim( from, comp ) =>
         for ( solvedFrom <- solve( from ) )
-          yield AvatarComponentElim( solvedFrom, comp )
+          yield AvatarSplit( solvedFrom, comp )
       case SketchComponentIntro( comp ) =>
-        AvatarComponentIntro( comp ).success
+        AvatarComponent( comp ).success
     } )
     solve( sketch ) map { simplifyResolutionProof( _ ) }
   }

--- a/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
@@ -4,7 +4,7 @@ import at.logic.gapt.expr.{ FOLAtom, HOLAtom, clauseSubsumption }
 import at.logic.gapt.proofs.resolution._
 import at.logic.gapt.proofs.{ FOLClause, HOLClause, OccConnector, SequentProof }
 import at.logic.gapt.provers.ResolutionProver
-import at.logic.gapt.provers.escargot.NonSplittingEscargot
+import at.logic.gapt.provers.escargot.{ Escargot, NonSplittingEscargot }
 import at.logic.gapt.provers.sat.Sat4j
 
 import scala.collection.mutable
@@ -112,6 +112,7 @@ object RefutationSketchToResolution {
         Applicative[ErrorOr].traverse( cases.toList )( solve ).flatMap { solvedCases =>
           solvedCases.find( p => p.conclusion.isEmpty && p.assertions.isEmpty ).
             orElse( Sat4j.getResolutionProof( solvedCases.map( AvatarContradiction( _ ) ) ) ).
+            orElse( NonSplittingEscargot.getResolutionProof( solvedCases.map( AvatarContradiction( _ ) ) ) ).
             map( _.success ).getOrElse( UnprovableSketchInference( s ).failureNel )
         }
       case SketchComponentElim( from, comp ) =>

--- a/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sketch/refutationSketch.scala
@@ -74,7 +74,9 @@ case class SketchSplitCombine( splitCases: Seq[RefutationSketch] ) extends Refut
   override def productElement( n: Int ) = splitCases( n )
 }
 
-case class UnprovableSketchInference( inference: RefutationSketch )
+case class UnprovableSketchInference( inference: RefutationSketch ) {
+  override def toString = s"Unprovable inference:\n$inference\n"
+}
 
 object RefutationSketchToResolution {
   /**

--- a/core/src/main/scala/at/logic/gapt/provers/escargot/inferences.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/escargot/inferences.scala
@@ -384,11 +384,11 @@ class StandardInferences( state: EscargotState, propositional: Boolean ) {
         for ( comp <- propComps; if !componentAlreadyDefined( comp.atom ) ) {
           componentAlreadyDefined += comp.atom
           for ( pol <- Seq( false, true ) )
-            inferred += DerivedCls( given, AvatarComponentIntro( AvatarGroundComp( comp.atom, pol ) ) )
+            inferred += DerivedCls( given, AvatarComponent( AvatarGroundComp( comp.atom, pol ) ) )
         }
         for ( comp <- nonPropComps if !componentAlreadyDefined( comp.atom ) ) {
           componentAlreadyDefined += comp.atom
-          inferred += DerivedCls( given, AvatarComponentIntro( comp ) )
+          inferred += DerivedCls( given, AvatarComponent( comp ) )
         }
 
         ( inferred, Set( given ) )

--- a/core/src/main/scala/at/logic/gapt/provers/escargot/state.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/escargot/state.scala
@@ -153,7 +153,7 @@ class EscargotState extends Logger {
             switchToNewModel( newModel )
           case None =>
             return Some( emptyClauses.get( Sequent() ).map( _.proof ).getOrElse {
-              Sat4j.getResolutionProof( emptyClauses.values.map( cls => AvatarAbsurd( cls.proof ) ) ).get
+              Sat4j.getResolutionProof( emptyClauses.values.map( cls => AvatarContradiction( cls.proof ) ) ).get
             } )
         }
       }

--- a/core/src/main/scala/at/logic/gapt/provers/vampire/vampire.scala
+++ b/core/src/main/scala/at/logic/gapt/provers/vampire/vampire.scala
@@ -10,6 +10,8 @@ import at.logic.gapt.proofs.sketch.RefutationSketchToResolution
 import at.logic.gapt.provers.{ ResolutionProver, renameConstantsToFi }
 import at.logic.gapt.utils.{ ExternalProgram, runProcess }
 
+import scalaz.Success
+
 object Vampire extends Vampire
 class Vampire extends ResolutionProver with ExternalProgram {
   override def getResolutionProof( seq: Traversable[HOLClause] ): Option[ResolutionProof] =
@@ -22,7 +24,8 @@ class Vampire extends ResolutionProver with ExternalProgram {
         ), tptpIn ).split( "\n" )
         if ( output.head startsWith "Refutation" ) {
           val sketch = TptpProofParser.parse( output.drop( 1 ).takeWhile( !_.startsWith( "---" ) ).mkString( "\n" ) )._2
-          RefutationSketchToResolution( sketch ) map { fixDerivation( _, cnf ) } toOption
+          val Success( resolution ) = RefutationSketchToResolution( sketch )
+          Some( fixDerivation( resolution, cnf ) )
         } else None
       }
     )

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -2381,20 +2381,22 @@ $C$.
 
 \begin{prooftree}
   \AxiomC{$C, S \leftarrow A$}
-  \RightLabel{AvatarComponentElim}
+  \RightLabel{AvatarSplit}
   \UnaryInfC{$S \leftarrow A \land \neg[C]$}
 \end{prooftree}
+(For simplicity, the AvatarSplit rule only splits away a single clause
+component at a time.)
 
 \begin{prooftree}
   \AxiomC{}
-  \RightLabel{AvatarComponentIntro}
+  \RightLabel{AvatarComponent}
   \UnaryInfC{$C \leftarrow [C]$}
 \end{prooftree}
 
 \begin{prooftree}
   \AxiomC{$\Gamma \vdash \Delta \:\leftarrow\:
     a_1 \land a_2 \land \cdots \land \neg b_1 \land \neg b_2 \land \cdots $}
-  \RightLabel{AvatarAbsurd}
+  \RightLabel{AvatarContradiction}
   \UnaryInfC{$a_1, a_2, \ldots, \Gamma \vdash \Delta, b_1, b_2, \ldots \:\leftarrow\: \top$}
 \end{prooftree}
 

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/EliminateSplittingTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/EliminateSplittingTest.scala
@@ -12,10 +12,10 @@ class EliminateSplittingTest extends Specification {
     val Some( proofWithSplitting ) = Escargot getResolutionProof hof"!x p x | !x q x -> !x (p x | q x) & ${BussTautology( 2 ).toImplication}"
     val proofWithoutSplitting = eliminateSplitting( proofWithSplitting )
     proofWithoutSplitting.subProofs foreach {
-      case AvatarAbsurd( _ )              => ko
-      case AvatarComponentIntro( _ )      => ko
-      case AvatarComponentElim( _, _, _ ) => ko
-      case _                              => ok
+      case AvatarContradiction( _ ) => ko
+      case AvatarComponent( _ )     => ko
+      case AvatarSplit( _, _, _ )   => ko
+      case _                        => ok
     }
     proofWithoutSplitting.isProof must_== true
   }

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
@@ -103,12 +103,12 @@ class ResolutionTest extends Specification with SatMatchers {
     val comp2 = AvatarNonGroundComp( hoa"spl2", hof"!x q x", Seq( hov"y" ) )
     val split = AvatarSplit( c1, Seq( comp1, comp2 ) )
 
-    val p1 = AvatarComponentIntro( comp1 )
-    val p2 = AvatarComponentIntro( comp2.copy( vars = Seq( hov"x" ) ) )
+    val p1 = AvatarComponent( comp1 )
+    val p2 = AvatarComponent( comp2.copy( vars = Seq( hov"x" ) ) )
 
-    val case1 = AvatarAbsurd( Resolution( Subst( p1, Substitution( hov"x" -> le"c" ) ), Suc( 0 ), c2, Ant( 0 ) ) )
-    val case2 = AvatarAbsurd( Resolution( Subst( p2, Substitution( hov"x" -> le"d" ) ), Suc( 0 ), c3, Ant( 0 ) ) )
-    val proof = Resolution( Resolution( AvatarAbsurd( split ), Suc( 0 ), case1, Ant( 0 ) ), Suc( 0 ), case2, Ant( 0 ) )
+    val case1 = AvatarContradiction( Resolution( Subst( p1, Substitution( hov"x" -> le"c" ) ), Suc( 0 ), c2, Ant( 0 ) ) )
+    val case2 = AvatarContradiction( Resolution( Subst( p2, Substitution( hov"x" -> le"d" ) ), Suc( 0 ), c3, Ant( 0 ) ) )
+    val proof = Resolution( Resolution( AvatarContradiction( split ), Suc( 0 ), case1, Ant( 0 ) ), Suc( 0 ), case2, Ant( 0 ) )
     proof.isProof must_== true
 
     ResolutionToExpansionProof.withDefs( proof ).deep must beValidSequent

--- a/tests/src/test/scala/at/logic/gapt/provers/spass/SpassTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/provers/spass/SpassTest.scala
@@ -3,7 +3,7 @@ package at.logic.gapt.provers.spass
 import at.logic.gapt.examples.CountingEquivalence
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.fol.{ naive, thresholds }
-import at.logic.gapt.proofs.resolution.{ AvatarComponentIntro, AvatarNegNonGroundComp, ResolutionToLKProof }
+import at.logic.gapt.proofs.resolution.{ AvatarComponent, AvatarNegNonGroundComp, ResolutionToLKProof }
 import at.logic.gapt.proofs.{ Clause, HOLSequent, Sequent, SequentMatchers }
 import at.logic.gapt.utils.SatMatchers
 import org.specs2.mutable.Specification
@@ -64,7 +64,7 @@ class SpassTest extends Specification with SequentMatchers with SatMatchers {
 
     "bug with ground parts in quantified splits" in {
       val Some( res ) = SPASS.getResolutionProof( CountingEquivalence( 1 ) )
-      res.subProofs.collect { case AvatarComponentIntro( c: AvatarNegNonGroundComp ) => c } must not( beEmpty )
+      res.subProofs.collect { case AvatarComponent( c: AvatarNegNonGroundComp ) => c } must not( beEmpty )
       ResolutionToLKProof( res )
       ok
     }

--- a/tests/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/provers/vampire/vampireTest.scala
@@ -5,8 +5,9 @@ import at.logic.gapt.expr.fol.{ naive, thresholds }
 import at.logic.gapt.proofs.{ Clause, HOLSequent, Sequent, SequentMatchers }
 import org.specs2.mutable._
 import at.logic.gapt.expr._
+import at.logic.gapt.utils.SatMatchers
 
-class VampireTest extends Specification with SequentMatchers {
+class VampireTest extends Specification with SequentMatchers with SatMatchers {
 
   args( skipAll = !Vampire.isInstalled )
 
@@ -104,6 +105,17 @@ class VampireTest extends Specification with SequentMatchers {
     }
 
     "large cnf" in { Vampire getResolutionProof CountingEquivalence( 2 ) must beSome }
+
+    "smt splitting" in {
+      val smtVampire = new Vampire( extraArgs = Seq( "-sas", "z3" ) )
+      if ( !smtVampire.isInstalled ) skipped
+      smtVampire getExpansionProof hof"""
+          a=b | b=c | c=d | !x f x = g x ->
+            f a = f b | f b = f c | f c = f d | f a = g a
+        """ must beLike {
+        case Some( proof ) => proof.deep must beEValidSequent
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This adds support for the changed proof output in Vampire 4.1 as presented yesterday at the Vampire workshop.

 * Splitting with SMT is not yet supported.  (Vampire only does this when explictly requested with the "-sas z3" flag.)  Unfortunately, Vampire calls both SAT and SMT refutations `AVATAR_sat_refutation` so we  can't tell from the output whether we need equality or not...  Come to think of it, I'll probably just add a fallback to Escargot if Sat4j says it's satisifiable (and hence requires equality).
 * Vampire now uses inferences that more closely resemble GAPT's.  However, the naming is quite different.  Should we adapt our names to match?  (Vampire seems to be most well-known implementation of Avatar at the moment, and adopting their naming might help to prevent confusion.)
  * `AvatarComponent` -> `AvatarDefinition`
  * `AvatarComponentIntro` -> `AvatarComponent(Clause)`
  * `AvatarComponentElim` -> `AvatarSplit(Clause)`
  * `AvatarAbsurd` -> `AvatarContradiction(Clause)`

To do:
 * Release notes
 * Inference names
 * SMT support