### PR TITLE
Lemmas without explicit labels

### DIFF
--- a/core/src/main/scala/at/logic/gapt/expr/ExpressionParseHelper.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/ExpressionParseHelper.scala
@@ -2,7 +2,7 @@ package at.logic.gapt.expr
 
 import at.logic.gapt.expr.ExpressionParseHelper.Splice
 import at.logic.gapt.formats.babel._
-import at.logic.gapt.proofs.{ FOLClause, FOLSequent, HOLClause, HOLSequent }
+import at.logic.gapt.proofs.{ FOLClause, FOLSequent, HOLClause, HOLSequent, Sequent }
 import fastparse.core.ParseError
 
 object ExpressionParseHelper {
@@ -203,6 +203,18 @@ class ExpressionParseHelper( sc: StringContext, file: sourcecode.File, line: sou
         s"Parse error at ${file.value}:${line.value}:\n${error.getMessage}"
       )
       case Right( sequent ) => sequent.map( _.asInstanceOf[HOLFormula] )
+    }
+  }
+
+  /** Parses a string as a labelled sequent. */
+  def hols( args: Splice[LambdaExpression]* ): Sequent[( String, HOLFormula )] = {
+    val ( combined, repl ) = interpolateHelper( args )
+
+    BabelParser.tryParseLabelledSequent( combined, repl ) match {
+      case Left( error ) => throw new IllegalArgumentException(
+        s"Parse error at ${file.value}:${line.value}:\n${error.getMessage}"
+      )
+      case Right( sequent ) => sequent
     }
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticCommands.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/TacticCommands.scala
@@ -531,7 +531,7 @@ trait TacticCommands {
    * Tactic that immediately fails.
    */
   def fail = new Tactical[Nothing] {
-    def apply( proofState: ProofState ) = Left( TacticalFailure( this, None, "explicit fail" ) )
+    def apply( proofState: ProofState ) = Left( TacticalFailure( this, Some( proofState ), "explicit fail" ) )
     override def toString = "fail"
   }
 

--- a/examples/lattice/lattice.scala
+++ b/examples/lattice/lattice.scala
@@ -37,9 +37,8 @@ object lattice extends TacticsProof {
   //
 
   // show that join is _least_ upper bound for \leq
-  val p_6 = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "a" ->
-    hof"∀z (x_0 <= z ∧ y_0 <= z ⊃ cup x_0 y_0 <= z)" ) ) ) {
-    unfold( "<=" ) in "a"
+  val p_6 = Lemma( hols"L1 :- ∀z (x_0 <= z ∧ y_0 <= z ⊃ cup x_0 y_0 <= z)" ) {
+    unfold( "<=" ) in "g"
     allR( hov"z_0" )
     impR
     andL
@@ -60,8 +59,8 @@ object lattice extends TacticsProof {
   }
 
   // continues showing that join is upper bound for \leq
-  val p_5_1 = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "a" -> hof"x <= cup x y" ) ) ) {
-    unfold( "<=" ) in "a"
+  val p_5_1 = Lemma( hols"L1 :- x <= cup x y" ) {
+    unfold( "<=" ) in "g"
     unfold( "L1" ) in "L1"
     allL( "L1", le"x", le"cup x y" )
     andL
@@ -71,7 +70,7 @@ object lattice extends TacticsProof {
   }
 
   // show that join is upper bound for \leq
-  val p_5 = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "LUB" -> FOLAtom( "LUB" ) ) ) ) {
+  val p_5 = Lemma( hols"L1 :- LUB" ) {
     unfold( "LUB" ) in "LUB"
     allR( "LUB", hov"x_0" )
     allR( "LUB", hov"y_0" )
@@ -85,33 +84,33 @@ object lattice extends TacticsProof {
   }
 
   //show that meet is _greatest_ lower bound for \leq
-  val p_4 = Lemma( Sequent( Nil, Seq( "a" -> hof"∀z (z <= x_0 ∧ z <= y_0 ⊃ z <= cap x_0 y_0)" ) ) ) {
-    unfold( "<=" ) in "a"
+  val p_4 = Lemma( hols":- ∀z (z <= x_0 ∧ z <= y_0 ⊃ z <= cap x_0 y_0)" ) {
+    unfold( "<=" ) in "g"
     decompose
     foTheory
   }
 
   // finishes showing that meet is lower bound for \leq
-  val p_3_1 = Lemma( Sequent( Nil, Seq( "a" -> hof"cap x_0 y_0 <= y_0" ) ) ) {
-    unfold( "<=" ) in "a"
+  val p_3_1 = Lemma( hols":- cap x_0 y_0 <= y_0" ) {
+    unfold( "<=" ) in "g"
     foTheory
   }
 
   // show that meet is lower bound for \leq
-  val p_3 = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "a" -> And( FOLAtom( "GLB" ), FOLAtom( "LUB" ) ) ) ) ) {
+  val p_3 = Lemma( hols"L1 :- GLB & LUB" ) {
     andR
-    unfold( "GLB" ) in "a"
+    unfold( "GLB" ) in "g"
     decompose
     andR
     andR
-    unfold( "<=" ) in "a"; foTheory
+    unfold( "<=" ) in "g"; foTheory
     insert( p_3_1 )
     insert( p_4 )
     insert( p_5 )
   }
 
   // show transitivity
-  val p_2 = Lemma( Sequent( Nil, Seq( "T" -> FOLAtom( "T" ) ) ) ) {
+  val p_2 = Lemma( hols":- T" ) {
     unfold( "T" ) in "T"
     decompose
     unfold( "<=" ) in ( "T_0_0", "T_0_1", "T_1" )
@@ -119,16 +118,16 @@ object lattice extends TacticsProof {
   }
 
   // show anti-symmetry
-  val p_1 = Lemma( Sequent( Nil, Seq( "a" -> And( FOLAtom( "AS" ), FOLAtom( "T" ) ) ) ) ) {
+  val p_1 = Lemma( hols":- AS & T" ) {
     andR
-    unfold( "AS" ) in "a"
+    unfold( "AS" ) in "g"
     decompose
-    unfold( "<=" ) in ( "a_0_0", "a_0_1" ); foTheory
+    unfold( "<=" ) in ( "g_0_0", "g_0_1" ); foTheory
     insert( p_2 )
   }
 
   // split up POSET, show reflexivity
-  val p1_3 = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "L3" -> FOLAtom( "L3" ) ) ) ) {
+  val p1_3 = Lemma( hols"L1 :- L3" ) {
     unfold( "L3" ) in "L3"
     andR
     unfold( "POSET" ) in "L3"
@@ -145,7 +144,7 @@ object lattice extends TacticsProof {
   //
 
   // finishes r_2
-  val r_2_1 = Lemma( Sequent( Seq( "LUB" -> FOLAtom( "LUB" ) ), Seq( "a" -> hof"x_0 <= cup x_0 y_0" ) ) ) {
+  val r_2_1 = Lemma( hols"LUB :- x_0 <= cup x_0 y_0" ) {
     unfold( "LUB" ) in "LUB"
     allL( "LUB", hov"x_0", hov"y_0" )
     andL
@@ -154,26 +153,22 @@ object lattice extends TacticsProof {
   }
 
   // absorption law 2 - difficult direction
-  val r_2 = Lemma( Sequent(
-    Seq( "LUB" -> FOLAtom( "LUB" ), "R" -> FOLAtom( "R" ),
-      "a" -> hof"∀z (z <= cup x_0 y_0 ∧ z <= x_0 ⊃ z <= cap (cup x_0 y_0) x_0)" ),
-    Seq( "b" -> hof"x_0 <= cap (cup x_0 y_0) x_0" )
-  ) ) {
-    allL( "a", le"x_0" )
-    impL
-    andR
-    insert( r_2_1 )
-    unfold( "R" ) in "R"
-    allL( "R", le"x_0" )
-    axiomLog
-    prop
-  }
+  val r_2 = Lemma(
+    hols"""LUB, R, ∀z (z <= cup x_0 y_0 ∧ z <= x_0 ⊃ z <= cap (cup x_0 y_0) x_0) :-
+      x_0 <= cap (cup x_0 y_0) x_0"""
+  ) {
+      allL( "h_0", le"x_0" )
+      impL
+      andR
+      insert( r_2_1 )
+      unfold( "R" ) in "R"
+      allL( "R", le"x_0" )
+      axiomLog
+      prop
+    }
 
   // apply anti-symmetry to show absorption law 2 (+ easy direction)
-  val q_2 = Lemma( Sequent(
-    Seq( "GLB" -> FOLAtom( "GLB" ), "LUB" -> FOLAtom( "LUB" ), "R" -> FOLAtom( "R" ), "AS" -> FOLAtom( "AS" ) ),
-    Seq( "a" -> hof"∀x∀y cap (cup x y) x = x" )
-  ) ) {
+  val q_2 = Lemma( hols"GLB, LUB, R, AS :- ∀x∀y cap (cup x y) x = x" ) {
     decompose
     unfold( "GLB" ) in "GLB"; allL( "GLB", le"cup x y", le"x" ); decompose
     unfold( "AS" ) in "AS"; chain( "AS" )
@@ -182,7 +177,7 @@ object lattice extends TacticsProof {
   }
 
   // finishes r_1
-  val r_1_1 = Lemma( Sequent( Seq( "GLB" -> FOLAtom( "GLB" ) ), Seq( "a" -> hof"cap x_0 y_0 <= x_0" ) ) ) {
+  val r_1_1 = Lemma( hols"GLB :- cap x_0 y_0 <= x_0" ) {
     unfold( "GLB" ) in "GLB"
     allL( "GLB", le"x_0", le"y_0" )
     forget( "GLB" )
@@ -192,26 +187,18 @@ object lattice extends TacticsProof {
   }
 
   // absorption law 1 - difficult direction
-  val r_1 = Lemma( Sequent(
-    Seq( "GLB" -> FOLAtom( "GLB" ), "R" -> FOLAtom( "R" ),
-      "a" -> hof"∀z (cap x_0 y_0 <= z ∧ x_0 <= z ⊃ cup (cap x_0 y_0) x_0 <= z)" ),
-    Seq( "b" -> hof"cup (cap x_0 y_0) x_0 <= x_0" )
-  ) ) {
-    allL( "a", le"x_0" )
-    impL
-    andR
+  val r_1 = Lemma( hols"""
+    GLB, R, ∀z (cap x_0 y_0 <= z ∧ x_0 <= z ⊃ cup (cap x_0 y_0) x_0 <= z) :-
+    cup (cap x_0 y_0) x_0 <= x_0
+    """ ) {
+    chain( "h_0" )
     insert( r_1_1 )
     unfold( "R" ) in "R"
-    allL( "R", le"x_0" )
-    axiomLog
-    prop
+    chain( "R" )
   }
 
   // apply anti-symmetry to show absorption law 1 (+ easy direction)
-  val q_1 = Lemma( Sequent(
-    Seq( "GLB" -> FOLAtom( "GLB" ), "LUB" -> FOLAtom( "LUB" ), "R" -> FOLAtom( "R" ), "AS" -> FOLAtom( "AS" ) ),
-    Seq( "a" -> hof"∀x∀y (cup (cap x y) x = x)" )
-  ) ) {
+  val q_1 = Lemma( hols"GLB, LUB, R, AS :- ∀x∀y (cup (cap x y) x = x)" ) {
     decompose
     unfold( "AS" ) in "AS"
     allL( "AS", le"cup (cap x y) x", le"x" )
@@ -228,7 +215,7 @@ object lattice extends TacticsProof {
     axiomLog
   }
 
-  val p3_2 = Lemma( Sequent( Seq( "L3" -> FOLAtom( "L3" ) ), Seq( "L2" -> FOLAtom( "L2" ) ) ) ) {
+  val p3_2 = Lemma( hols"L3 :- L2" ) {
     unfold( "L3" ) in "L3"
     decompose
     unfold( "POSET" ) in "L3_0"
@@ -240,8 +227,8 @@ object lattice extends TacticsProof {
   }
 
   // Main proof
-  val p = Lemma( Sequent( Seq( "L1" -> FOLAtom( "L1" ) ), Seq( "L2" -> FOLAtom( "L2" ) ) ) ) {
-    cut( "L3", FOLAtom( "L3" ) )
+  val p = Lemma( hols"L1 :- L2" ) {
+    cut( "L3", hof"L3" )
     insert( p1_3 )
     insert( p3_2 )
   }

--- a/examples/pi2pigeonhole.scala
+++ b/examples/pi2pigeonhole.scala
@@ -12,25 +12,24 @@ object Pi2Pigeonhole extends TacticsProof {
   ctx += hoc"f: i>i"
   ctx += hoc"'<=': i>i>o"
 
-  val proof = Lemma(
-    ( "maxlt" -> hof"∀x∀y (x <= M x y  ∧  y <= M x y)" ) +:
-      ( "bound" -> hof"∀x (f x = 0  ∨  f x = s 0)" ) +:
-      Sequent()
-      :+ ( "t" -> hof"∃x ∃y (s x <= y  ∧  f x = f y)" )
-  ) {
-      cut( "I0", hof"∀x ∃y (x <= y  ∧  f y = 0)" )
-      cut( "I1", hof"∀x ∃y (x <= y  ∧  f y = s 0)" )
+  val proof = Lemma( hols"""
+      maxlt: ∀x∀y (x <= M x y  ∧  y <= M x y),
+      bound: ∀x (f x = 0  ∨  f x = s 0)
+      :- t: ∃x ∃y (s x <= y  ∧  f x = f y)
+  """ ) {
+    cut( "I0", hof"∀x ∃y (x <= y  ∧  f y = 0)" )
+    cut( "I1", hof"∀x ∃y (x <= y  ∧  f y = s 0)" )
 
-      forget( "t" ); decompose; escargot
+    forget( "t" ); decompose; escargot
 
-      allL( "I1", le"0" ); decompose
-      allL( "I1", le"s y" ); decompose
-      forget( "I0", "I1" ); escargot
+    allL( "I1", le"0" ); decompose
+    allL( "I1", le"s y" ); decompose
+    forget( "I0", "I1" ); escargot
 
-      allL( "I0", le"0" ); decompose
-      allL( "I0", le"s y" ); decompose
-      forget( "I0" ); escargot
-    }
+    allL( "I0", le"0" ); decompose
+    allL( "I0", le"s y" ); decompose
+    forget( "I0" ); escargot
+  }
 }
 
 object Pi3Pigeonhole extends TacticsProof {
@@ -41,20 +40,19 @@ object Pi3Pigeonhole extends TacticsProof {
   ctx += hoc"f: i>i"
   ctx += hoc"'<=': i>i>o"
 
-  val proof = Lemma(
-    ( "maxlt" -> hof"∀x∀y (x <= M x y  ∧  y <= M x y)" ) +:
-      ( "bound" -> hof"∀x (f x = 0  ∨  f x = s 0)" ) +:
-      Sequent()
-      :+ ( "t" -> hof"∃x ∃y (s x <= y  ∧  f x = f y)" )
-  ) {
-      cut( "I", hof"∃z ∀x ∃y (x <= y  ∧  f y = z)" )
+  val proof = Lemma( hols"""
+      maxlt: ∀x∀y (x <= M x y  ∧  y <= M x y),
+      bound: ∀x (f x = 0  ∨  f x = s 0)
+      :- t: ∃x ∃y (s x <= y  ∧  f x = f y)
+  """ ) {
+    cut( "I", hof"∃z ∀x ∃y (x <= y  ∧  f y = z)" )
 
-      exR( "I", le"0" ); exR( "I", le"s 0" )
-      forget( "t", "I" ); decompose; escargot
+    exR( "I", le"0" ); exR( "I", le"s 0" )
+    forget( "t", "I" ); decompose; escargot
 
-      decompose
-      allL( "I", le"0" ); decompose
-      allL( "I", le"s y" ); decompose
-      forget( "I" ); escargot
-    }
+    decompose
+    allL( "I", le"0" ); decompose
+    allL( "I", le"s y" ); decompose
+    forget( "I" ); escargot
+  }
 }

--- a/examples/prime/euclid.scala
+++ b/examples/prime/euclid.scala
@@ -7,10 +7,7 @@ import at.logic.gapt.proofs.lk.LKProof
 
 case class euclid( k: Int ) extends PrimeDefinitions {
   def ldivprod( i: Int ): LKProof = {
-    val sequent =
-      ( "linp" -> hof"${P( i )} l" ) +:
-        Sequent() :+
-        ( "div" -> hof"DIV l ${prod( i )}" )
+    val sequent = hols"linp: ${P( i )} l  :-  div: DIV l ${prod( i )}"
 
     if ( i == 0 )
       Lemma( sequent ) {
@@ -53,44 +50,37 @@ case class euclid( k: Int ) extends PrimeDefinitions {
     } yield ()
   }
 
-  def prodgt0( i: Int ): LKProof = Lemma(
-    ( "gt0" -> hof"${prod( i )} + 1 = 1" ) +:
-      ( "fk" -> hof"${F( k )}" ) +:
-      Sequent()
-  ) {
-      unfold( prod( i ).name ) in "gt0"
+  def prodgt0( i: Int ): LKProof = Lemma( hols"gt0: ${prod( i )} + 1 = 1, fk: ${F( k )} :-" ) {
+    unfold( prod( i ).name ) in "gt0"
 
-      if ( i > 0 ) splitgt0( "gt0" ) andThen insert( prodgt0( i - 1 ) ) else skip
+    if ( i > 0 ) splitgt0( "gt0" ) andThen insert( prodgt0( i - 1 ) ) else skip
 
-      unfold( F( k ).name ) in "fk"
-      allL( "fk", p( i ) ).forget; decompose; destruct( "fk_1" )
-      Tactical.sequence( for ( j <- i to k reverse ) yield repeat( unfold( P( j ).name, "union", "set_1" ) in "fk_1" ) )
-      decompose; trivial
-      unfold( "PRIME" ) in "fk_1"; decompose
+    unfold( F( k ).name ) in "fk"
+    allL( "fk", p( i ) ).forget; decompose; destruct( "fk_1" )
+    Tactical.sequence( for ( j <- i to k reverse ) yield repeat( unfold( P( j ).name, "union", "set_1" ) in "fk_1" ) )
+    decompose; trivial
+    unfold( "PRIME" ) in "fk_1"; decompose
 
-      theory
-    }
+    theory
+  }
 
   val proof =
-    Lemma(
-      ( "fk" -> hof"${F( k )}" ) +:
-        ( "primediv" -> hof"'PRIME-DIV'" ) +: Sequent()
-    ) {
-        unfold( "PRIME-DIV" ) in "primediv"
-        allL( "primediv", le"${prod( k )} + 1" ).forget
-        destruct( "primediv" ) onAll decompose
+    Lemma( hols"fk: ${F( k )}, primediv: 'PRIME-DIV' :-" ) {
+      unfold( "PRIME-DIV" ) in "primediv"
+      allL( "primediv", le"${prod( k )} + 1" ).forget
+      destruct( "primediv" ) onAll decompose
 
-        insert( prodgt0( k ) )
+      insert( prodgt0( k ) )
 
-        unfold( s"F[$k]" ) in "fk"
-        allL( "fk", le"l" ).forget; decompose
-        destruct( "fk_0" ); trivial
-        include( "ldivprod", ldivprod( k ) )
-        unfold( "PRIME" ) in "primediv_0"
-        unfold( "DIV" ) in ( "ldivprod", "primediv_1" )
-        decompose
-        rewrite rtl "ldivprod" in "primediv_1"
-        theory
-      }
+      unfold( s"F[$k]" ) in "fk"
+      allL( "fk", le"l" ).forget; decompose
+      destruct( "fk_0" ); trivial
+      include( "ldivprod", ldivprod( k ) )
+      unfold( "PRIME" ) in "primediv_0"
+      unfold( "DIV" ) in ( "ldivprod", "primediv_1" )
+      decompose
+      rewrite rtl "ldivprod" in "primediv_1"
+      theory
+    }
 }
 object euclid3 extends euclid( 3 )

--- a/examples/primediv/primediv.scala
+++ b/examples/primediv/primediv.scala
@@ -9,12 +9,12 @@ object primediv extends TacticsProof {
   ctx += hoc"1: nat"
   ctx += hoc"'<': nat>nat>o"
 
-  val theory =
-    ( "assoc" -> hof"∀x∀y∀z x*(y*z) = (x*y)*z" ) +:
-      ( "neutral" -> hof"∀x x*1 = x" ) +:
-      ( "mulleq" -> hof"∀x∀y∀z (x*y=z ∧ x!=z ⊃ x<z)" ) +:
-      ( "oneleqeq" -> hof"∀x (x!=1 ⊃ 1<x)" ) +:
-      Sequent()
+  val theory = hols"""
+      assoc: ∀x∀y∀z x*(y*z) = (x*y)*z,
+      neutral: ∀x x*1 = x,
+      mulleq: ∀x∀y∀z (x*y=z ∧ x!=z ⊃ x<z),
+      oneleqeq: ∀x (x!=1 ⊃ 1<x) :-
+    """
 
   ctx += hof"LNP = (∀X (∃y X y ⊃ ∃y (X y ∧ ∀z (z < y ⊃ ¬X z))))"
   ctx += hof"IND = (∀X ((∀y (∀z (z < y ⊃ X z) ⊃ X y)) ⊃ ∀y X y))"
@@ -25,15 +25,15 @@ object primediv extends TacticsProof {
 
   // TODO: expose current BabelSignature inside Lemma, then we can drop the (x:nat) annotation
 
-  val lnpind = Lemma( ( "lnp" -> hof"LNP" ) +: Sequent() :+ ( "ind" -> hof"IND" ) ) {
-    unfold( "LNP" ) in "lnp"; unfold( "IND" ) in "ind"; decompose
-    allL( "lnp", le"λ(x:nat) ¬X x" ).forget; destruct( "lnp" )
-    exR( "lnp", le"y:nat" ); prop
-    decompose; chain( "ind_0" ).at( "lnp_0" )
-    decompose; allL( "lnp_1", le"z:nat" ); prop
+  val lnpind = Lemma( hols"LNP :- IND" ) {
+    unfold( "LNP" ) in "LNP"; unfold( "IND" ) in "IND"; decompose
+    allL( "LNP", le"λ(x:nat) ¬X x" ).forget; destruct( "LNP" )
+    exR( "LNP", le"y:nat" ); prop
+    decompose; chain( "IND_0" ).at( "LNP_0" )
+    decompose; allL( "LNP_1", le"z:nat" ); prop
   }
 
-  val proof = Lemma( ( "lnp" -> hof"LNP" ) +: theory :+ ( "goal" -> hof"∀y (y > 1 ⊃ ∃w PD w y)" ) ) {
+  val proof = Lemma( theory ++ hols"LNP :- ∀y (y > 1 ⊃ ∃w PD w y)" ) {
     include( "ind", lnpind ); unfold( "IND" ) in "ind"
     allL( "ind", le"λu (u > 1 ⊃ ∃w PD w u)" )
     chain( "ind_0" ); decompose
@@ -43,21 +43,21 @@ object primediv extends TacticsProof {
     // case b
     repeat( unfold( "PRIME", "D" ) in "yprime" )
     destruct( "yprime" ); prop; decompose
-    allL( "goal_0", le"z:nat" ).forget
-    destruct( "goal_0" ); chain( "mulleq" ).at( "goal_0" ).subst( hov"y:nat" -> le"z_0:nat" ); prop; prop
-    destruct( "goal_0" ); unfold( ">" ) in "goal_0"; chain( "oneleqeq" ).at( "goal_0" ); prop
+    allL( "g_0", le"z:nat" ).forget
+    destruct( "g_0" ); chain( "mulleq" ).at( "g_0" ).subst( hov"y:nat" -> le"z_0:nat" ); prop; prop
+    destruct( "g_0" ); unfold( ">" ) in "g_0"; chain( "oneleqeq" ).at( "g_0" ); prop
     decompose; exR( le"w:nat" ).forget
-    repeat( unfold( "PD", "D" ) in ( "goal_0", "goal_1_1" ) )
-    destruct( "goal_1_1" ); prop; decompose
+    repeat( unfold( "PD", "D" ) in ( "g_0", "g_1_1" ) )
+    destruct( "g_1_1" ); prop; decompose
     exR( le"z_1*z_0" ).forget
-    rewrite.many ltr ( "assoc", "goal_0_1" ) in "goal_1_1"; trivial
+    rewrite.many ltr ( "assoc", "g_0_1" ) in "g_1_1"; trivial
 
     // case a
-    unfold( "PD" ) in "goal_1_1"
-    exR( le"y: nat" ).forget; destruct( "goal_1_1" ); prop
-    unfold( "D" ) in "goal_1_1"
-    exR( "goal_1_1", le"1" ).forget
-    rewrite ltr "neutral" in "goal_1_1"
+    unfold( "PD" ) in "g_1_1"
+    exR( le"y: nat" ).forget; destruct( "g_1_1" ); prop
+    unfold( "D" ) in "g_1_1"
+    exR( "g_1_1", le"1" ).forget
+    rewrite ltr "neutral" in "g_1_1"
     refl
   }
 

--- a/examples/simple/fol1.scala
+++ b/examples/simple/fol1.scala
@@ -11,12 +11,8 @@ object fol1 extends TacticsProof {
   ctx += hoc"a: i"
   ctx += hoc"b: i"
 
-  val proof = Lemma( Sequent(
-    Seq( "L" -> fof"(all x all y (P(x,y) -> Q(x,y)))" ),
-    Seq( "R" -> fof"(exists x exists y (-Q(x,y) -> -P(x,y)))" )
-  ) ) {
-
-    cut( "C", fof"(all x exists y (-P(x,y) | Q(x,y)))" )
+  val proof = Lemma( hols"L: !x!y (P x y -> Q x y) :- R: ?x?y (-Q x y -> - P x y)" ) {
+    cut( "C", fof"!x?y (-P x y | Q x y)" )
 
     // left subproof
     allR( "C" )


### PR DESCRIPTION
This adds a new string interpolator for labelled sequents.  Labels can be either manually specified, or are assigned a unique label otherwise:
```
scala> hols"label: x=x, P, x>x :- Q(1), R(2)"
res0: at.logic.gapt.proofs.Sequent[(String, at.logic.gapt.expr.HOLFormula)] =
(label,x = x), (P,P:o), (h_0,x > x) :- (g,Q(1): o), (g_0,R(2): o)
```
(The rule is that if the formula is a constant, then we take the constant's name.)

This makes some of the lemmas in the lattice proof fairly nice:
```scala
val p1_3 = Lemma( hols"L1 :- L3" ) { // ...
```

@loewenheim We were talking about this the other day.  Is this what you had in mind?