### PR TITLE
Add general definition rules.

### DIFF
--- a/core/src/main/scala/at/logic/gapt/expr/BetaReduction.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/BetaReduction.scala
@@ -38,6 +38,9 @@ class Normalizer( rule: ReductionRule ) {
     Apps( hd_, as_ )
   }
 
+  def isDefEq( a: LambdaExpression, b: LambdaExpression ): Boolean =
+    normalize( a ) == normalize( b )
+
   @tailrec
   final def appWHNF( hd: LambdaExpression, as: List[LambdaExpression] ): ( LambdaExpression, List[LambdaExpression] ) =
     rule.reduce( this, hd, as ) match {

--- a/core/src/main/scala/at/logic/gapt/expr/BetaReduction.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/BetaReduction.scala
@@ -38,6 +38,12 @@ class Normalizer( rule: ReductionRule ) {
     Apps( hd_, as_ )
   }
 
+  def reduce1( expr: LambdaExpression ): Option[LambdaExpression] = {
+    val Apps( hd, as ) = expr
+    for ( ( hd_, as_ ) <- rule.reduce( this, hd, as ) )
+      yield Apps( hd_, as_ )
+  }
+
   def isDefEq( a: LambdaExpression, b: LambdaExpression ): Boolean =
     normalize( a ) == normalize( b )
 

--- a/core/src/main/scala/at/logic/gapt/expr/constructors.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/constructors.scala
@@ -90,6 +90,9 @@ object All extends QuantifierHelper( ForallC )
 object Ex extends QuantifierHelper( ExistsC )
 
 object Quant {
+  def apply( x: Var, sub: HOLFormula, pol: Boolean ): HOLFormula =
+    if ( pol ) All( x, sub ) else Ex( x, sub )
+
   def unapply( f: HOLFormula ): Option[( Var, HOLFormula, Boolean )] =
     f match {
       case All( v, g ) => Some( ( v, g, true ) )

--- a/core/src/main/scala/at/logic/gapt/formats/llk/LLKExporter.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/llk/LLKExporter.scala
@@ -180,9 +180,9 @@ class LLKExporter( val expandTex: Boolean ) {
     case EqualityRightRule( p1, _, _, _ ) =>
       generateProof( p1, "\\UEQR" + fsequentString( p.endSequent, escape_latex ) + nLine + s, escape_latex )
     //definition rules
-    case DefinitionLeftRule( p1, _, _, _ ) =>
+    case DefinitionLeftRule( p1, _, _ ) =>
       generateProof( p1, "\\DEF" + fsequentString( p.endSequent, escape_latex ) + nLine + s, escape_latex )
-    case DefinitionRightRule( p1, _, _, _ ) =>
+    case DefinitionRightRule( p1, _, _ ) =>
       generateProof( p1, "\\DEF" + fsequentString( p.endSequent, escape_latex ) + nLine + s, escape_latex )
 
     //TODO: this is only a way to write out the proof, but it cannot be read back in (labels are not handled by llk so far)

--- a/core/src/main/scala/at/logic/gapt/formats/llk/LLKImporter.scala
+++ b/core/src/main/scala/at/logic/gapt/formats/llk/LLKImporter.scala
@@ -764,10 +764,10 @@ trait TokenToLKConverter extends Logger {
 
         //try each definition to infer the main formula
         val rule = definitions.dropWhile( d => try {
-          DefinitionRightRule( parent, aux, d, main );
+          DefinitionRightRule( parent, aux, main );
           false
         } catch { case e: Exception => true } ) match {
-          case d :: _ => DefinitionRightRule( parent, aux, d, main )
+          case d :: _ => DefinitionRightRule( parent, aux, main )
           case _ =>
             throw new HybridLatexParserException( "Couldn't find a matching definition to infer " + f( main ) + " from " + f( aux ) )
         }
@@ -775,9 +775,9 @@ trait TokenToLKConverter extends Logger {
       case ( HOLSequent( Vector( aux ), Vector() ), HOLSequent( Vector( main ), Vector() ) ) =>
         //try each definition to infer the main formula
         val rule = definitions.dropWhile( d => try {
-          DefinitionLeftRule( parent, aux, d, main ); false
+          DefinitionLeftRule( parent, aux, main ); false
         } catch { case e: Exception => true } ) match {
-          case d :: _ => DefinitionLeftRule( parent, aux, d, main )
+          case d :: _ => DefinitionLeftRule( parent, aux, main )
           case _ =>
             throw new HybridLatexParserException( "Couldn't find a matching definition to infer " + f( main ) + " from " + f( aux ) )
         }
@@ -894,7 +894,7 @@ trait TokenToLKConverter extends Logger {
     val defs = definitions.toList.map( x => llkDefinitionToLKDefinition( x._1, x._2 ) )
     val ( _, axproof ) = getAxiomLookupProof( name, axiom, auxf, axiomconjunction, Axiom( auxf :: Nil, auxf :: Nil ), sub2, defs )
     val Some( axdef ) = defs.find( _.what == Const( "AX", To ) )
-    val axrule = DefinitionLeftRule( axproof, axiomconjunction, axdef, axformula )
+    val axrule = DefinitionLeftRule( axproof, axiomconjunction, axformula )
 
     val Eq( s, t ) = auxf
 
@@ -990,7 +990,7 @@ trait TokenToLKConverter extends Logger {
     val defs = definitions.toList.map( x => llkDefinitionToLKDefinition( x._1, x._2 ) )
     val ( _, axproof ) = getAxiomLookupProof( name, axiom, auxf, axiomconjunction, oldproof, sub2, defs )
     val Some( axdef ) = defs.find( _.what == Const( "AX", To ) )
-    val axrule = DefinitionLeftRule( axproof, axiomconjunction, axdef, axformula )
+    val axrule = DefinitionLeftRule( axproof, axiomconjunction, axformula )
     ContractionMacroRule( axrule, fs, strict = false ) :: rest
   }
 
@@ -1214,7 +1214,7 @@ trait TokenToLKConverter extends Logger {
         val d = definitions.find( _.what == c ).getOrElse(
           throw new Exception( s"could not find a definition for $c in ${definitions.map( _.what ).sortBy( _.name )}" )
         )
-        ( axiomconj, DefinitionLeftRule( pi, axiom, d, axiomconj ) )
+        ( axiomconj, DefinitionLeftRule( pi, axiom, axiomconj ) )
 
       case And( x, y ) if formula_contains_atom( x, name ) =>
         val ( aux, uproof ) = getAxiomLookupProof( name, axiom, instance, x, axiomproof, sub, definitions )

--- a/core/src/main/scala/at/logic/gapt/proofs/Context.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/Context.scala
@@ -80,9 +80,17 @@ class Context private ( val state: State, val updates: List[Update] ) extends Ba
   def +( update: Update ): Context =
     new Context( update( this ), update :: updates )
 
+  def normalizer = {
+    val redRules = reductionRules.toVector
+    new Normalizer( if ( redRules.isEmpty ) BetaReduction else ReductionRule( BetaReduction +: redRules ) )
+  }
+
   /** Normalizes an expression with the reduction rules stored in this context. */
   def normalize( expression: LambdaExpression ): LambdaExpression =
-    at.logic.gapt.expr.normalize( expression )( this )
+    normalizer.normalize( expression )
+
+  def isDefEq( a: LambdaExpression, b: LambdaExpression ): Boolean =
+    normalizer.isDefEq( a, b )
 
   def signatureLookup( s: String ): BabelSignature.VarConst =
     constant( s ) match {

--- a/core/src/main/scala/at/logic/gapt/proofs/ceres/projections.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/ceres/projections.scala
@@ -73,8 +73,8 @@ object Projections {
       case ForallSkRightRule( p, a, m, t, d )     => handleSkQuantRule( proof, p, a, m, t, d, ForallSkRightRule.apply, pred )
       case ExistsSkLeftRule( p, a, m, t, d )      => handleSkQuantRule( proof, p, a, m, t, d, ExistsSkLeftRule.apply, pred )
 
-      case DefinitionLeftRule( p, a, d, c )       => handleDefRule( proof, p, a, d, c, DefinitionLeftRule.apply, pred )
-      case DefinitionRightRule( p, a, d, c )      => handleDefRule( proof, p, a, d, c, DefinitionRightRule.apply, pred )
+      case DefinitionLeftRule( p, a, m )          => handleDefRule( proof, p, a, m, DefinitionLeftRule.apply, pred )
+      case DefinitionRightRule( p, a, m )         => handleDefRule( proof, p, a, m, DefinitionRightRule.apply, pred )
       case EqualityLeftRule( p1, e, a, con )      => handleEqRule( proof, p1, e, a, con, EqualityLeftRule.apply, pred )
       case EqualityRightRule( p1, e, a, con )     => handleEqRule( proof, p1, e, a, con, EqualityRightRule.apply, pred )
       case rule @ CutRule( p1, a1, p2, a2 ) =>
@@ -177,14 +177,14 @@ object Projections {
     else s.map( pm => constructor( pm, m ) )
   }
 
-  def handleDefRule( proof: LKProof, p: LKProof, a: SequentIndex, d: Definition, c: Abs,
-                     constructor: ( LKProof, SequentIndex, Definition, Abs ) => LKProof,
+  def handleDefRule( proof: LKProof, p: LKProof, a: SequentIndex, m: HOLFormula,
+                     constructor: ( LKProof, SequentIndex, HOLFormula ) => LKProof,
                      pred:        HOLFormula => Boolean )( implicit cut_ancs: Sequent[Boolean] ): Set[LKProof] = {
     val s = apply( p, copySetToAncestor( proof.occConnectors( 0 ), cut_ancs ), pred )
     if ( cut_ancs( proof.mainIndices( 0 ) ) ) s
     else s.map( pm => {
       val List( a_ ) = pickrule( proof, List( p ), List( pm ), List( a ) )
-      constructor( pm, a_, d, c )
+      constructor( pm, a_, m )
     } )
   }
 

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/ExpansionProofToLK.scala
@@ -54,10 +54,10 @@ class ExpansionProofToLK(
 
   private def tryDef( cuts: Seq[ETImp], expSeq: ExpansionSequent ): Option[UnprovableOrLKProof] =
     expSeq.zipWithIndex.elements collectFirst {
-      case ( e @ ETDefinedAtom( atom, pol, definedExpr ), i ) =>
-        mapIf( solve( cuts, expSeq.updated( i, ETAtom( atom, pol ) ) ), atom, pol ) { DefinitionRule( _, atom, e.definition, e.shallow, pol ) }
-      case ( e @ ETDefinition( sh, defExpr, ch ), i ) =>
-        mapIf( solve( cuts, expSeq.updated( i, ch ) ), ch.shallow, i.polarity ) { DefinitionRule( _, ch.shallow, e.definition, sh, i.polarity ) }
+      case ( ETDefinition( sh, ch ), i ) =>
+        mapIf( solve( cuts, expSeq.updated( i, ch ) ), ch.shallow, i.polarity ) {
+          DefinitionRule( _, ch.shallow, sh, i.polarity )
+        }
     }
 
   private def tryMerge( cuts: Seq[ETImp], expSeq: ExpansionSequent ): Option[UnprovableOrLKProof] =

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/deskolemizeET.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/deskolemizeET.scala
@@ -40,8 +40,8 @@ class deskolemizeET {
       et.copy( formula = TermReplacement( formula, repl ) )
     case et @ ETAtom( atom, _ ) =>
       et.copy( atom = TermReplacement( atom, repl ) )
-    case ETDefinedAtom( atom, pol, definition ) =>
-      ETDefinedAtom( TermReplacement( atom, repl ), pol, TermReplacement( definition, repl ) )
+    case ETDefinition( sh, ch ) =>
+      ETDefinition( TermReplacement( sh, repl ), rm( ch, repl ) )
 
     case _: ETTop | _: ETBottom  => et
     case ETNeg( child )          => ETNeg( rm( child, repl ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/eliminateMerges.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/eliminateMerges.scala
@@ -17,15 +17,15 @@ object eliminateMerges {
     var eigenVarSubst = Substitution()
 
     def merge( tree: ExpansionTree ): ExpansionTree = tree match {
-      case ETMerge( t, s )              => merge2( t, s )
-      case _: ETDefinedAtom | _: ETAtom => tree
-      case tree: ETDefinition           => tree.copy( child = merge( tree.child ) )
-      case ETWeakening( formula, pol )  => ETWeakening( formula, pol )
-      case _: ETTop | _: ETBottom       => tree
-      case ETNeg( t )                   => ETNeg( merge( t ) )
-      case ETAnd( t, s )                => ETAnd( merge( t ), merge( s ) )
-      case ETOr( t, s )                 => ETOr( merge( t ), merge( s ) )
-      case ETImp( t, s )                => ETImp( merge( t ), merge( s ) )
+      case ETMerge( t, s )             => merge2( t, s )
+      case _: ETAtom                   => tree
+      case tree: ETDefinition          => tree.copy( child = merge( tree.child ) )
+      case ETWeakening( formula, pol ) => ETWeakening( formula, pol )
+      case _: ETTop | _: ETBottom      => tree
+      case ETNeg( t )                  => ETNeg( merge( t ) )
+      case ETAnd( t, s )               => ETAnd( merge( t ), merge( s ) )
+      case ETOr( t, s )                => ETOr( merge( t ), merge( s ) )
+      case ETImp( t, s )               => ETImp( merge( t ), merge( s ) )
       case ETWeakQuantifier( shallow, inst ) =>
         ETWeakQuantifier( shallow, Map() ++ inst.mapValues( merge ) )
       case tree: ETStrongQuantifier => tree.copy( child = merge( tree.child ) )
@@ -39,11 +39,11 @@ object eliminateMerges {
           case t: ETMerge => ETMerge( t, merge( s ) )
           case t          => merge2( t, s )
         }
-      case ( t, s: ETMerge ) => merge2( s, t )
+      case ( t, s: ETMerge )        => merge2( s, t )
       case ( t: ETAtom, _: ETAtom ) => t
-      case ( t @ ETDefinedAtom( a1, _, d1 ), ETDefinedAtom( a2, _, d2 ) ) if d1 == d2 => t
-      case ( ETDefinition( shallow, def1, t1 ), ETDefinition( _, def2, t2 ) ) if def1 == def2 =>
-        ETDefinition( shallow, def1, merge2( t1, t2 ) )
+      case ( ETDefinition( sh, t ), ETDefinition( _, s ) ) =>
+        if ( t.shallow == s.shallow ) ETDefinition( sh, merge2( t, s ) )
+        else ETMerge( merge( tree1 ), merge( tree2 ) )
       case ( t: ETTop, _: ETTop )               => t
       case ( t: ETBottom, _: ETBottom )         => t
       case ( ETNeg( t ), ETNeg( s ) )           => ETNeg( merge2( t, s ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionProofs.scala
@@ -37,19 +37,6 @@ case class ExpansionProof( expansionSequent: Sequent[ExpansionTree] ) {
     }
   )
 
-  val atomDefs =
-    subProofs collect {
-      case d: ETDefinedAtom => d.definitionConst -> d.definedExpr
-      case d: ETDefinition  => d.definition.toTuple
-    } groupBy { _._1 } map {
-      case ( c, ds ) =>
-        require(
-          ds.size == 1,
-          s"Inconsistent definition $c:\n${ds.map { _._2 }.mkString( "\n" )}"
-        )
-        c -> ds.head._2
-    }
-
   /**
    * Contains the pair (x, y) iff x occurs as a selected term in any sort of quantifier node
    * below the strong quantifier node introducing y.

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/minimal.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/minimal.scala
@@ -216,9 +216,8 @@ private[expansion] class Minimizer( val sequent: ExpansionSequent, val prover: P
     case ETWeakening( _, _ ) => Nil
     case ETTop( _ )          => Nil
     case ETBottom( _ )       => Nil
-    case _: ETDefinedAtom    => Nil
-    case ETDefinition( sh, defexpr, child ) =>
-      generateSuccessorTrees( child ).map( ETDefinition( sh, defexpr, _ ) )
+    case ETDefinition( sh, child ) =>
+      generateSuccessorTrees( child ).map( ETDefinition( sh, _ ) )
     case ETNeg( s ) => generateSuccessorTrees( s ).map( ETNeg.apply )
     case ETAnd( left, right ) =>
       val sLeft = generateSuccessorTrees( left )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/package.scala
@@ -31,8 +31,6 @@ package object expansion {
 
     def names( proof: ExpansionTree ) =
       proof.subProofs flatMap {
-        case p: ETDefinition       => containedNames( p.shallow ) ++ containedNames( p.definition.by )
-        case p: ETDefinedAtom      => containedNames( p.shallow ) ++ containedNames( p.definedExpr )
         case p: ETSkolemQuantifier => containedNames( p.shallow ) ++ containedNames( p.skolemDef )
         case p: ETStrongQuantifier => containedNames( p.shallow ) + p.eigenVariable
         case p                     => containedNames( p.shallow )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/positions.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/positions.scala
@@ -2,6 +2,7 @@ package at.logic.gapt.proofs.expansion
 
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.{ HOLPosition, instantiate }
+import at.logic.gapt.proofs.Context
 
 private object getAtHOLPosition {
   def apply( et: ExpansionTree, pos: HOLPosition ): Set[ExpansionTree] =
@@ -43,11 +44,16 @@ object replaceWithContext {
    * @param exp The term to insert for x.
    * @return A new expansion tree where x has been replaced with exp in every node.
    */
-  def apply( et: ExpansionTree, replacementContext: Abs, exp: LambdaExpression ): ExpansionTree = {
+  def apply( et: ExpansionTree, replacementContext: Abs, exp: LambdaExpression )( implicit ctx: Context = Context() ): ExpansionTree = {
     def newFormula = BetaReduction.betaNormalize( App( replacementContext, exp ) ).asInstanceOf[HOLFormula]
     def newAtom = newFormula.asInstanceOf[HOLAtom]
 
     ( et, replacementContext ) match {
+      case ( ETDefinition( sh, sub ), _ ) =>
+        val Some( matching ) = syntacticMatching( replacementContext.term, et.shallow )
+        val newCtx = commuteReplacementCtxWithDefEq( replacementContext, matching( replacementContext.variable ), sub.shallow )
+        ETDefinition.ifNecessary( newFormula, apply( sub, newCtx, exp ) )
+
       case ( ETMerge( left, right ), _ )                   => ETMerge( apply( left, replacementContext, exp ), apply( right, replacementContext, exp ) )
       case ( ETTop( _ ), _ ) | ( ETBottom( _ ), _ )        => et
       case ( et @ ETAtom( formula, _ ), _ )                => et.copy( atom = newAtom )
@@ -81,6 +87,32 @@ object replaceWithContext {
       case _ => throw new IllegalArgumentException( s"Tree $et and context $replacementContext could not be handled." )
     }
   }
+}
+
+object commuteReplacementCtxWithDefEq {
+  /**
+   * Given c[x\t] =def a, tries to find c' such that c'[x\t] = a and c' =def c.
+   *
+   * Right now this only works if c[x\t] ~> a, and may fail even then.
+   */
+  def apply( x: Var, c: LambdaExpression, t: LambdaExpression, a: LambdaExpression )( implicit ctx: Context ): LambdaExpression =
+    ( c, a ) match {
+      case _ if Substitution( x -> t )( c ) == a => c
+      case ( Apps( fn1, as1 ), Apps( fn2, as2 ) ) if fn1 == fn2 && !freeVariables( fn1 ).contains( x ) =>
+        fn1( for ( ( a1, a2 ) <- as1 zip as2 ) yield apply( x, a1, t, a2 ) )
+      case ( c @ Quant( y1, _, pol1 ), a @ Quant( y2, _, pol2 ) ) if y1.exptype == y2.exptype && pol1 == pol2 =>
+        val y = rename( y1, freeVariables( c ) ++ freeVariables( a ) ++ freeVariables( t ) + x )
+        Quant( y, apply( x, instantiate( c, y ), t, instantiate( a, y ) ).asInstanceOf[HOLFormula], pol1 )
+      case _ =>
+        ctx.normalizer.reduce1( c ) match {
+          case Some( c_ ) => apply( x, BetaReduction.betaNormalize( c_ ), t, a )
+          case None =>
+            throw new IllegalArgumentException( s"Cannot solve c'[$x\\$t] = $a\n  and c' =def $c" )
+        }
+    }
+
+  def apply( replCtx: Abs, t: LambdaExpression, a: LambdaExpression )( implicit ctx: Context ): Abs =
+    Abs( replCtx.variable, apply( replCtx.variable, replCtx.term, t, a ) )
 }
 
 /**
@@ -139,6 +171,44 @@ object insertDefinition {
         replaceWithContext( et, replacementContext, defn.what )
     }
   }
+}
+
+object moveDefsUpward {
+  private def apply( tree: ExpansionTree, expectedSh: HOLFormula )( implicit ctx: Context ): ExpansionTree =
+    ( tree, expectedSh ) match {
+      case ( ETDefinition( _, t ), _ )                        => apply( t, expectedSh )
+      case ( ETWeakening( _, pol ), _ )                       => ETWeakening( expectedSh, pol )
+      case ( ETMerge( t1, t2 ), _ )                           => ETMerge( apply( t1, expectedSh ), apply( t2, expectedSh ) )
+      case ( ETAtom( _, _ ) | ETTop( _ ) | ETBottom( _ ), _ ) => ETDefinition.ifNecessary( expectedSh, tree )
+      case ( ETNeg( t ), Neg( f ) )                           => ETNeg( apply( t, f ) )
+      case ( ETAnd( t1, t2 ), And( f1, f2 ) )                 => ETAnd( apply( t1, f1 ), apply( t2, f2 ) )
+      case ( ETOr( t1, t2 ), Or( f1, f2 ) )                   => ETOr( apply( t1, f1 ), apply( t2, f2 ) )
+      case ( ETImp( t1, t2 ), Imp( f1, f2 ) )                 => ETImp( apply( t1, f1 ), apply( t2, f2 ) )
+      case ( ETStrongQuantifier( _, eig, t ), Quant( _, _, _ ) ) =>
+        ETStrongQuantifier( expectedSh, eig, apply( t, instantiate( expectedSh, eig ) ) )
+      case ( ETSkolemQuantifier( _, _, _, _ ), Quant( _, _, _ ) ) =>
+        ETDefinition.ifNecessary( expectedSh, tree ) // TODO
+      case ( ETWeakQuantifier( _, insts ), Quant( _, _, _ ) ) =>
+        ETWeakQuantifier(
+          expectedSh,
+          for ( ( term, ch ) <- insts )
+            yield term -> apply( ch, BetaReduction.betaNormalize( instantiate( expectedSh, term ) ) )
+        )
+      case ( _, _ ) =>
+        val expectedShWhnf = ctx.normalizer.whnf( expectedSh ).asInstanceOf[HOLFormula]
+        if ( expectedShWhnf == expectedSh ) {
+          // We encountered a definition rule that was not valid in this context.
+          ETDefinition( expectedSh, apply( tree, tree.shallow ) )
+        } else {
+          ETDefinition( expectedSh, apply( tree, expectedShWhnf ) )
+        }
+    }
+
+  def apply( et: ExpansionTree )( implicit ctx: Context ): ExpansionTree = apply( et, et.shallow )
+  def apply( es: ExpansionSequent )( implicit ctx: Context ): ExpansionSequent = es.map( apply )
+  def apply( ep: ExpansionProof )( implicit ctx: Context ): ExpansionProof = ExpansionProof( apply( ep.expansionSequent ) )
+  def apply( ep: ExpansionProofWithCut )( implicit ctx: Context ): ExpansionProofWithCut =
+    ExpansionProofWithCut( apply( ep.expansionWithCutAxiom.expansionSequent ) )
 }
 
 /**

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
@@ -66,11 +66,7 @@ class ExpansionTreePrettyPrinter( sig: BabelSignature ) extends BabelExporter( u
           ( pretty( term_ ), group( nest( "+^{" <> term_ <> "}" <@> child_ ) ) )
       }
       parenIf( p, prio.conj, vsep( sh_ +: insts_.sortBy( _._1.layout ).map( _._2 ) ) ) -> t2
-    case et @ ETDefinedAtom( atom, pol, _ ) =>
-      val ( sh_, t1 ) = show( et.shallow, true, Set(), t0, prio.conj )
-      val ( child_, t2 ) = show( ETAtom( atom, pol ), t1, prio.conj )
-      parenIf( p, prio.conj, sh_ <+> "+def" <@> child_ ) -> t2
-    case ETDefinition( shallow, _, child ) =>
+    case ETDefinition( shallow, child ) =>
       val ( sh_, t1 ) = show( shallow, true, Set(), t0, prio.conj )
       val ( child_, t2 ) = show( child, t1, prio.conj )
       parenIf( p, prio.conj, sh_ <+> "+def" <@> child_ ) -> t2

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/tactics/complexTactics.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/tactics/complexTactics.scala
@@ -193,7 +193,7 @@ case class UnfoldTactic( target: String, definition: String, definitions: Seq[St
       newGoal = OpenAssumption( goal.labelledSequent.updated( idx, label -> normalized ) )
       proof_ : Either[TacticalFailure, LKProof] = ( defPositions, definitions ) match {
         case ( p :: ps, _ ) =>
-          Right( DefinitionRule( newGoal, normalized, defn, repContext, idx.polarity ) )
+          Right( DefinitionRule( newGoal, normalized, main, idx.polarity ) )
         case ( Nil, hd +: tl ) =>
           UnfoldTactic( target, hd, tl )( ctx )( newGoal ) map { _._2 }
         case _ =>

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKProofSubstitutable.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKProofSubstitutable.scala
@@ -130,13 +130,13 @@ class LKProofSubstitutable( preserveEigenvariables: Boolean ) extends Substituta
         indCase( substitution, _ )
       }, substitution( main ).asInstanceOf[Abs], substitution( term ) )
 
-    case DefinitionLeftRule( subProof, aux, definition, context ) =>
+    case DefinitionLeftRule( subProof, aux, main ) =>
       val subProofNew = applySubstitution( substitution, subProof )
-      DefinitionLeftRule( subProofNew, aux, definition, betaNormalize( substitution( context ) ).asInstanceOf[Abs] )
+      DefinitionLeftRule( subProofNew, aux, substitution( main ) )
 
-    case DefinitionRightRule( subProof, aux, definition, context ) =>
+    case DefinitionRightRule( subProof, aux, main ) =>
       val subProofNew = applySubstitution( substitution, subProof )
-      DefinitionRightRule( subProofNew, aux, definition, betaNormalize( substitution( context ) ).asInstanceOf[Abs] )
+      DefinitionRightRule( subProofNew, aux, substitution( main ) )
 
     case _ => throw new IllegalArgumentException( s"This rule is not handled at this time." )
   }
@@ -250,14 +250,12 @@ class LKProofReplacer( repl: PartialFunction[LambdaExpression, LambdaExpression]
   override protected def visitDefinitionLeft( proof: DefinitionLeftRule, otherArg: Unit ): ( LKProof, SequentConnector ) =
     one2one( proof, otherArg ) {
       case Seq( ( subProofNew, subConnector ) ) =>
-        val definitionNew = TermReplacement( proof.definition, repl )
-        DefinitionLeftRule( subProofNew, subConnector.child( proof.aux ), definitionNew, TermReplacement( proof.replacementContext, repl ).asInstanceOf[Abs] )
+        DefinitionLeftRule( subProofNew, subConnector.child( proof.aux ), TermReplacement( proof.mainFormula, repl ) )
     }
 
   override protected def visitDefinitionRight( proof: DefinitionRightRule, otherArg: Unit ): ( LKProof, SequentConnector ) =
     one2one( proof, otherArg ) {
       case Seq( ( subProofNew, subConnector ) ) =>
-        val definitionNew = TermReplacement( proof.definition, repl )
-        DefinitionRightRule( subProofNew, subConnector.child( proof.aux ), definitionNew, TermReplacement( proof.replacementContext, repl ).asInstanceOf[Abs] )
+        DefinitionRightRule( subProofNew, subConnector.child( proof.aux ), TermReplacement( proof.mainFormula, repl ) )
     }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKToExpansionProof.scala
@@ -140,14 +140,14 @@ object LKToExpansionProof {
       val context = sequent.updated( p.eq, newEqTree ).delete( p.aux )
       ( subCuts, if ( p.aux.isAnt ) newAuxTree +: context else context :+ newAuxTree )
 
-    case DefinitionLeftRule( subProof, aux, defn, ctx ) =>
+    case DefinitionLeftRule( subProof, aux, main ) =>
       val ( subCuts, subSequent ) = extract( subProof )
 
-      ( subCuts, insertDefinition( subSequent( aux ), defn, ctx ) +: subSequent.delete( aux ) )
+      ( subCuts, ETDefinition( main, subSequent( aux ) ) +: subSequent.delete( aux ) )
 
-    case DefinitionRightRule( subProof, aux, defn, ctx ) =>
+    case DefinitionRightRule( subProof, aux, main ) =>
       val ( subCuts, subSequent ) = extract( subProof )
 
-      ( subCuts, subSequent.delete( aux ) :+ insertDefinition( subSequent( aux ), defn, ctx ) )
+      ( subCuts, subSequent.delete( aux ) :+ ETDefinition( main, subSequent( aux ) ) )
   }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/LKVisitor.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/LKVisitor.scala
@@ -273,13 +273,13 @@ trait LKVisitor[T] {
   protected def visitDefinitionLeft( proof: DefinitionLeftRule, otherArg: T ): ( LKProof, SequentConnector ) =
     one2one( proof, otherArg ) {
       case Seq( ( subProof, subConn ) ) =>
-        DefinitionLeftRule( subProof, subConn.child( proof.aux ), proof.definition, proof.replacementContext )
+        DefinitionLeftRule( subProof, subConn.child( proof.aux ), proof.mainFormula )
     }
 
   protected def visitDefinitionRight( proof: DefinitionRightRule, otherArg: T ): ( LKProof, SequentConnector ) =
     one2one( proof, otherArg ) {
       case Seq( ( subProof, subConn ) ) =>
-        DefinitionRightRule( subProof, subConn.child( proof.aux ), proof.definition, proof.replacementContext )
+        DefinitionRightRule( subProof, subConn.child( proof.aux ), proof.mainFormula )
     }
 
   /**

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/Utils.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/Utils.scala
@@ -21,7 +21,7 @@ object containsEqualityReasoning {
 object containsDefinitionRules {
   def apply( proof: LKProof ): Boolean =
     proof.subProofs.exists {
-      case DefinitionLeftRule( _, _, _, _ ) | DefinitionRightRule( _, _, _, _ ) => true
+      case DefinitionLeftRule( _, _, _ ) | DefinitionRightRule( _, _, _ ) => true
       case _ => false
     }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/cleanStructuralRules.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/cleanStructuralRules.scala
@@ -419,26 +419,26 @@ object cleanStructuralRules {
           ( proofNew, proofNew.getSequentConnector * subConnector_ * p.getSequentConnector.inv )
       }
 
-    case p @ DefinitionLeftRule( subProof, aux, definition, ctx ) =>
+    case p @ DefinitionLeftRule( subProof, aux, main ) =>
       val ( subProofNew, subConnector ) = apply_( subProof, reductive )
 
       subConnector.children( aux ) match {
 
         case Seq( a ) => // The inference is performed on a non-weak formula → just do it
-          val proofNew = DefinitionLeftRule( subProofNew, a, definition, ctx )
+          val proofNew = DefinitionLeftRule( subProofNew, a, main )
           ( proofNew, proofNew.getSequentConnector * subConnector * p.getSequentConnector.inv )
 
         case _ => // The aux formula is weak → do nothing
           ( subProofNew, subConnector * p.getSequentConnector.inv )
       }
 
-    case p @ DefinitionRightRule( subProof, aux, definition, ctx ) =>
+    case p @ DefinitionRightRule( subProof, aux, main ) =>
       val ( subProofNew, subConnector ) = apply_( subProof, reductive )
 
       subConnector.children( aux ) match {
 
         case Seq( a ) => // The inference is performed on a non-weak formula → just do it
-          val proofNew = DefinitionRightRule( subProofNew, a, definition, ctx )
+          val proofNew = DefinitionRightRule( subProofNew, a, main )
           ( proofNew, proofNew.getSequentConnector * subConnector * p.getSequentConnector.inv )
 
         case _ => // The aux formula is weak → do nothing

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/eliminateDefinitions.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/eliminateDefinitions.scala
@@ -120,11 +120,17 @@ class eliminateDefinitions private ( dmap: Map[Const, LambdaExpression] ) extend
         sequent. We use exchange macro rules to artificially replicate the movement of formulas that the definition
          rule would have performed.*/
 
-    case DefinitionLeftRule( subProof, aux, _, _ ) =>
-      ExchangeLeftMacroRule( apply( subProof ), aux )
+    case proof @ DefinitionLeftRule( subProof, aux, _ ) =>
+      if ( apply( proof.auxFormula ) == apply( proof.mainFormula ) )
+        ExchangeLeftMacroRule( apply( subProof ), aux )
+      else
+        DefinitionLeftRule( apply( subProof ), aux, apply( proof.mainFormula ) )
 
-    case DefinitionRightRule( subProof, aux, _, _ ) =>
-      ExchangeRightMacroRule( apply( subProof ), aux )
+    case proof @ DefinitionRightRule( subProof, aux, _ ) =>
+      if ( apply( proof.auxFormula ) == apply( proof.mainFormula ) )
+        ExchangeRightMacroRule( apply( subProof ), aux )
+      else
+        DefinitionRightRule( apply( subProof ), aux, apply( proof.mainFormula ) )
 
     case InductionRule( cases, main, term ) =>
       InductionRule( cases map { cs => cs.copy( proof = apply( cs.proof ) ) }, apply( main ).asInstanceOf[Abs], apply( term ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/reductiveCutElimination.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/reductiveCutElimination.scala
@@ -253,9 +253,6 @@ class ReductiveCutElimination {
         val rSubProofNew = Substitution( eigen, term )( rSubProof )
         CutRule( lSubProof, rSubProofNew, left.auxFormulas.head.head )
 
-      case ( DefinitionRightRule( lSubProof, a1, definition1, ctx1 ), DefinitionLeftRule( rSubProof, a2, definition2, ctx2 ) ) if left.mainIndices.head == aux1 && right.mainIndices.head == aux2 =>
-        CutRule( lSubProof, a1, rSubProof, a2 )
-
       // If no grade reduction rule can be applied -- in particular, if one of the cut formulas is not introduced directly above the cut
       // -- we attempt to reduce the rank, starting on the left.
       case _ => reduceRankLeft( left, aux1, right, aux2 )
@@ -316,19 +313,19 @@ class ReductiveCutElimination {
             CutRule( leftSubProof, a1, cutSub, cutSub.getLeftSequentConnector.child( a2 ) )
         }
 
-      case l @ DefinitionLeftRule( subProof, a, d, c ) =>
+      case l @ DefinitionLeftRule( subProof, a, m ) =>
 
         val aux1Sub = l.getSequentConnector.parent( aux1 )
         val cutSub = CutRule( l.subProof, aux1Sub, right, aux2 )
         val aNew = cutSub.getLeftSequentConnector.child( a )
-        DefinitionLeftRule( cutSub, aNew, d, c )
+        DefinitionLeftRule( cutSub, aNew, m )
 
-      case l @ DefinitionRightRule( subProof, a, d, c ) if left.mainIndices.head != aux1 =>
+      case l @ DefinitionRightRule( subProof, a, m ) if left.mainIndices.head != aux1 =>
 
         val aux1Sub = l.getSequentConnector.parent( aux1 )
         val cutSub = CutRule( l.subProof, aux1Sub, right, aux2 )
         val aNew = cutSub.getLeftSequentConnector.child( a )
-        DefinitionRightRule( cutSub, aNew, d, c )
+        DefinitionRightRule( cutSub, aNew, m )
 
       case l @ AndLeftRule( subProof, a1, a2 ) =>
 
@@ -516,17 +513,17 @@ class ReductiveCutElimination {
             CutRule( leftSubProof, a1, cutSub, cutSub.getRightSequentConnector.child( a2 ) )
         }
 
-      case r @ DefinitionLeftRule( subProof, a, d, c ) if right.mainIndices.head != aux2 =>
+      case r @ DefinitionLeftRule( subProof, a, m ) if right.mainIndices.head != aux2 =>
         val aux2Sub = r.getSequentConnector.parent( aux2 )
         val cutSub = CutRule( left, aux1, r.subProof, aux2Sub )
         val aNew = cutSub.getRightSequentConnector.child( a )
-        DefinitionLeftRule( cutSub, aNew, d, c )
+        DefinitionLeftRule( cutSub, aNew, m )
 
-      case r @ DefinitionRightRule( subProof, a, d, c ) =>
+      case r @ DefinitionRightRule( subProof, a, m ) =>
         val aux2Sub = r.getSequentConnector.parent( aux2 )
         val cutSub = CutRule( left, aux1, r.subProof, aux2Sub )
         val aNew = cutSub.getRightSequentConnector.child( a )
-        DefinitionLeftRule( cutSub, aNew, d, c )
+        DefinitionLeftRule( cutSub, aNew, m )
 
       case r @ AndLeftRule( subProof, a1, a2 ) if right.mainIndices.head != aux2 =>
         val aux2Sub = r.getSequentConnector.parent( aux2 )

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/skolemizeInferences.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/skolemizeInferences.scala
@@ -139,14 +139,14 @@ private class skolemizeInferences(
           apply( q2, p.getRightSequentConnector.parent( info, Info( Seq( p.cutFormula ), isCutAnc = true, Seq(), Seq( -1 ) ) ), subst ), a2
         )
 
-      case p @ DefinitionLeftRule( q, a, d, c ) =>
+      case p @ DefinitionLeftRule( q, a, m ) =>
         val qNew = apply( q, p.getSequentConnector.parent( info ).
           updated( a, info( p.mainIndices.head ).copy( generalizedFormulas = Seq( q.conclusion( a ) ) ) ), subst )
-        DefinitionLeftRule( qNew, a, d, subst( c ).asInstanceOf[Abs] )
-      case p @ DefinitionRightRule( q, a, d, c ) =>
+        DefinitionLeftRule( qNew, a, subst( m ) )
+      case p @ DefinitionRightRule( q, a, m ) =>
         val qNew = apply( q, p.getSequentConnector.parent( info ).
           updated( a, info( p.mainIndices.head ).copy( generalizedFormulas = Seq( q.conclusion( a ) ) ) ), subst )
-        DefinitionRightRule( qNew, a, d, subst( c ).asInstanceOf[Abs] )
+        DefinitionRightRule( qNew, a, subst( m ) )
 
       case p @ WeakQuantifierRule( q, a, _, term, bound, pol ) =>
         val freshVar = nameGen fresh bound

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToExpansionProof.scala
@@ -1,7 +1,6 @@
 package at.logic.gapt.proofs.resolution
 
 import at.logic.gapt.expr._
-import at.logic.gapt.expr.hol.containsQuantifierOnLogicalLevel
 import at.logic.gapt.proofs.{ HOLSequent, Sequent }
 import at.logic.gapt.proofs.expansion._
 import at.logic.gapt.provers.sat.Sat4j
@@ -59,7 +58,7 @@ object ResolutionToExpansionProof {
   def inputsAsExpansionSequent( input: Input, set: Set[( Substitution, ExpansionSequent )] ): ExpansionSequent = {
     input match {
       case ( Input( Sequent( Seq( f ), Seq() ) ) ) if freeVariables( f ).isEmpty =>
-        Sequent() :+ ( ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) ) )
+        Sequent() :+ ETMerge( f, Polarity.InSuccedent, set.map( _._2.elements.head ) )
 
       case ( Input( Sequent( Seq(), Seq( f ) ) ) ) if freeVariables( f ).isEmpty =>
         ETMerge( f, Polarity.InAntecedent, set.map( _._2.elements.head ) ) +: Sequent()
@@ -178,7 +177,13 @@ object ResolutionToExpansionProof {
         propg( p, q2, _.map( es => es._1 -> oc2.parent( es._2, ETAtom( es._1( atom ).asInstanceOf[HOLAtom], Polarity.InSuccedent ) ) ) )
       case p @ DefIntro( q, i, definition, repContext ) =>
         val Seq( oc ) = p.occConnectors
-        propg( p, q, _.map( es => es._1 -> oc.parent( es._2 ).updated( i, ETDefinedAtom( es._1( p.defAtom ).asInstanceOf[HOLAtom], !i.polarity, p.by ) ) ) )
+        propg( p, q, _.map( es => es._1 -> oc.parent( es._2 ).updated(
+          i,
+          ETDefinition(
+            es._1( p.auxFormula ),
+            ETAtom( es._1( p.defAtom ).asInstanceOf[HOLAtom], !i.polarity )
+          )
+        ) ) )
 
       case p @ Paramod( q1, i1, ltr, q2, i2, ctx ) =>
         val Seq( oc1, oc2 ) = p.occConnectors

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/ResolutionToLKProof.scala
@@ -43,15 +43,14 @@ object ResolutionToLKProof {
 
       case p @ Defn( defConst, defExpr ) =>
         val phi = BetaReduction.betaNormalize( defExpr( p.vars ) ).asInstanceOf[HOLFormula]
-        val definition = Definition( defConst, defExpr )
-        val ctx = replacementContext.abstractTerm( defConst( p.vars: _* ) )( defConst )
+        val defAtom = p.defConst( p.vars ).asInstanceOf[HOLFormula]
 
         ProofBuilder.
           c( LogicalAxiom( phi ) ).
-          u( DefinitionLeftRule( _, Ant( 0 ), definition, ctx ) ).
+          u( DefinitionLeftRule( _, Ant( 0 ), defAtom ) ).
           u( ImpRightRule( _, Ant( 0 ), Suc( 0 ) ) ).
           c( LogicalAxiom( phi ) ).
-          u( DefinitionRightRule( _, Suc( 0 ), definition, ctx ) ).
+          u( DefinitionRightRule( _, Suc( 0 ), defAtom ) ).
           u( ImpRightRule( _, Ant( 0 ), Suc( 0 ) ) ).
           b( AndRightRule( _, Suc( 0 ), _, Suc( 0 ) ) ).
           u( ForallRightBlock( _, p.definitionFormula, p.vars ) ).
@@ -77,13 +76,13 @@ object ResolutionToLKProof {
         val Right( p1 ) = solvePropositional( comp.disjunction +: comp.clause )
         val p2 = ForallLeftBlock( p1, aux, vars )
 
-        val p3 = DefinitionLeftRule( p2, aux, comp.toDefinition, splAtom )
+        val p3 = DefinitionLeftRule( p2, aux, splAtom )
         p3
       case AvatarComponent( AvatarGroundComp( atom, _ ) ) => LogicalAxiom( atom )
       case AvatarComponent( comp @ AvatarNegNonGroundComp( splAtom, aux, vars, idx ) ) =>
         val Right( p1 ) = solvePropositional( comp.clause :+ comp.disjunction )
         val p2 = ForallRightBlock( p1, aux, vars )
-        val p3 = DefinitionRightRule( p2, aux, comp.toDefinition, splAtom )
+        val p3 = DefinitionRightRule( p2, aux, splAtom )
         p3
       case AvatarSplit( q, indices, AvatarGroundComp( _, _ ) ) => f( q )
       case p @ AvatarSplit( q, _, comp @ AvatarNonGroundComp( splAtom, aux, vars ) ) =>
@@ -103,22 +102,14 @@ object ResolutionToLKProof {
           }
         mkOr( comp.disjunction )
         p_ = ForallRightBlock( p_, aux, vars )
-        p_ = DefinitionRightRule( p_, aux, comp.toDefinition, splAtom )
+        p_ = DefinitionRightRule( p_, aux, splAtom )
         p_
 
-      case DefIntro( q, i: Suc, definition, args ) =>
-        val Definition( what, by ) = definition
-        val tp = what.exptype
-        val X = rename awayFrom freeVariables( args ) fresh Var( "X", tp )
-        val ctx = Abs( X, Apps( X, args ) )
-        DefinitionRightRule( f( q ), q.conclusion( i ), definition, ctx )
+      case p @ DefIntro( q, i: Suc, definition, args ) =>
+        DefinitionRightRule( f( q ), q.conclusion( i ), p.defAtom )
 
-      case DefIntro( q, i: Ant, definition, args ) =>
-        val Definition( what, by ) = definition
-        val tp = what.exptype
-        val X = rename awayFrom freeVariables( args ) fresh Var( "X", tp )
-        val ctx = Abs( X, Apps( X, args ) )
-        DefinitionLeftRule( f( q ), q.conclusion( i ), definition, ctx )
+      case p @ DefIntro( q, i: Ant, definition, args ) =>
+        DefinitionLeftRule( f( q ), q.conclusion( i ), p.defAtom )
 
       case p @ Flip( q, i: Ant ) =>
         CutRule( mkSymmProof( p.s, p.t ), f( q ), q.conclusion( i ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/expansionProofFromInstances.scala
@@ -24,7 +24,6 @@ object expansionProofFromInstances {
       polarizedElements.groupBy( pe => pe._1.shallow -> pe._2 ).
       values.map( g => ETMerge( g.map( _._1 ) ) -> g.head._2 ).toSeq ) )
 
-    val defConsts = expansionWithDefs.expansionWithCutAxiom.atomDefs.keySet
-    eliminateCutsET( eliminateDefsET( eliminateCutsET( eliminateMerges( expansionWithDefs ) ), pureFOLwithoutEquality, defConsts ) )
+    eliminateCutsET( eliminateDefsET( eliminateCutsET( eliminateMerges( expansionWithDefs ) ), pureFOLwithoutEquality ) )
   }
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/resolution/resolution.scala
@@ -363,6 +363,7 @@ case class DefIntro( subProof: ResolutionProof, idx: SequentIndex, definition: D
   val defAtom = defConst( args ).asInstanceOf[HOLAtom]
   val expandedFormula = BetaReduction.betaNormalize( Apps( by, args ) )
   requireEq( subProof.conclusion( idx ), expandedFormula )
+  def auxFormula = expandedFormula.asInstanceOf[HOLFormula]
   override def introducedDefinitions = Map( defConst -> by )
   override def mainFormulaSequent =
     if ( idx isAnt ) defAtom +: Sequent()

--- a/core/src/main/scala/at/logic/gapt/prooftool/DrawExpansionTree.scala
+++ b/core/src/main/scala/at/logic/gapt/prooftool/DrawExpansionTree.scala
@@ -438,7 +438,7 @@ class DrawETNonQuantifier(
 ) extends DrawExpansionTree( main, expansionTree, outerQuantifier ) {
 
   override val subTrees = expansionTree match {
-    case ETAtom( _, _ ) | ETTop( _ ) | ETBottom( _ ) | ETWeakening( _, _ ) | ETDefinition( _, _, _ ) =>
+    case ETAtom( _, _ ) | ETTop( _ ) | ETBottom( _ ) | ETWeakening( _, _ ) | ETDefinition( _, _ ) =>
       val lbl = LatexLabel( main, LatexExporter( expansionTree.shallow ) )
       lbl.deafTo( lbl.mouse.moves, lbl.mouse.clicks ) // We don't want atoms to react to mouse behavior.
       contents += lbl

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -1734,7 +1734,7 @@ et: at.logic.gapt.proofs.expansion.ExpansionProofWithCut =
   +^{M(s(y_1), x_1)}
     ((f(M(s(y_1), x_1)) = 0)- ∨ (f(M(s(y_1), x_1)) = s(0))-)
   +^{y_1} ((f(y_1) = 0)- ∨ (f(y_1) = s(0))-),
-∀x_0 ∀y_0 (...
+∀x_1 ∀y (x_...
 gapt> prooftool(et)
 
 \end{clilisting}
@@ -1952,7 +1952,14 @@ P(nil:list)- ∧
 
 \subsection{LK}\label{app:sequent_calculus}
 
-The rules of LK are listed below. Proof trees are constructed top-down, starting with axioms and with each rule introducing new inferences. With the exception of the definition rules, the constructors of the rules only allow inferences that are actually valid. Note that the rules are presented here as if they always act upon the outermost formulas in the upper sequent, but this is only for convenience of presentation. The basic constructors actually require the user to specify on which concrete formulas the inference should be performed.
+The rules of LK are listed below. Proof trees are constructed top-down,
+starting with axioms and with each rule introducing new inferences. With the
+exception of the definition rules, theory axioms, and induction rules, the
+constructors of the rules only allow inferences that are actually valid. Note
+that the rules are presented here as if they always act upon the outermost
+formulas in the upper sequent, but this is only for convenience of
+presentation. The basic constructors actually require the user to specify on
+which concrete formulas the inference should be performed.
 
 Apart from those basic constructors, there is also a multitude of convenience constructors that facilitate easier proof construction. Moreover, there are so-called macro rules that reduce several inferences to a single command (e.g. introducing quantifier blocks). See the API documentation of the individual rules for details.
 
@@ -2192,7 +2199,9 @@ Each equation rule replaces an arbitrary number of occurrences of $T$.
  \UnaryInfCm{\Gamma \seq \Delta, B}
  \DisplayProof
 \end{center}
-These definition rules are extremely liberal, as they allow the replacement of any formula by any other formula.
+These definition rules are extremely liberal, as they allow the replacement of
+any formula by any other formula.  When checking these rule against a context,
+we verify that both $A$ and $B$ normalize to the same normal form.
 
 \subsubsection*{Induction}
 The induction rule applies to arbitrary algebraic data types. Let $c_1,\dots,c_n$ be the constructors of a type and let $k_i$ be the arity of $c_i$. Let $F[x]$ be a formula with $x$ a free variable of the appropriate type. Then we call the sequent $\mathcal{S}_i := F[x_1],\dots,F[x_{k_i}], \Gamma_i \seq \Delta_i, F[c_i(x_1,\dots,x_{k_i})]$ the $i$-th induction step. In this case, the induction rule has the form
@@ -2483,8 +2492,7 @@ nodes, definitions, merges, and cuts~\cite{Hetzl2013Expansion}.
   \cli{ETAtom} & $A$ \quad (where $A$ is a HOL atom) \\
 \cli{ETWeakening} & $\mathsf{wk}(\varphi)$ \quad (where $\varphi$ is a formula) \\
 \cli{ETMerge} & $E_1 \sqcup E_2$ \\
-\cli{ETDefinition} & $D +_\mathsf{def} E$ \quad (where $D$ is a defined atom expanding to the shallow formula of $E$) \\
-\cli{ETDefinedAtom} & $\varphi +_\mathsf{def} D$ \quad (where $D$ is a defined atom expanding to $\varphi$) \\
+\cli{ETDefinition} & $D +_\mathsf{def} E$ \quad (where $D$ is definitionally equal to the shallow formula of $E$) \\
 \cli{ETTop} & $\top$ \\
 \cli{ETBottom} & $\bot$ \\
 \cli{ETNeg} & $\neg E$ \\

--- a/tests/src/test/scala/at/logic/gapt/proofs/expansion/ExpansionProofTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/expansion/ExpansionProofTest.scala
@@ -104,7 +104,7 @@ class ExpansionProofDefinitionEliminationTest extends Specification with SatMatc
       hof"∃x (P x ∧ P (f x) ⊃ P (f x))",
       Map( le"c" ->
         ETImp(
-          ETDefinedAtom( hoa"D c", Polarity.InAntecedent, ctx.definition( "D" ).get ),
+          ETDefinition( hof"P c & P (f c)", ETAtom( hoa"D c", Polarity.InAntecedent ) ),
           ETAtom( hoa"P (f c)", Polarity.InSuccedent )
         ) )
     )

--- a/tests/src/test/scala/at/logic/gapt/proofs/lk/LKToExpansionProofTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/lk/LKToExpansionProofTest.scala
@@ -1,8 +1,8 @@
 package at.logic.gapt.proofs.lk
 
-import at.logic.gapt.examples.{ Pi2Pigeonhole, LinearExampleProof }
+import at.logic.gapt.examples.{ LinearExampleProof, Pi2Pigeonhole }
 import at.logic.gapt.expr._
-import at.logic.gapt.proofs.{ Suc, Ant, Sequent }
+import at.logic.gapt.proofs.{ Ant, Context, Sequent, Suc }
 import at.logic.gapt.proofs.expansion._
 import at.logic.gapt.utils.SatMatchers
 import org.specs2.mutable._
@@ -141,7 +141,7 @@ class LKToExpansionProofTest extends Specification with SatMatchers {
         c( LogicalAxiom( fof"x = x" ) ).
         u( NegRightRule( _, Ant( 0 ) ) ).
         u( OrRightRule( _, Suc( 0 ), Suc( 1 ) ) ).
-        u( DefinitionRightRule( _, Suc( 0 ), d, fof"P(x)" ) ).
+        u( DefinitionRightRule( _, Suc( 0 ), fof"P(x)" ) ).
         u( OrRightMacroRule( _, fof"P(x)", fof"Q(x)" ) ).
         qed
 
@@ -151,63 +151,87 @@ class LKToExpansionProofTest extends Specification with SatMatchers {
     }
 
     "handle atom definitions in non-top position" in {
-      val d = Definition( hoc"P: i>o", le" λx (x = x ∨ (¬ x = x))" )
+      implicit var ctx = Context()
+      ctx += TBase( "i" )
+      ctx += hoc"Q:i>o"
+      ctx += hof"P x = (x = x ∨ (¬ x = x))"
 
       val p = ProofBuilder.
         c( LogicalAxiom( fof"x = x" ) ).
         u( NegRightRule( _, Ant( 0 ) ) ).
         u( OrRightRule( _, Suc( 0 ), Suc( 1 ) ) ).
         u( OrRightMacroRule( _, fof"x = x ∨ ¬ x = x", fof"Q(x)" ) ).
-        u( DefinitionRightRule( _, Suc( 0 ), d, fof"P(x) ∨ Q(x)" ) ).
+        u( DefinitionRightRule( _, Suc( 0 ), fof"P(x) ∨ Q(x)" ) ).
         qed
 
       val e = LKToExpansionProof( p )
+
+      ctx.check( p )
+      ctx.check( e )
 
       e.shallow must_== hos" :- P(x) ∨ Q(x)"
     }
 
     "handle term definitions" in {
-      val d = Definition( hoc"h: i>i", le" λx f (g x)" )
+      implicit var ctx = Context()
+      ctx += TBase( "i" )
+      ctx += hoc"f: i>i"
+      ctx += hoc"g: i>i"
+      ctx += hof"h x = f (g x)"
 
       val p = ProofBuilder.
         c( LogicalAxiom( fof"f( g x) = f (g x)" ) ).
         u( NegRightRule( _, Ant( 0 ) ) ).
         u( OrRightRule( _, Suc( 0 ), Suc( 1 ) ) ).
-        u( DefinitionRightRule( _, Suc( 0 ), d, fof"h x = f (g x) ∨ ¬ f (g x) = f (g x)" ) ).
+        u( DefinitionRightRule( _, Suc( 0 ), fof"h x = f (g x) ∨ ¬ f (g x) = f (g x)" ) ).
         qed
 
       val e = LKToExpansionProof( p )
+
+      ctx.check( p )
+      ctx.check( e )
 
       e.shallow must_== fos":- h x = f (g x) ∨ ¬ f(g x) = f (g x)"
     }
 
     "work on a simple example of a term definition of type o" in {
-      val d = Definition( hoc"P: o", le"Q & R" )
-      val S = hoc"S: o > o"
+      implicit var ctx = Context()
+      ctx += hoc"Q: o"
+      ctx += hoc"R: o"
+      ctx += hoc"S: o >o"
+      ctx += hof"P = (Q & R)"
 
       val p = ProofBuilder.
-        c( LogicalAxiom( hof"$S(Q & R)" ) ).
-        u( DefinitionRightRule( _, Suc( 0 ), d, le"λ (x: o) $S(x)".asInstanceOf[Abs] ) ).
+        c( LogicalAxiom( hof"S(Q & R)" ) ).
+        u( DefinitionRightRule( _, Suc( 0 ), hof"S P" ) ).
         qed
 
       val e = LKToExpansionProof( p )
+
+      ctx.check( p )
+      ctx.check( e )
 
       e.shallow must_== hos"S(Q & R) :- S(P)"
     }
 
     "fail on double negation definition example" in {
-
-      val d = Definition( hoc" n: o>o", le"λx ¬x" )
+      implicit var ctx = Context()
+      ctx += hof"n X = (-X)"
 
       val p = ProofBuilder.
         c( LogicalAxiom( hoa"X" ) ).
         u( NegLeftRule( _, Suc( 0 ) ) ).
         u( NegRightRule( _, Ant( 0 ) ) ).
         u( ImpRightRule( _, Ant( 0 ), Suc( 0 ) ) ).
-        u( DefinitionRightRule( _, Suc( 0 ), d, le"λ(x: o>o) X -> x (x X)".asInstanceOf[Abs] ) ).
+        u( DefinitionRightRule( _, Suc( 0 ), hof"X -> n (n X)" ) ).
         qed
 
-      LKToExpansionProof( p ) must throwAn[IllegalArgumentException]
+      val e = LKToExpansionProof( p )
+
+      ctx.check( p )
+      ctx.check( e )
+
+      e.shallow must_== hos":- X -> n (n X)"
     }
   }
 }


### PR DESCRIPTION
We can change an auxiliary formula into the main formula if they are definitionally equal.  That is, when they reduce to the same normal form in the current context.

The double-negation example works trivially.

If there are no objections, I'll merge this tomorrow.