### PR TITLE
Context: polymorphic constant declarations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 * Special class for polarities instead of Booleans
 * Support for Vampire 4.1
 * Support for SPASS 3.9
+* Context now support polymorphic declarations (for equality, ...)
 
 ## Version 2.2 (released on 2016-07-09)
 

--- a/core/src/main/scala/at/logic/gapt/expr/utils.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/utils.scala
@@ -105,12 +105,11 @@ object freeVariables {
  * Returns the set of non-logical constants occuring in the given argument.
  */
 object constants {
-  def apply( expression: LambdaExpression ): Set[Const] = {
+  def all( expression: LambdaExpression ): Set[Const] = {
     val cs = mutable.Set[Const]()
     def f( e: LambdaExpression ): Unit = e match {
-      case _: Var             =>
-      case _: LogicalConstant =>
-      case c: Const           => cs += c
+      case _: Var   =>
+      case c: Const => cs += c
       case App( exp, arg ) =>
         f( exp ); f( arg )
       case Abs( v, exp ) => f( exp )
@@ -118,6 +117,8 @@ object constants {
     f( expression )
     cs.toSet
   }
+  def apply( expression: LambdaExpression ): Set[Const] =
+    all( expression ).filter { !_.isInstanceOf[LogicalConstant] }
 
   def apply( es: GenTraversable[LambdaExpression] ): Set[Const] = ( Set.empty[Const] /: es ) { ( acc, e ) => acc union apply( e ) }
 

--- a/core/src/main/scala/at/logic/gapt/formats/babel/ast.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/babel/ast.scala
@@ -4,6 +4,8 @@ import scalaz._
 import Scalaz._
 import at.logic.gapt.{ expr => real }
 
+import scala.collection.mutable
+
 /**
  * Intermediate representation for expressions parsed by Babel.
  *
@@ -14,23 +16,24 @@ import at.logic.gapt.{ expr => real }
  * It differs from the "real" lambda calculus in [[at.logic.gapt.expr]]
  * in three major ways:
  *
- *  1. There are type variables.
+ *  1. There are type meta-variables.
  *  1. There are type annotations.
  *  1. Free variables, bound variables, and constants are not
  *     distinguished; they are all stored as "identifiers".
  */
 object ast {
 
-  class TypeVarIdx {
+  class MetaTypeIdx {
     override def toString = Integer toHexString hashCode() take 3
   }
-  def gensym() = new TypeVarIdx
+  def gensym() = new MetaTypeIdx
 
   sealed trait Type
   case class BaseType( name: String ) extends Type
   case class ArrType( a: Type, b: Type ) extends Type
-  case class TypeVar( idx: TypeVarIdx ) extends Type
-  def freshTypeVar() = TypeVar( gensym() )
+  case class VarType( name: String ) extends Type
+  case class MetaType( idx: MetaTypeIdx ) extends Type
+  def freshMetaType() = MetaType( gensym() )
 
   sealed trait Expr
   case class TypeAnnotation( expr: Expr, ty: Type ) extends Expr
@@ -41,8 +44,9 @@ object ast {
 
   def readable( t: Type ): String = t match {
     case BaseType( name ) => name
+    case VarType( name )  => s"?$name"
     case ArrType( a, b )  => s"(${readable( a )}>${readable( b )})"
-    case TypeVar( idx )   => s"_$idx"
+    case MetaType( idx )  => s"_$idx"
   }
   def readable( e: Expr ): String = e match {
     case TypeAnnotation( expr, ty ) => s"(${readable( expr )}:${readable( ty )})"
@@ -55,7 +59,7 @@ object ast {
   def Bool = BaseType( "o" )
 
   def Eq( a: Expr, b: Expr ) = {
-    val argType = freshTypeVar()
+    val argType = freshMetaType()
     val eqType = ArrType( argType, ArrType( argType, Bool ) )
     App( App( Ident( real.EqC.name, eqType ), a ), b )
   }
@@ -74,62 +78,74 @@ object ast {
   def Imp = BinaryConn( real.ImpC )
 
   def Quant( name: String ): ( Ident, Expr ) => Expr = ( v, sub ) =>
-    App( Ident( name, ArrType( ArrType( freshTypeVar(), Bool ), Bool ) ), Abs( v, sub ) )
+    App( Ident( name, ArrType( ArrType( freshMetaType(), Bool ), Bool ) ), Abs( v, sub ) )
   def Ex: ( Ident, Expr ) => Expr = Quant( real.ExistsC.name )
   def All = Quant( real.ForallC.name )
 
-  def liftType( t: real.Ty ): Type = t match {
+  def liftTypePoly( t: real.Ty ) = {
+    val vars = mutable.Map[real.TVar, Type]()
+    def lift( t: real.Ty ): Type = t match {
+      case t: real.TVar         => vars.getOrElse( t, freshMetaType() )
+      case real.TBase( name )   => BaseType( name )
+      case real.`->`( in, out ) => ArrType( lift( in ), lift( out ) )
+    }
+    lift( t )
+  }
+
+  def liftTypeMono( t: real.Ty ): Type = t match {
+    case real.TVar( name )    => VarType( name )
     case real.TBase( name )   => BaseType( name )
-    case real.`->`( in, out ) => ArrType( liftType( in ), liftType( out ) )
+    case real.`->`( in, out ) => ArrType( liftTypeMono( in ), liftTypeMono( out ) )
   }
 
   def LiftBlackbox( e: real.LambdaExpression ) =
-    Lifted( e, liftType( e.exptype ), Map() )
+    Lifted( e, liftTypeMono( e.exptype ), Map() )
 
   def LiftWhitebox( e: real.LambdaExpression ) =
-    Lifted( e, liftType( e.exptype ),
+    Lifted( e, liftTypeMono( e.exptype ),
       real.freeVariables( e ).
-      map { case real.Var( name, ty ) => name -> liftType( ty ) }.
+      map { case real.Var( name, ty ) => name -> liftTypeMono( ty ) }.
       toMap )
 
-  def freeVars( t: Type ): Set[TypeVarIdx] = t match {
-    case BaseType( name ) => Set()
-    case ArrType( a, b )  => freeVars( a ) union freeVars( b )
-    case TypeVar( idx )   => Set( idx )
+  def freeMetas( t: Type ): Set[MetaTypeIdx] = t match {
+    case BaseType( _ ) | VarType( _ ) => Set()
+    case ArrType( a, b )              => freeMetas( a ) union freeMetas( b )
+    case MetaType( idx )              => Set( idx )
   }
 
-  def subst( t: Type, assg: Map[TypeVarIdx, Type] ): Type = t match {
-    case BaseType( _ )   => t
-    case ArrType( a, b ) => ArrType( subst( a, assg ), subst( b, assg ) )
-    case TypeVar( idx )  => assg.get( idx ).fold( t )( subst( _, assg ) )
+  def subst( t: Type, assg: Map[MetaTypeIdx, Type] ): Type = t match {
+    case BaseType( _ ) | VarType( _ ) => t
+    case ArrType( a, b )              => ArrType( subst( a, assg ), subst( b, assg ) )
+    case MetaType( idx )              => assg.get( idx ).fold( t )( subst( _, assg ) )
   }
   type UnificationError = String
-  def printCtx( eqs: List[( Type, Type )], assg: Map[TypeVarIdx, Type] ): String =
-    ( assg.map { case ( idx, t ) => s"${readable( TypeVar( idx ) )} = ${readable( t )}\n" } ++
+  def printCtx( eqs: List[( Type, Type )], assg: Map[MetaTypeIdx, Type] ): String =
+    ( assg.map { case ( idx, t ) => s"${readable( MetaType( idx ) )} = ${readable( t )}\n" } ++
       eqs.map { case ( t1, t2 ) => s"${readable( t1 )} = ${readable( t2 )}\n" } ).mkString
 
-  def solve( eqs: List[( Type, Type )], assg: Map[TypeVarIdx, Type] ): UnificationError \/ Map[TypeVarIdx, Type] = eqs match {
+  def solve( eqs: List[( Type, Type )], assg: Map[MetaTypeIdx, Type] ): UnificationError \/ Map[MetaTypeIdx, Type] = eqs match {
     case Nil => assg.right
     case ( first :: rest ) => first match {
       case ( ArrType( a1, b1 ), ArrType( a2, b2 ) ) =>
         solve( ( a1 -> a2 ) :: ( b1 -> b2 ) :: rest, assg )
       case ( BaseType( n1 ), BaseType( n2 ) ) if n1 == n2 => solve( rest, assg )
-      case ( t1 @ TypeVar( i1 ), t2 ) if assg contains i1 =>
+      case ( VarType( n1 ), VarType( n2 ) ) if n1 == n2   => solve( rest, assg )
+      case ( t1 @ MetaType( i1 ), t2 ) if assg contains i1 =>
         solve( ( assg( i1 ) -> t2 ) :: rest, assg )
-      case ( t1 @ TypeVar( i1 ), t2 ) =>
+      case ( t1 @ MetaType( i1 ), t2 ) =>
         val t2_ = subst( t2, assg )
         if ( t1 == t2_ )
           solve( rest, assg )
-        else if ( freeVars( t2_ ) contains i1 )
+        else if ( freeMetas( t2_ ) contains i1 )
           s"Cannot unify types: ${readable( t1 )} occurs in ${readable( t2_ )} in\n${printCtx( eqs, assg )}".left
         else
           solve( rest, assg + ( i1 -> t2_ ) )
-      case ( t1, t2: TypeVar ) => solve( ( t2 -> t1 ) :: rest, assg )
-      case ( t1, t2 )          => s"Cannot unify types ${readable( t1 )} and ${readable( t2 )} in\n${printCtx( eqs, assg )}".left
+      case ( t1, t2: MetaType ) => solve( ( t2 -> t1 ) :: rest, assg )
+      case ( t1, t2 )           => s"Cannot unify types ${readable( t1 )} and ${readable( t2 )} in\n${printCtx( eqs, assg )}".left
     }
   }
 
-  def infers( exprs: Seq[Expr], env: Map[String, Type], s0: Map[TypeVarIdx, Type] ): UnificationError \/ ( Map[TypeVarIdx, Type], Seq[Type] ) =
+  def infers( exprs: Seq[Expr], env: Map[String, () => Type], s0: Map[MetaTypeIdx, Type] ): UnificationError \/ ( Map[MetaTypeIdx, Type], Seq[Type] ) =
     exprs match {
       case Seq() => ( s0 -> Seq() ).right
       case expr +: rest =>
@@ -139,7 +155,7 @@ object ast {
         } yield ( s2, exprt +: restts )
     }
 
-  def infer( expr: Expr, env: Map[String, Type], s0: Map[TypeVarIdx, Type] ): UnificationError \/ ( Map[TypeVarIdx, Type], Type ) =
+  def infer( expr: Expr, env: Map[String, () => Type], s0: Map[MetaTypeIdx, Type] ): UnificationError \/ ( Map[MetaTypeIdx, Type], Type ) =
     expr match {
       case TypeAnnotation( e, t ) =>
         for {
@@ -148,14 +164,14 @@ object ast {
         } yield ( s2, et )
       case Ident( n, t ) =>
         if ( env contains n )
-          for ( s1 <- solve( List( env( n ) -> t ), s0 ) ) yield ( s1, t )
+          for ( s1 <- solve( List( env( n )() -> t ), s0 ) ) yield ( s1, t )
         else ( s0 -> t ).right
       case Abs( Ident( vn, vt ), t ) =>
         for {
-          ( s1, subt ) <- infer( t, env + ( vn -> vt ), s0 )
+          ( s1, subt ) <- infer( t, env + ( vn -> ( () => vt ) ), s0 )
         } yield ( s1, ArrType( vt, subt ) )
       case App( a, b ) =>
-        val appType = freshTypeVar()
+        val appType = freshMetaType()
         for {
           ( s1, at ) <- infer( a, env, s0 )
           ( s2, bt ) <- infer( b, env, s1 )
@@ -163,11 +179,9 @@ object ast {
         } yield ( s3, appType )
       case Lifted( e, ty, fvs ) =>
         for {
-          s1 <- solve( fvs.mapKeys( env( _ ) ).toList, s0 )
+          s1 <- solve( fvs.mapKeys( env( _ )() ).toList, s0 )
         } yield ( s1, ty )
     }
-
-  val polymorphic = Set( real.EqC.name, real.ForallC.name, real.ExistsC.name )
 
   def freeIdentifers( expr: Expr ): Set[String] = expr match {
     case TypeAnnotation( e, ty ) => freeIdentifers( e )
@@ -177,13 +191,14 @@ object ast {
     case Lifted( e, ty, fvs )    => fvs.keySet
   }
 
-  def toRealType( ty: Type, assg: Map[TypeVarIdx, Type] ): real.Ty = ty match {
+  def toRealType( ty: Type, assg: Map[MetaTypeIdx, Type] ): real.Ty = ty match {
     case BaseType( name ) => real.TBase( name )
+    case VarType( name )  => real.TVar( name )
     case ArrType( a, b )  => toRealType( a, assg ) -> toRealType( b, assg )
-    case TypeVar( idx )   => toRealType( assg( idx ), assg )
+    case MetaType( idx )  => toRealType( assg( idx ), assg )
   }
 
-  def toRealExpr( expr: Expr, assg: Map[TypeVarIdx, Type], bound: Set[String] ): real.LambdaExpression = expr match {
+  def toRealExpr( expr: Expr, assg: Map[MetaTypeIdx, Type], bound: Set[String] ): real.LambdaExpression = expr match {
     case TypeAnnotation( e, ty ) => toRealExpr( e, assg, bound )
     case expr @ Ident( name, ty ) =>
       if ( bound( name ) ) real.Var( name, toRealType( ty, assg ) )
@@ -196,9 +211,17 @@ object ast {
     case Lifted( e, ty, fvs ) => e
   }
   def toRealExprs( expr: Seq[Expr], sig: BabelSignature ): UnificationError \/ Seq[real.LambdaExpression] = {
-    val fi = expr.view.flatMap( freeIdentifers ).toSet diff polymorphic
+    val fi = expr.view.flatMap( freeIdentifers ).toSet
     val freeVars = fi filter sig.isVar
-    val startingEnv = fi.map { i => i -> sig.getType( i ) }
+    val startingEnv = fi.map { i =>
+      i -> ( sig.apply( i ) match {
+        case IsConst( Some( ty ) ) => () => liftTypePoly( ty )
+        case IsVar( Some( ty ) ) => () => liftTypeMono( ty )
+        case IsConst( None ) | IsVar( None ) =>
+          val fixedMeta = freshMetaType()
+          () => fixedMeta
+      } )
+    }
     for ( ( assg, _ ) <- infers( expr, startingEnv.toMap, Map() ) )
       yield expr.map( toRealExpr( _, assg.withDefaultValue( BaseType( "i" ) ), freeVars ) )
   }

--- a/core/src/main/scala/at/logic/gapt/proofs/Checkable.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Checkable.scala
@@ -22,6 +22,7 @@ object Checkable {
             context.typeDef( name ).isDefined,
             s"Unknown base type: $name"
           )
+        case TVar( _ ) =>
         case in -> out =>
           check( context, in )
           check( context, out )
@@ -31,12 +32,9 @@ object Checkable {
   implicit object expressionIsCheckable extends Checkable[LambdaExpression] {
     def check( context: Context, expr: LambdaExpression ): Unit =
       expr match {
-        case _: LogicalConstant =>
-        case c @ Const( "=", _ ) =>
-          require( EqC.unapply( c ).isDefined )
         case c @ Const( name, _ ) =>
           require(
-            context.constant( name ).contains( c ),
+            context.constant( name ).exists( defC => typeMatching( defC.exptype, c.exptype ).isDefined ),
             s"Unknown constant: $c"
           )
         case Var( _, t ) => context.check( t )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
@@ -17,7 +17,7 @@ class ExpansionTreePrettyPrinter( sig: BabelSignature ) extends BabelExporter( u
       case Negative => doc <> "-"
     }
 
-  def show( et: ExpansionTree, t0: Map[String, LambdaExpression], p: Int ): ( Doc, Map[String, LambdaExpression] ) = et match {
+  def show( et: ExpansionTree, t0: Map[String, VarOrConst], p: Int ): ( Doc, Map[String, VarOrConst] ) = et match {
     case ETTop( pol )    => ( addPol( "⊤", pol ), t0 )
     case ETBottom( pol ) => ( addPol( "⊥", pol ), t0 )
     case ETWeakening( f, pol ) =>

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticsProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticsProof.scala
@@ -2,8 +2,8 @@ package at.logic.gapt.proofs.gaptic
 
 import at.logic.gapt.proofs.Context
 
-class TacticsProof {
-  private var _ctx = Context()
+class TacticsProof( initialContext: Context = Context.default ) {
+  private var _ctx = initialContext
   protected def ctx_=( newContext: Context ) = { _ctx = newContext }
   implicit def ctx = _ctx
 

--- a/examples/poset/proof.scala
+++ b/examples/poset/proof.scala
@@ -4,7 +4,7 @@ import at.logic.gapt.expr._
 import at.logic.gapt.proofs.{ Context, Sequent }
 import at.logic.gapt.proofs.gaptic._
 
-object proof extends TacticsProof {
+object proof extends TacticsProof( Context.withoutEquality ) {
   ctx += Context.Sort( "i" )
   ctx += hoc"f: i>i>i"
   ctx += hoc"'=':i>i>o"


### PR DESCRIPTION
We currently have some ad-hoc support for a few polymorphic constants: equality and quantifiers.  I would like to put them on a more principled foundation.

This PR implements Hindley-Milner-style polymorphism:
 - In addition to base types and arrow types, we add a new type constructor for type variables.
 - Type variables are intended to be used only in constant declarations (for now): for example, equality has the type `?x > ?x > o`
 - The main magic happens in proof checking: here we check that each constant is a type-instance of a declared constant.
 - All used constants (including top, bottom, and, ...) are declared in Context.

In the future, we could easily extend this approach to support polymorphic definitions, and parameterized types as well.

Alternatives:
 - Stronger type systems.  In #488, I proposed to implement System F for expressions.  However its usefulness is limited as we cannot easily introduce type-level definitions.  We would also need to figure out syntax for type application and type binders, and extend positions, etc.  There is also a small foundation question: for example System F allows us to define recursors--what does a proof in LK mean if each step can contain significant computational content?
 - Even stronger type systems, like LF.  Here type-level definitions would be only as difficult as term-level definitions.  However even type-checking would require definition unfolding, i.e. we would no longer have type-correct terms by construction (for example, right now App checks that that the first argument is a function type).

Fixes the main problem behind #488.