### PR TITLE
new CERES method 

### DIFF
--- a/core/src/main/scala/at/logic/gapt/proofs/ceres/CERES.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/ceres/CERES.scala
@@ -150,7 +150,7 @@ class CERES {
    *         the expansion trees of all formulas in the end-sequent of the projection except of the formulas corresponding
    *         to the input clause).
    */
-  def findPartialExpansionSequent( endsequent: HOLSequent, projections: Set[LKProof] )( input: Input, expSeq: ExpansionSequent, set: Set[( Substitution, ExpansionSequent )] ): ExpansionSequent = {
+  def findPartialExpansionSequent( endsequent: HOLSequent, projections: Set[LKProof] )( input: Input, set: Set[( Substitution, ExpansionSequent )] ): ExpansionSequent = {
     var expansionSequent = LKToExpansionProof( findMatchingProjection( endsequent, projections )( input ) ).expansionSequent
 
     for ( c <- input.sequent.antecedent ) {
@@ -174,8 +174,6 @@ class CERES {
     }
 
     var retSeq: ExpansionSequent = Sequent()
-
-    retSeq = expSeq
 
     for ( subst <- set.map( _._1 ).seq ) {
       retSeq ++= subst( expansionSequent )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -9,7 +9,7 @@ import at.logic.gapt.provers.sat.Sat4j
 import scala.collection.mutable
 
 /**
- * Converts a resolution proof to an expansion proof.*
+ * Converts a resolution proof to an expansion proof.
  * ResolutionToExpansionProof( rp ) will return the expansion proof of rp and ResolutionToExpansionProof( rp, input )
  * is used by the CERES method to return the expansion proof of the ACNF, which is extracted from the proof projections.
  *
@@ -62,13 +62,13 @@ object ResolutionToExpansionProof {
         Sequent() :+ ( ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) ) )
 
       case ( Input( Sequent( Seq(), Seq( f ) ) ) ) if freeVariables( f ).isEmpty =>
-        Sequent().+:( ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) ) )
+        ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) ) +: Sequent()
 
       case ( Input( seq ) ) =>
         val fvs = freeVariables( seq ).toSeq
         val sh = All.Block( fvs, seq.toDisjunction )
-        Sequent().+:( ETWeakQuantifierBlock( sh, fvs.size,
-          for ( ( subst, es ) <- set ) yield subst( fvs ) -> es.toDisjunction( Polarity.Negative ) ) )
+        ETWeakQuantifierBlock( sh, fvs.size,
+          for ( ( subst, es ) <- set ) yield subst( fvs ) -> es.toDisjunction( Polarity.Negative ) ) +: Sequent()
     }
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable
  *
  * In the unlikely case that the resolution proof starts from clauses, we just pretend that the clauses are derived
  * from formulas--that is, we instead of beginning with `D(x), E(x,y) :- F(y)` we just imagine the proof begins with
- * `:- ∀x ∀y (¬D(x) ∨ ¬E(x,y) ∨ F(y))`.*
+ * `:- ∀x ∀y (¬D(x) ∨ ¬E(x,y) ∨ F(y))`.
  *
  * Splitting inferences are converted to cuts in the expansion proof: formally, we can first skip all the splitting
  * inferences in the resoltion proof; the assertions now become part of the clauses, and we get additional input sequents.

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -53,13 +53,13 @@ import scala.collection.mutable
 object ResolutionToExpansionProof {
 
   def apply( proof: ResolutionProof ): ExpansionProof = {
-    apply( proof, setInput() )
+    apply( proof, inputsAsExpansionSequent )
   }
 
-  def setInput()( input: Input, set: Set[( Substitution, ExpansionSequent )] ): ExpansionSequent = {
+  def inputsAsExpansionSequent( input: Input, set: Set[( Substitution, ExpansionSequent )] ): ExpansionSequent = {
     input match {
       case ( Input( Sequent( Seq( f ), Seq() ) ) ) if freeVariables( f ).isEmpty =>
-        Sequent().:+( ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) ) )
+        Sequent() :+ ( ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) ) )
 
       case ( Input( Sequent( Seq(), Seq( f ) ) ) ) if freeVariables( f ).isEmpty =>
         Sequent().+:( ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
@@ -21,25 +21,7 @@ object expansionProofFromInstances {
 
     var retSeq: ExpansionSequent = Sequent()
     val expansionWithDefs = ExpansionProofWithCut( Sequent( proofs.
-      flatMapS( ResolutionToExpansionProof.withDefs( _, {
-        case ( Input( Sequent( Seq( f ), Seq() ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
-          retSeq = expSeq
-          retSeq :+= ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) )
-          retSeq
-
-        case ( Input( Sequent( Seq(), Seq( f ) ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
-          retSeq = expSeq
-          retSeq +:= ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) )
-          retSeq
-
-        case ( Input( seq ), expSeq, set ) =>
-          retSeq = expSeq
-          val fvs = freeVariables( seq ).toSeq
-          val sh = All.Block( fvs, seq.toDisjunction )
-          retSeq +:= ETWeakQuantifierBlock( sh, fvs.size,
-            for ( ( subst, es ) <- set ) yield subst( fvs ) -> es.toDisjunction( Polarity.Negative ) )
-          retSeq
-      }, addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
+      flatMapS( ResolutionToExpansionProof.withDefs( _, ResolutionToExpansionProof.setInput(), addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
       polarizedElements.groupBy( pe => pe._1.shallow -> pe._2 ).
       values.map( g => ETMerge( g.map( _._1 ) ) -> g.head._2 ).toSeq ) )
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
@@ -19,8 +19,27 @@ object expansionProofFromInstances {
       subst <- substs
     } yield Subst( just, subst )
 
+    var retSeq: ExpansionSequent = Sequent()
     val expansionWithDefs = ExpansionProofWithCut( Sequent( proofs.
-      flatMapS( ResolutionToExpansionProof.withDefs( _, addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
+      flatMapS( ResolutionToExpansionProof.withDefs( _, {
+        case ( Input( Sequent( Seq( f ), Seq() ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
+          retSeq = expSeq
+          retSeq :+= ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) )
+          retSeq
+
+        case ( Input( Sequent( Seq(), Seq( f ) ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
+          retSeq = expSeq
+          retSeq +:= ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) )
+          retSeq
+
+        case ( Input( seq ), expSeq, set ) =>
+          retSeq = expSeq
+          val fvs = freeVariables( seq ).toSeq
+          val sh = All.Block( fvs, seq.toDisjunction )
+          retSeq +:= ETWeakQuantifierBlock( sh, fvs.size,
+            for ( ( subst, es ) <- set ) yield subst( fvs ) -> es.toDisjunction( Polarity.Negative ) )
+          retSeq
+      }, addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
       polarizedElements.groupBy( pe => pe._1.shallow -> pe._2 ).
       values.map( g => ETMerge( g.map( _._1 ) ) -> g.head._2 ).toSeq ) )
 

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
@@ -19,9 +19,8 @@ object expansionProofFromInstances {
       subst <- substs
     } yield Subst( just, subst )
 
-    var retSeq: ExpansionSequent = Sequent()
     val expansionWithDefs = ExpansionProofWithCut( Sequent( proofs.
-      flatMapS( ResolutionToExpansionProof.withDefs( _, ResolutionToExpansionProof.setInput(), addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
+      flatMapS( ResolutionToExpansionProof.withDefs( _, ResolutionToExpansionProof.inputsAsExpansionSequent, addConclusion = false ).expansionWithCutAxiom.expansionSequent ).
       polarizedElements.groupBy( pe => pe._1.shallow -> pe._2 ).
       values.map( g => ETMerge( g.map( _._1 ) ) -> g.head._2 ).toSeq ) )
 

--- a/examples/simple/CERESExampleProof.scala
+++ b/examples/simple/CERESExampleProof.scala
@@ -11,8 +11,8 @@ object CERESExpansionExampleProof {
   val z = FOLVar( "z" )
 
   def f( x: FOLTerm ) = FOLFunction( "f", List( x ) )
-  def g( x: FOLTerm ) = FOLFunction( "g", x )
-  def P( x: FOLTerm ) = FOLFunction( "P", x )
+  def g( x: FOLTerm ) = FOLFunction( "g", List( x ) )
+  def P( x: FOLTerm ) = FOLFunction( "P", List( x ) )
 
   def ax1 = Eq( f( f( z ) ), g( z ) )
   def seq = Sequent( Seq(), Seq( ax1 ) )

--- a/examples/simple/CERESExampleProof.scala
+++ b/examples/simple/CERESExampleProof.scala
@@ -1,0 +1,37 @@
+package at.logic.gapt.examples
+
+import at.logic.gapt.expr._
+import at.logic.gapt.proofs.Sequent
+import at.logic.gapt.proofs.lk._
+
+object CERESExpansionExampleProof {
+  val c = FOLConst( "c" )
+  val x = FOLVar( "x" )
+  val y = FOLVar( "y" )
+  val z = FOLVar( "z" )
+
+  def f( x: FOLTerm ) = FOLFunction( "f", List( x ) )
+  def g( x: FOLTerm ) = FOLFunction( "g", x )
+  def P( x: FOLTerm ) = FOLFunction( "P", x )
+
+  def ax1 = Eq( f( f( z ) ), g( z ) )
+  def seq = Sequent( Seq(), Seq( ax1 ) )
+
+  val proof = {
+
+    val p5 = ImpLeftRule( LogicalAxiom( fof"P(c)" ), fof"P(c)", ImpLeftRule( LogicalAxiom( fof"P(g(c))" ), fof"P(g(c))", LogicalAxiom( fof"P(g(g(c)))" ), fof"P(g(g(c)))" ), fof"P(g(c))" )
+
+    val p8 = ContractionLeftRule( ForallLeftRule( ForallLeftRule( p5, fof"!x (P(x)->P(g(x)))", c ), fof"!x (P(x)->P(g(x)))", g( c ) ), fof"!x (P(x)->P(g(x)))" )
+
+    val p11 = ParamodulationRightRule( Axiom( seq ), ax1, LogicalAxiom( fof"P(f(f(z)))" ), fof"P(f(f(z)))", fof"P(g(z))" )
+
+    val p15 = ImpLeftRule( LogicalAxiom( fof"P(z)" ), fof"P(z)", ImpLeftRule( LogicalAxiom( fof"P(f(z))" ), fof"P(f(z))", p11, fof"P(f(f(z)))" ), fof"P(f(z))" )
+
+    val p18 = ContractionLeftRule( ForallLeftRule( ForallLeftRule( p15, fof"!x (P(x)->P(f(x)))", z ), fof"!x (P(x)->P(f(x)))", f( z ) ), fof"!x (P(x)->P(f(x)))" )
+
+    val p19 = ImpRightRule( p18, fof"P(z)", fof"P(g(z))" )
+
+    CutRule( ForallRightRule( p19, fof"!x (P(x)->P(g(x)))", z ), fof"!x (P(x)->P(g(x)))", p8, fof"!x (P(x)->P(g(x)))" )
+
+  }
+}

--- a/tests/src/test/scala/at/logic/gapt/proofs/ceres/CeresTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/ceres/CeresTest.scala
@@ -93,4 +93,18 @@ class CeresTest extends Specification with SequentMatchers with SatMatchers {
     for ( CutRule( p1, a1, p2, a2 ) <- acnf.subProofs ) isAtom( p1.endSequent( a1 ) ) must beTrue
     ok
   }
+
+  "extraction of expansions from projections" should {
+    "work for simple fol proofs" in {
+      val p = fol1.proof
+      val e = CERES.CERESExpansionProof( p, Escargot )
+      e.deep must beValidSequent
+    }
+
+    "work for proofs with equality" in {
+      val p = Pi2Pigeonhole.proof
+      val e = CERES.CERESExpansionProof( p, Escargot )
+      e.deep must beEValidSequent
+    }
+  }
 }

--- a/tests/src/test/scala/at/logic/gapt/proofs/ceres/CeresTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/ceres/CeresTest.scala
@@ -9,11 +9,12 @@ import at.logic.gapt.expr.hol.isAtom
 import at.logic.gapt.formats.ClasspathInputFile
 import at.logic.gapt.proofs.SequentMatchers
 import at.logic.gapt.proofs.{ Context, Sequent, gaptic }
-import at.logic.gapt.proofs.lk.{ CutRule, ReductiveCutElimination }
+import at.logic.gapt.proofs.lk.{ CutRule, LKToExpansionProof, ReductiveCutElimination }
 import at.logic.gapt.provers.escargot.Escargot
+import at.logic.gapt.utils.SatMatchers
 import org.specs2.mutable._
 
-class CeresTest extends Specification with SequentMatchers {
+class CeresTest extends Specification with SequentMatchers with SatMatchers {
 
   def load( file: String, pname: String ) =
     LLKProofParser( ClasspathInputFile( file ) ).proof( pname )
@@ -92,5 +93,4 @@ class CeresTest extends Specification with SequentMatchers {
     for ( CutRule( p1, a1, p2, a2 ) <- acnf.subProofs ) isAtom( p1.endSequent( a1 ) ) must beTrue
     ok
   }
-
 }

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
@@ -113,25 +113,7 @@ class ResolutionTest extends Specification with SatMatchers {
     proof.isProof must_== true
 
     var retSeq: ExpansionSequent = Sequent()
-    ResolutionToExpansionProof.withDefs( proof, {
-      case ( Input( Sequent( Seq( f ), Seq() ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
-        retSeq = expSeq
-        retSeq :+= ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) )
-        retSeq
-
-      case ( Input( Sequent( Seq(), Seq( f ) ) ), expSeq, set ) if freeVariables( f ).isEmpty =>
-        retSeq = expSeq
-        retSeq +:= ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) )
-        retSeq
-
-      case ( Input( seq ), expSeq, set ) =>
-        retSeq = expSeq
-        val fvs = freeVariables( seq ).toSeq
-        val sh = All.Block( fvs, seq.toDisjunction )
-        retSeq +:= ETWeakQuantifierBlock( sh, fvs.size,
-          for ( ( subst, es ) <- set ) yield subst( fvs ) -> es.toDisjunction( Polarity.Negative ) )
-        retSeq
-    } ).deep must beValidSequent
+    ResolutionToExpansionProof.withDefs( proof, ResolutionToExpansionProof.setInput() ).deep must beValidSequent
     val expansion = ResolutionToExpansionProof( proof )
     expansion.deep must beValidSequent
     val Some( resFromExp ) = ExpansionToResolutionProof( expansion )

--- a/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/resolution/ResolutionTest.scala
@@ -112,8 +112,7 @@ class ResolutionTest extends Specification with SatMatchers {
     val proof = Resolution( Resolution( AvatarContradiction( split ), Suc( 0 ), case1, Ant( 0 ) ), Suc( 0 ), case2, Ant( 0 ) )
     proof.isProof must_== true
 
-    var retSeq: ExpansionSequent = Sequent()
-    ResolutionToExpansionProof.withDefs( proof, ResolutionToExpansionProof.setInput() ).deep must beValidSequent
+    ResolutionToExpansionProof.withDefs( proof, ResolutionToExpansionProof.inputsAsExpansionSequent ).deep must beValidSequent
     val expansion = ResolutionToExpansionProof( proof )
     expansion.deep must beValidSequent
     val Some( resFromExp ) = ExpansionToResolutionProof( expansion )


### PR DESCRIPTION
new CERES method which extracts expansion proofs from projections and the resolution refutation,
changes in ResolutionToExpansionProof to handle cases where we call the method with the new CERES method
new testProof in simple