### PR TITLE
LKt: proof terms for high performance cut normalization

### DIFF
--- a/core/src/main/scala/at/logic/gapt/expr/Polarity.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/Polarity.scala
@@ -19,25 +19,19 @@ package at.logic.gapt.expr
  * in the antecedent of a clause in a resolution proof has the negative/in-antecedent polarity (as it is in the
  * antecedent of a sequent).  However upon conversion to LK/ET, the polarity switches to positive/in-succedent polarity.
  */
-sealed abstract class Polarity {
-  def inSuc: Boolean
+case class Polarity( inSuc: Boolean ) extends AnyVal {
   def inAnt = !inSuc
 
   def positive = inSuc
   def negative = !positive
 
-  def unary_! : Polarity
+  def unary_! : Polarity = Polarity( !inSuc )
+
+  override def toString = if ( inSuc ) "Positive" else "Negative"
 }
 object Polarity {
-  case object Positive extends Polarity {
-    def inSuc = true
-    def unary_! = Negative
-  }
-  case object Negative extends Polarity {
-    def inSuc = false
-    def unary_! = Positive
-
-  }
+  val Positive = Polarity( true )
+  val Negative = Polarity( false )
 
   val InSuccedent = Positive
   val InAntecedent = Negative

--- a/core/src/main/scala/at/logic/gapt/expr/hol/utils.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/hol/utils.scala
@@ -294,7 +294,8 @@ object instantiate {
     case Ex( v, form ) =>
       val sub = Substitution( v, t )
       sub( form )
-    case _ => throw new Exception( "ERROR: trying to replace variables in a formula without quantifier." )
+    case _ =>
+      throw new Exception( "ERROR: trying to replace variables in a formula without quantifier." )
   }
 
   /**

--- a/core/src/main/scala/at/logic/gapt/expr/substitution.scala
+++ b/core/src/main/scala/at/logic/gapt/expr/substitution.scala
@@ -88,7 +88,7 @@ class Substitution( map: Map[Var, Expr], typeMap: Map[TVar, Ty] = Map() ) extend
       ( this.typeMap.keySet ++ that.typeMap.keySet ).map( v => ( v, this( that( v ) ) ) ) )
 
   def restrict( newDomain: Iterable[Var] ): Substitution =
-    Substitution( newDomain.view.map( v => v -> this( v ) ) )
+    Substitution( newDomain.view.map( v => v -> this( v ) ), typeMap )
 
   def isInjectiveOnDomain: Boolean = isInjective( domain )
   def isInjective( dom: Set[Var] ): Boolean =

--- a/core/src/main/scala/at/logic/gapt/proofs/SequentConnector.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/SequentConnector.scala
@@ -109,6 +109,9 @@ case class SequentConnector( lowerSizes: ( Int, Int ), upperSizes: ( Int, Int ),
     else
       throw new IndexOutOfBoundsException
 
+  def children[T]( upperTs: Sequent[T] ): Sequent[Seq[T]] =
+    inv.parents( upperTs )
+
   /**
    * Given a SequentIndex for the upper sequent, this returns the child of that occurrence in the lower sequent
    * (if there is exactly one).

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionTrees.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/expansionTrees.scala
@@ -332,9 +332,9 @@ object ETWeakQuantifierBlock {
         case ETWeakening( _, _ ) =>
       }
 
-    val numberQuants = ( et.polarity, et.shallow ) match {
-      case ( Polarity.InSuccedent, Ex.Block( vs, _ ) )   => vs.size
-      case ( Polarity.InAntecedent, All.Block( vs, _ ) ) => vs.size
+    val numberQuants = et.shallow match {
+      case Ex.Block( vs, _ ) if et.polarity.inSuc  => vs.size
+      case All.Block( vs, _ ) if et.polarity.inAnt => vs.size
     }
 
     walk( et, Seq(), numberQuants )

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/prenexifyET.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/prenexifyET.scala
@@ -7,10 +7,7 @@ import at.logic.gapt.proofs.Sequent
 
 object prenexifyET {
   private def weakQuantifier( polarity: Polarity ) =
-    polarity match {
-      case Positive => Ex
-      case Negative => All
-    }
+    if ( polarity.inSuc ) Ex else All
 
   private def handleBinary(
     f1: Formula, f2: Formula,

--- a/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/expansion/pretty.scala
@@ -1,6 +1,5 @@
 package at.logic.gapt.proofs.expansion
 
-import at.logic.gapt.expr.Polarity.{ Negative, Positive }
 import at.logic.gapt.expr._
 import at.logic.gapt.formats.babel.{ BabelExporter, BabelSignature, Precedence }
 import at.logic.gapt.utils.Doc
@@ -11,10 +10,7 @@ class ExpansionTreePrettyPrinter( sig: BabelSignature ) extends BabelExporter( u
     group( show( et, Map[String, VarOrConst]() )._1.inPrec( 0 ) ).render( lineWidth )
 
   def addPol( doc: Doc, pol: Polarity ) =
-    pol match {
-      case Positive => doc <> "+"
-      case Negative => doc <> "-"
-    }
+    doc <> ( if ( pol.positive ) "+" else "-" )
 
   def show( et: ExpansionTree, t0: Map[String, VarOrConst] ): ( Parenable, Map[String, VarOrConst] ) = et match {
     case ETTop( pol )    => ( Parenable( Precedence.max, addPol( "⊤", pol ) ), t0 )

--- a/core/src/main/scala/at/logic/gapt/proofs/gaptic/macros.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/gaptic/macros.scala
@@ -25,7 +25,7 @@ object LemmaMacros {
     } ) match {
       case Right( ( _, newState ) ) => newState
       case Left( error ) =>
-        throw TacticFailureFailureException( error )
+        throw TacticFailureFailureException( error.defaultState( proofState ) )
     }
 
   import reflect.macros._

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
@@ -1866,10 +1866,11 @@ abstract class DefinitionRule extends UnaryLKProof with CommonRule {
 object DefinitionRule extends ConvenienceConstructor( "DefinitionRule" ) {
   def apply( subProof: LKProof, aux: SequentIndex, main: Formula ): LKProof =
     apply( subProof, aux, main, aux.polarity )
-  def apply( subProof: LKProof, aux: IndexOrFormula, main: Formula, polarity: Polarity ): LKProof = polarity match {
-    case Polarity.InSuccedent  => DefinitionRightRule( subProof, aux, main )
-    case Polarity.InAntecedent => DefinitionLeftRule( subProof, aux, main )
-  }
+  def apply( subProof: LKProof, aux: IndexOrFormula, main: Formula, polarity: Polarity ): LKProof =
+    if ( polarity.inSuc )
+      DefinitionRightRule( subProof, aux, main )
+    else
+      DefinitionLeftRule( subProof, aux, main )
 }
 
 /**

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/lk.scala
@@ -1494,7 +1494,7 @@ object ExistsRightRule extends ConvenienceConstructor( "ExistsRightRule" ) {
 }
 
 object WeakQuantifierRule {
-  def unapply( p: LKProof ) = p match {
+  def unapply( p: UnaryLKProof ) = p match {
     case ForallLeftRule( subProof, aux, f, t, v ) =>
       Some( ( subProof, aux, f, t, v, false ) )
     case ExistsRightRule( subProof, aux, f, t, v ) =>
@@ -1504,7 +1504,7 @@ object WeakQuantifierRule {
 }
 
 object StrongQuantifierRule {
-  def unapply( p: LKProof ) = p match {
+  def unapply( p: UnaryLKProof ) = p match {
     case ExistsLeftRule( subProof, aux, eigen, quant ) =>
       Some( ( subProof, aux, eigen, quant, false ) )
     case ForallRightRule( subProof, aux, eigen, quant ) =>

--- a/core/src/main/scala/at/logic/gapt/proofs/lk/macroRules.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lk/macroRules.scala
@@ -396,7 +396,7 @@ object ForallLeftBlock {
    */
   def withSequentConnector( subProof: LKProof, main: Formula, terms: Seq[Expr] ): ( LKProof, SequentConnector ) = {
     val partiallyInstantiatedMains = ( 0 to terms.length ).toList.reverse.
-      map( n => instantiate( main, terms.take( n ) ) )
+      map( n => BetaReduction.betaNormalize( instantiate( main, terms.take( n ) ) ) )
 
     val series = terms.reverse.foldLeft(
       ( subProof, partiallyInstantiatedMains, SequentConnector( subProof.endSequent ) ) ) { ( acc, ai ) =>

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/atomizeEquality.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/atomizeEquality.scala
@@ -1,0 +1,109 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr._
+
+object atomizeEquality {
+
+  def apply( b: Bound1, lctx: LocalCtx ): Bound1 = b.copy( p = apply( b.p, lctx ) )
+  def apply( b: Bound2, lctx: LocalCtx ): Bound2 = b.copy( p = apply( b.p, lctx ) )
+  def apply( b: BoundN, lctx: LocalCtx ): BoundN = b.copy( p = apply( b.p, lctx ) )
+
+  def apply( p: LKt, lctx: LocalCtx ): LKt = p match {
+    case Cut( f, q1, q2 ) =>
+      Cut( f, apply( q1, lctx.up1( p ) ), apply( q2, lctx.up2( p ) ) )
+    case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) | Link( _, _ ) => p
+    case NegR( main, q ) =>
+      NegR( main, apply( q, lctx.up1( p ) ) )
+    case NegL( main, q ) =>
+      NegL( main, apply( q, lctx.up1( p ) ) )
+    case AndR( main, q1, q2 ) =>
+      AndR( main, apply( q1, lctx.up1( p ) ), apply( q2, lctx.up2( p ) ) )
+    case AndL( main, q ) =>
+      AndL( main, apply( q, lctx.up1( p ) ) )
+    case AllL( main, term, q ) =>
+      AllL( main, term, apply( q, lctx.up1( p ) ) )
+    case AllR( main, ev, q ) =>
+      AllR( main, ev, apply( q, lctx.up1( p ) ) )
+    case Eql( main, eq, ltr, rwCtx @ Abs( _, _: Atom ), q ) =>
+      Eql( main, eq, ltr, rwCtx, apply( q, lctx.up1( p ) ) )
+    case Eql( main, eq, ltr, rwCtx, q ) if main.inAnt =>
+      val aux = Set( main, eq ).fresh( !main.polarity )
+      val cutf = lctx.up1( p )( q.aux )
+      val sim = simulate( rwCtx, ltr, eq, main, aux )
+      Cut( cutf, Bound1( aux, sim ), apply( q, lctx.up1( p ) ) )
+    case Eql( main, eq, ltr, rwCtx, q ) if main.inSuc =>
+      val aux = Set( main, eq ).fresh( !main.polarity )
+      val cutf = lctx.up1( p )( q.aux )
+      val sim = simulate( rwCtx, !ltr, eq, aux, main )
+      Cut( cutf, apply( q, lctx.up1( p ) ), Bound1( aux, sim ) )
+    case AllSk( main, term, skDef, q ) =>
+      AllSk( main, term, skDef, apply( q, lctx.up1( p ) ) )
+    case Def( main, f, q ) =>
+      Def( main, f, apply( q, lctx.up1( p ) ) )
+    case Ind( main, f, term, cases ) =>
+      Ind( main, f, term, cases.zipWithIndex.map { case ( c, i ) => c.copy( q = apply( c.q, lctx.upn( p, i ) ) ) } )
+  }
+
+  /**
+   * Produces a proof of
+   * eq: l=r, left: rwCtx(l) :- right: rwCtx(r)
+   */
+  def simulate( rwCtx: Expr, ltr: Boolean, eq: Hyp, left: Hyp, right: Hyp ): LKt =
+    rwCtx match {
+      case Abs( x, phi ) if !freeVariables( phi ).contains( x ) =>
+        Ax( left, right )
+      case Abs( x, Neg( phi ) ) =>
+        val List( left_, right_ ) =
+          Set( eq, left, right ).freshSameSide( List( left, right ) )
+        NegL( left, Bound1(
+          right_,
+          NegR( right, Bound1(
+            left_,
+            simulate( Abs( x, phi ), !ltr, eq, left_, right_ ) ) ) ) )
+      case Abs( x, And( phi, psi ) ) =>
+        val List( left1, left2, right1, right2 ) =
+          Set( eq, left, right ).freshSameSide( List( left, left, right, right ) )
+        AndL( left, Bound2( left1, left2,
+          AndR(
+            right,
+            Bound1( right1, simulate( Abs( x, phi ), ltr, eq, left1, right1 ) ),
+            Bound1( right2, simulate( Abs( x, psi ), ltr, eq, left2, right2 ) ) ) ) )
+      case Abs( x, Or( phi, psi ) ) =>
+        val List( left1, left2, right1, right2 ) =
+          Set( eq, left, right ).freshSameSide( List( left, left, right, right ) )
+        AndL( right, Bound2( right1, right2,
+          AndR(
+            left,
+            Bound1( left1, simulate( Abs( x, phi ), ltr, eq, left1, right1 ) ),
+            Bound1( left2, simulate( Abs( x, psi ), ltr, eq, left2, right2 ) ) ) ) )
+      case Abs( x, Imp( phi, psi ) ) =>
+        val List( left1, left2, right1, right2 ) =
+          Set( eq, left, right ).freshSameSide( List( left, left, right, right ) )
+        AndL( right, Bound2( left1, right2,
+          AndR(
+            left,
+            Bound1( right1, simulate( Abs( x, phi ), !ltr, eq, left1, right1 ) ),
+            Bound1( left2, simulate( Abs( x, psi ), ltr, eq, left2, right2 ) ) ) ) )
+      case Abs( x, All( y, phi ) ) =>
+        assert( x != y )
+        val List( left_, right_ ) =
+          Set( eq, left, right ).freshSameSide( List( left, right ) )
+        AllR( right, y, Bound1(
+          right_,
+          AllL( left, y, Bound1(
+            left_,
+            simulate( Abs( x, phi ), ltr, eq, left_, right_ ) ) ) ) )
+      case Abs( x, Ex( y, phi ) ) =>
+        assert( x != y )
+        val List( left_, right_ ) =
+          Set( eq, left, right ).freshSameSide( List( left, right ) )
+        AllR( left, y, Bound1(
+          left_,
+          AllL( right, y, Bound1(
+            right_,
+            simulate( Abs( x, phi ), ltr, eq, left_, right_ ) ) ) ) )
+      case _ =>
+        Eql( left, eq, ltr, rwCtx, Bound1( left, Ax( left, right ) ) )
+    }
+
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/checker.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/checker.scala
@@ -1,0 +1,72 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr.Polarity._
+import at.logic.gapt.expr._
+import at.logic.gapt.proofs.Context
+import at.logic.gapt.utils.Maybe
+
+object check {
+  private def requireEq( a: Expr, b: Expr ): Unit =
+    require( a == b, ( -( a === b ) ).toUntypedString )
+  def apply( p: LKt, lctx: LocalCtx )( implicit ctx: Maybe[Context] ): Unit = {
+    p match {
+      case Cut( f, q1, q2 ) =>
+        require( q1.aux.inSuc && q2.aux.inAnt )
+        ctx.foreach( _.check( f ) )
+        check( q1.p, lctx.up1( p ) )
+        check( q2.p, lctx.up2( p ) )
+      case Ax( main1, main2 ) =>
+        require( main1.inAnt && main2.inSuc )
+        requireEq( lctx( main1 ), lctx( main2 ) )
+      case Rfl( main ) =>
+        require( main.inSuc )
+        lctx( main ) match { case Eq( t, s ) => require( t == s ) }
+      case TopR( main ) =>
+        requireEq( lctx( main ), if ( main.inSuc ) Top() else Bottom() )
+      case NegR( main, q ) =>
+        require( main.inSuc && q.aux.inAnt )
+        check( q.p, lctx.up1( p ) )
+      case NegL( main, q ) =>
+        require( main.inAnt && q.aux.inSuc )
+        check( q.p, lctx.up1( p ) )
+      case AndR( main, q1, q2 ) =>
+        ( lctx( main ), main.polarity, q1.aux.polarity, q2.aux.polarity ) match {
+          case ( And( _, _ ), InSuccedent, InSuccedent, InSuccedent )   =>
+          case ( Or( _, _ ), InAntecedent, InAntecedent, InAntecedent ) =>
+          case ( Imp( _, _ ), InAntecedent, InSuccedent, InAntecedent ) =>
+        }
+        check( q1.p, lctx.up1( p ) )
+        check( q2.p, lctx.up2( p ) )
+      case AndL( main, q ) =>
+        ( lctx( main ), main.polarity, q.aux1.polarity, q.aux2.polarity ) match {
+          case ( And( _, _ ), InAntecedent, InAntecedent, InAntecedent ) =>
+          case ( Or( _, _ ), InSuccedent, InSuccedent, InSuccedent )     =>
+          case ( Imp( _, _ ), InSuccedent, InAntecedent, InSuccedent )   =>
+        }
+        check( q.p, lctx.up1( p ) )
+      case AllL( main, term, q ) =>
+        require( main.inSuc == q.aux.inSuc )
+        lctx( main ) match {
+          case All( _, _ ) => require( main.inAnt )
+          case Ex( _, _ )  => require( main.inSuc )
+        }
+        ctx.foreach( _.check( term ) )
+        check( q.p, lctx.up1( p ) )
+      case AllR( main, ev, q ) =>
+        require( main.inSuc == q.aux.inSuc )
+        lctx( main ) match {
+          case All( _, _ ) => require( main.inSuc )
+          case Ex( _, _ )  => require( main.inAnt )
+        }
+        ctx.foreach( _.check( ev ) )
+        check( q.p, lctx.up1( p ) )
+      case p @ Eql( main, eq, _, rwCtx, _ ) =>
+        require( eq.inAnt )
+        requireEq( BetaReduction.betaNormalize( lctx.subst( rwCtx ).apply( lctx.eqLhs( p ) ) ), lctx( main ) )
+        ctx.foreach( _.check( rwCtx ) )
+        check( p.q.p, lctx.up1( p ) )
+    }
+    () // prevent TCO
+  }
+}
+

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/checker.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/checker.scala
@@ -2,7 +2,7 @@ package at.logic.gapt.proofs.lkt
 
 import at.logic.gapt.expr.Polarity._
 import at.logic.gapt.expr._
-import at.logic.gapt.proofs.Context
+import at.logic.gapt.proofs.{ Checkable, Context, Sequent }
 import at.logic.gapt.utils.Maybe
 
 object check {
@@ -60,11 +60,44 @@ object check {
         }
         ctx.foreach( _.check( ev ) )
         check( q.p, lctx.up1( p ) )
-      case p @ Eql( main, eq, _, rwCtx, _ ) =>
+      case p @ Eql( main, eq, _, rwCtx, q ) =>
         require( eq.inAnt )
         requireEq( BetaReduction.betaNormalize( lctx.subst( rwCtx ).apply( lctx.eqLhs( p ) ) ), lctx( main ) )
         ctx.foreach( _.check( rwCtx ) )
-        check( p.q.p, lctx.up1( p ) )
+        check( q.p, lctx.up1( p ) )
+      case AllSk( main, term0, skDef, q ) =>
+        val term = lctx.subst( term0 )
+        val Apps( skSym: Const, skArgs ) = term
+        requireEq( BetaReduction.betaNormalize( skDef( skArgs ) ), lctx( main ) )
+        for ( ctx_ <- ctx )
+          require( ctx_.skolemDef( skSym ).contains( skDef ) )
+        check( q.p, lctx.up1( p ) )
+      case Def( main, f0, q ) =>
+        val f = lctx.subst( f0 )
+        for ( ctx_ <- ctx )
+          Checkable.requireDefEq( lctx( main ), f )( ctx_ )
+        check( q.p, lctx.up1( p ) )
+      case p @ Ind( main, f0, t0, cases ) =>
+        val ( f: Abs, t ) = lctx.subst( ( f0, t0 ) )
+        requireEq( lctx( main ), Substitution( f.variable -> t )( f.term ) )
+        for ( ctx_ <- ctx ) {
+          val Some( ctrs ) = ctx_.getConstructors( p.indTy )
+          require( ctrs.size == cases.size )
+          for ( ( c, ctr ) <- cases.zip( ctrs ) ) {
+            require( c.ctr == ctr )
+            ctx_.check( c.ctr( c.evs ) )
+          }
+        }
+        for ( ( c, i ) <- cases.zipWithIndex )
+          check( c.q.p, lctx.upn( p, i ) )
+      case Link( mains, name0 ) =>
+        val name = lctx.subst( name0 )
+        for ( ctx_ <- ctx ) {
+          val declSeq = ctx_.get[Context.ProofNames].lookup( name )
+          require( declSeq.nonEmpty )
+          val refSeq = Sequent( for ( m <- mains ) yield lctx( m ) -> m.polarity )
+          require( declSeq.contains( refSeq ) )
+        }
     }
     () // prevent TCO
   }

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
@@ -60,12 +60,12 @@ object LKToLKt {
             AndL( main, b )
         }
       case p @ lk.WeakQuantifierRule( p1, a1, _, t, _, isEx ) =>
-        val aux = Hyp.mk( idx, inSuc = isEx )
+        val aux = Hyp.mk( idx, if ( isEx ) Polarity.InSuccedent else Polarity.InAntecedent )
         AllL( hyps( p.mainIndices.head ), t, Bound1(
           aux,
           go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, aux ) ) ) )
       case p @ lk.StrongQuantifierRule( p1, a1, ev, _, isAll ) =>
-        val aux = Hyp.mk( idx, inSuc = isAll )
+        val aux = Hyp.mk( idx, if ( isAll ) Polarity.InSuccedent else Polarity.InAntecedent )
         AllR( hyps( p.mainIndices.head ), ev, Bound1(
           aux,
           go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, aux ) ) ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
@@ -5,7 +5,7 @@ import at.logic.gapt.proofs.Sequent
 import at.logic.gapt.proofs.lk
 import lk.LKProof
 
-class LKToLKt( debugging: Boolean ) {
+trait FreshHyp {
   private var idx = 0
 
   def fresh( pol: Polarity ): Hyp = {
@@ -15,6 +15,10 @@ class LKToLKt( debugging: Boolean ) {
   def freshAnt() = fresh( Polarity.InAntecedent )
   def freshSuc() = fresh( Polarity.InSuccedent )
 
+  def markUsed( h: Hyp ) = idx = math.max( idx, math.abs( h.idx ) + 1 )
+}
+
+class LKToLKt( debugging: Boolean ) extends FreshHyp {
   def go( p: lk.LKProof, hyps: Sequent[Hyp] ): LKt = {
     val result = p match {
       case p: lk.ContractionRule              => go( p.subProof, p.getSequentConnector.parent( hyps ) )

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
@@ -15,7 +15,8 @@ trait FreshHyp {
   def freshAnt() = fresh( Polarity.InAntecedent )
   def freshSuc() = fresh( Polarity.InSuccedent )
 
-  def markUsed( h: Hyp ) = idx = math.max( idx, math.abs( h.idx ) + 1 )
+  def markUsed( h: Hyp ): Unit = idx = math.max( idx, math.abs( h.idx ) + 1 )
+  def markUsed( p: LKt ): Unit = p.containedHyps.foreach( markUsed )
 }
 
 class LKToLKt( debugging: Boolean ) extends FreshHyp {

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/convert.scala
@@ -1,0 +1,190 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr._
+import at.logic.gapt.proofs.Sequent
+import at.logic.gapt.proofs.lk
+import lk.LKProof
+
+object LKToLKt {
+  private def go( p: lk.LKProof, idx: Int, hyps: Sequent[Hyp] ): LKt = {
+    val res = p match {
+      case p: lk.ContractionRule              => go( p.subProof, idx, p.getSequentConnector.parent( hyps ) )
+      case p @ lk.WeakeningLeftRule( p1, _ )  => go( p1, idx, p.getSequentConnector.parent( hyps ) )
+      case p @ lk.WeakeningRightRule( p1, _ ) => go( p1, idx, p.getSequentConnector.parent( hyps ) )
+      case p @ lk.CutRule( p1, _, p2, _ ) =>
+        Cut(
+          p.cutFormula,
+          Bound1( Hyp( idx ), go( p1, idx + 1, p.getLeftSequentConnector.parent( hyps, Hyp( idx ) ) ) ),
+          Bound1( Hyp( -idx ), go( p2, idx + 1, p.getRightSequentConnector.parent( hyps, Hyp( -idx ) ) ) ) )
+      case lk.LogicalAxiom( _ )     => Ax( hyps.antecedent.head, hyps.succedent.head )
+      case lk.ReflexivityAxiom( _ ) => Rfl( hyps.succedent.head )
+      case lk.TopAxiom              => TopR( hyps.succedent.head )
+      case lk.BottomAxiom           => TopR( hyps.antecedent.head )
+      case p @ lk.NegRightRule( p1, a1 ) =>
+        NegR( hyps( p.mainIndices.head ), Bound1(
+          Hyp( -idx ),
+          go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, Hyp( -idx ) ) ) ) )
+      case p @ lk.NegLeftRule( p1, a1 ) =>
+        NegL( hyps( p.mainIndices.head ), Bound1(
+          Hyp( idx ),
+          go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, Hyp( idx ) ) ) ) )
+      case p: lk.BinaryLKProof =>
+        val hyp = hyps( p.mainIndices.head )
+        val Seq( Seq( a1 ), Seq( a2 ) ) = p.auxIndices
+        val aux1 = if ( a1.isSuc ) Hyp( idx ) else Hyp( -idx )
+        val aux2 = if ( a2.isSuc ) Hyp( idx ) else Hyp( -idx )
+        val b1 = Bound1( aux1, go( p.leftSubProof, idx + 1, p.getLeftSequentConnector.parent( hyps ).updated( a1, aux1 ) ) )
+        val b2 = Bound1( aux2, go( p.rightSubProof, idx + 1, p.getRightSequentConnector.parent( hyps ).updated( a2, aux2 ) ) )
+        p match {
+          case lk.AndRightRule( _, _, _, _ ) | lk.OrLeftRule( _, _, _, _ ) | lk.ImpLeftRule( _, _, _, _ ) =>
+            AndR( hyp, b1, b2 )
+        }
+      case p: lk.EqualityRule =>
+        val main = hyps( p.auxInConclusion )
+        val aux = if ( main.inSuc ) Hyp( idx ) else Hyp( -idx )
+        val eq = hyps( p.eqInConclusion )
+        Eql( main, eq, !p.leftToRight, p.replacementContext, Bound1(
+          aux,
+          go( p.subProof, idx + 1, p.getSequentConnector.parents( hyps ).map( _.head ).
+            updated( p.aux, aux ).updated( p.eq, eq ) ) ) )
+      case p: lk.UnaryLKProof if p.auxIndices.head.size == 2 =>
+        val Seq( a1, a2 ) = p.auxIndices.head
+        val aux1 = if ( a1.isSuc ) Hyp( idx ) else Hyp( -idx )
+        val aux2 = if ( a2.isSuc ) Hyp( idx + 1 ) else Hyp( -( idx + 1 ) )
+        val b = Bound2( aux1, aux2,
+          go( p.subProof, idx + 2,
+            p.getSequentConnector.parent( hyps ).updated( a1, aux1 ).updated( a2, aux2 ) ) )
+        val main = hyps( p.mainIndices.head )
+        p match {
+          case lk.AndLeftRule( _, _, _ ) | lk.OrRightRule( _, _, _ ) | lk.ImpRightRule( _, _, _ ) =>
+            AndL( main, b )
+        }
+      case p @ lk.WeakQuantifierRule( p1, a1, _, t, _, isEx ) =>
+        val aux = if ( isEx ) Hyp( idx ) else Hyp( -idx )
+        AllL( hyps( p.mainIndices.head ), t, Bound1(
+          aux,
+          go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, aux ) ) ) )
+      case p @ lk.StrongQuantifierRule( p1, a1, ev, _, isAll ) =>
+        val aux = if ( isAll ) Hyp( idx ) else Hyp( -idx )
+        AllR( hyps( p.mainIndices.head ), ev, Bound1(
+          aux,
+          go( p1, idx + 1, p.getSequentConnector.parent( hyps ).updated( a1, aux ) ) ) )
+    }
+    //    check( res, LocalCtx( hyps.zip( p.endSequent ).elements.toMap, Substitution() ) )
+    res
+  }
+
+  def apply( p: LKProof ): ( LKt, LocalCtx ) = {
+    var idx = 0
+    val hyps = p.endSequent.indicesSequent.map { i =>
+      idx += 1
+      if ( i.isSuc ) Hyp( idx ) else Hyp( -idx )
+    }
+    go( p, idx + 1, hyps ) -> LocalCtx( hyps.zip( p.endSequent ).elements.toMap, Substitution() )
+  }
+}
+
+object LKtToLK {
+  import at.logic.gapt.proofs.lk
+
+  private def down( p: LKProof, s: Sequent[Hyp], main: Hyp ): ( LKProof, Sequent[Hyp] ) =
+    p -> p.occConnectors.head.child( s, main ).updated( p.mainIndices.head, main )
+  private def down( r: LKProof, s1: Sequent[Hyp], s2: Sequent[Hyp], main: Hyp ): ( LKProof, Sequent[Hyp] ) =
+    r -> r.occConnectors.head.children( s1 ).zip( r.occConnectors( 1 ).children( s2 ) ).
+      map { case ( cs1, cs2 ) => ( cs1.view ++ cs2 ).head }.
+      updated( r.mainIndices.head, main )
+
+  private def withMap( b: Bound1, lctx: LocalCtx ): ( LKProof, Sequent[Hyp] ) = withMap( b.p, lctx, b.aux )
+  private def withMap( b: Bound2, lctx: LocalCtx ): ( LKProof, Sequent[Hyp] ) = withMap( b.p, lctx, b.aux1, b.aux2 )
+  private def withMap( p: LKt, lctx: LocalCtx, toBeWeakenedIn: Hyp* ): ( LKProof, Sequent[Hyp] ) =
+    toBeWeakenedIn match {
+      case h +: hs =>
+        val ( r1, s1 ) = withMap( p, lctx, hs: _* )
+        if ( s1.contains( h ) ) ( r1, s1 ) else {
+          val r2 = if ( h.inAnt ) lk.WeakeningLeftRule( r1, lctx( h ) ) else lk.WeakeningRightRule( r1, lctx( h ) )
+          down( r2, s1, h )
+        }
+      case Seq() => withMap( p, lctx )
+    }
+
+  private def contract( res: ( LKProof, Sequent[Hyp] ) ): ( LKProof, Sequent[Hyp] ) = {
+    val ( r1, s1 ) = res
+    s1.elements.diff( s1.elements.distinct ).headOption match {
+      case Some( dup ) =>
+        val Seq( a1, a2, _* ) = s1.indicesWhere( _ == dup )
+        val r2 = if ( dup.inAnt ) lk.ContractionLeftRule( r1, a1, a2 )
+        else lk.ContractionRightRule( r1, a1, a2 )
+        contract( down( r2, s1, dup ) )
+      case None => res
+    }
+  }
+
+  def withMap( p: LKt, lctx: LocalCtx ): ( LKProof, Sequent[Hyp] ) =
+    contract( p match {
+      case Cut( _, q1, q2 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        val ( r2, s2 ) = withMap( q2, lctx.up2( p ) )
+        val r = lk.CutRule( r1, s1.indexOf( q1.aux ), r2, s2.indexOf( q2.aux ) )
+        r -> r.getLeftSequentConnector.children( s1 ).zip( r.getRightSequentConnector.children( s2 ) ).
+          map { case ( cs1, cs2 ) => ( cs1 ++ cs2 ).head }
+      case Ax( main1, main2 ) => ( lk.LogicalAxiom( lctx( main1 ) ), main1 +: Sequent() :+ main2 )
+      case Rfl( main ) =>
+        val Eq( t, _ ) = lctx( main )
+        ( lk.ReflexivityAxiom( t ), Sequent() :+ main )
+      case TopR( main ) if main.inAnt => ( lk.BottomAxiom, main +: Sequent() )
+      case TopR( main ) if main.inSuc => ( lk.TopAxiom, Sequent() :+ main )
+      case NegR( main, q1 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        down( lk.NegRightRule( r1, s1.indexOf( q1.aux ) ), s1, main )
+      case NegL( main, q1 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        down( lk.NegLeftRule( r1, s1.indexOf( q1.aux ) ), s1, main )
+      case AndR( main, q1, q2 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        val ( r2, s2 ) = withMap( q2, lctx.up2( p ) )
+        val r = lctx( main ) match {
+          case And( _, _ ) => lk.AndRightRule( r1, s1.indexOf( q1.aux ), r2, s2.indexOf( q2.aux ) )
+          case Or( _, _ )  => lk.OrLeftRule( r1, s1.indexOf( q1.aux ), r2, s2.indexOf( q2.aux ) )
+          case Imp( _, _ ) => lk.ImpLeftRule( r1, s1.indexOf( q1.aux ), r2, s2.indexOf( q2.aux ) )
+        }
+        down( r, s1, s2, main )
+      case AndL( main, q1 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        val r = lctx( main ) match {
+          case And( _, _ ) => lk.AndLeftRule( r1, s1.indexOf( q1.aux1 ), s1.indexOf( q1.aux2 ) )
+          case Or( _, _ )  => lk.OrRightRule( r1, s1.indexOf( q1.aux1 ), s1.indexOf( q1.aux2 ) )
+          case Imp( _, _ ) => lk.ImpRightRule( r1, s1.indexOf( q1.aux1 ), s1.indexOf( q1.aux2 ) )
+        }
+        down( r, s1, main )
+      case AllL( main, term, q1 ) =>
+        val ( r1, s1 ) = withMap( q1, lctx.up1( p ) )
+        val r = lctx( main ) match {
+          case All( _, _ ) => lk.ForallLeftRule( r1, s1.indexOf( q1.aux ), lctx( main ), lctx.subst( term ) )
+          case Ex( _, _ )  => lk.ExistsRightRule( r1, s1.indexOf( q1.aux ), lctx( main ), lctx.subst( term ) )
+        }
+        down( r, s1, main )
+      case AllR( main, ev0, q1 ) =>
+        val lctx1 = lctx.up1( p )
+        val ( r1, s1 ) = withMap( q1, lctx1 )
+        val ev = lctx1.subst( ev0 ).asInstanceOf[Var]
+        val r = lctx( main ) match {
+          case All( _, _ ) => lk.ForallRightRule( r1, s1.indexOf( q1.aux ), lctx( main ), ev )
+          case Ex( _, _ )  => lk.ExistsLeftRule( r1, s1.indexOf( q1.aux ), lctx( main ), ev )
+        }
+        down( r, s1, main )
+      case Eql( main, eq, ltr, rwCtx0, q1 ) if q1.aux == eq =>
+        withMap( Eql( main, eq, ltr, rwCtx0, q1.rename( Seq( eq ) ) ), lctx )
+      case Eql( main, eq, _, rwCtx0, q1 ) =>
+        val ( r1, s1 ) = withMap( q1.p, lctx.up1( p ), q1.aux )
+        val r2 = lk.WeakeningLeftRule( r1, lctx( eq ) )
+        val s2 = r2.getSequentConnector.child( s1, eq )
+        val rwCtx = lctx.subst( rwCtx0 )
+        val r =
+          if ( main.inAnt ) lk.EqualityLeftRule( r2, s2.indexOf( eq ), s2.indexOf( q1.aux ), rwCtx.asInstanceOf[Abs] )
+          else lk.EqualityRightRule( r2, s2.indexOf( eq ), s2.indexOf( q1.aux ), rwCtx.asInstanceOf[Abs] )
+        r -> r.getSequentConnector.child( s2, main ).updated( r.eqInConclusion, eq ).updated( r.auxInConclusion, main )
+    } )
+
+  def apply( p: LKt, lctx: LocalCtx ): LKProof = withMap( p, lctx )._1
+}
+

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/localctx.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/localctx.scala
@@ -14,6 +14,7 @@ object BinConn {
 
 case class LocalCtx( hyps: Map[Hyp, Formula], subst: Substitution ) extends ALCtx[LocalCtx] {
   def updated( hyp: Hyp, f: Formula ): LocalCtx = copy( hyps.updated( hyp, f ) )
+  def updated( hs: Iterable[( Hyp, Formula )] ): LocalCtx = copy( hyps = hyps ++ hs )
   def renamed( a: Hyp, b: Hyp ): LocalCtx = copy( hyps = hyps - a + ( b -> hyps( a ) ) )
   def apply( hyp: Hyp ) = hyps( hyp )
   def formulas = hyps.values

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/localctx.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/localctx.scala
@@ -1,0 +1,98 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr._
+import at.logic.gapt.expr.hol.instantiate
+
+object BinConn {
+  def unapply( f: Formula ): Option[( Formula, Formula )] =
+    f match {
+      case And( g1, g2 ) => Some( g1, g2 )
+      case Or( g1, g2 )  => Some( g1, g2 )
+      case Imp( g1, g2 ) => Some( g1, g2 )
+    }
+}
+
+case class LocalCtx( hyps: Map[Hyp, Formula], subst: Substitution ) extends ALCtx[LocalCtx] {
+  def updated( hyp: Hyp, f: Formula ): LocalCtx = copy( hyps.updated( hyp, f ) )
+  def renamed( a: Hyp, b: Hyp ): LocalCtx = copy( hyps = hyps - a + ( b -> hyps( a ) ) )
+  def apply( hyp: Hyp ) = hyps( hyp )
+  def formulas = hyps.values
+  def freeVars = freeVariables( hyps.values )
+
+  override def toString =
+    hyps.toSeq.sortBy( _._1.idx ).map( p => s"${p._1} -> ${p._2}" ).mkString( "\n" ) + "\n" + subst
+
+  def up( f: Formula ): LC1 = h => updated( h, f )
+  def up( f1: Formula, f2: Formula ): LC2 = ( h1, h2 ) => updated( h1, f1 ).updated( h2, f2 )
+
+  def upS( f: Formula ): LC1 = up( subst( f ) )
+  def upS( f1: Formula, f2: Formula ): LC2 = up( subst( f1 ), subst( f2 ) )
+
+  def up1_( p: LKt ): LC1 = ( p: @unchecked ) match {
+    case Cut( f, _, _ )     => up( subst( f ) )
+    case AndR( main, _, _ ) => up( hyps( main ) match { case BinConn( g, _ ) => g } )
+    case NegR( main, _ )    => up( hyps( main ) match { case Neg( g ) => g } )
+    case NegL( main, _ )    => up( hyps( main ) match { case Neg( g ) => g } )
+    case p: Eql =>
+      up( BetaReduction.betaNormalize( subst( p.rwCtx ).apply( eqRhs( p ) ).asInstanceOf[Formula] ) )
+    case p: AllL => up( BetaReduction.betaNormalize( instantiate( hyps( p.main ), subst( p.term ) ) ) )
+    case p: AllR =>
+      if ( subst.domain( p.ev ) ) {
+        copy( subst = Substitution( subst.map - p.ev, subst.typeMap ) ).up1_( p )
+      } else {
+        val ev = rename( p.ev, subst.range union subst.domain union freeVars )
+        copy( subst = subst compose Substitution( p.ev -> ev ) ).
+          up( instantiate( hyps( p.main ), ev ) )
+      }
+  }
+  def up12_( p: LKt ): LC2 = ( p: @unchecked ) match {
+    case AndL( main, _ ) => hyps( main ) match { case BinConn( f, g ) => up( f, g ) }
+  }
+  def up2_( p: LKt ): LC1 = ( p: @unchecked ) match {
+    case c: Cut  => up( subst( c.f ) )
+    case p: AndR => up( hyps( p.main ) match { case BinConn( _, g ) => g } )
+  }
+
+  def eqLhs( p: Eql ) = hyps( p.eq ) match { case Eq( t, s ) => if ( p.ltr ) t else s }
+  def eqRhs( p: Eql ) = hyps( p.eq ) match { case Eq( t, s ) => if ( p.ltr ) s else t }
+}
+
+trait B1[LC <: ALCtx[LC]] { def apply( h: Hyp ): LC }
+trait B2[LC <: ALCtx[LC]] { def apply( h1: Hyp, h2: Hyp ): LC }
+
+trait ALCtx[LC <: ALCtx[LC]] {
+  type LC1 = B1[LC]
+  type LC2 = B2[LC]
+
+  def up1_( p: LKt ): LC1
+  def up12_( p: LKt ): LC2
+  def up2_( p: LKt ): LC1
+  def renamed( a: Hyp, b: Hyp ): LC
+
+  def up1( p: LKt ): LC = ( p: @unchecked ) match {
+    case Cut( _, q1, _ )      => up1_( p )( q1.aux )
+    case NegR( _, q )         => up1_( p )( q.aux )
+    case NegL( _, q )         => up1_( p )( q.aux )
+    case AndR( _, q1, _ )     => up1_( p )( q1.aux )
+    case AndL( _, q )         => up12_( p )( q.aux1, q.aux2 )
+    case AllL( _, _, q )      => up1_( p )( q.aux )
+    case AllR( _, _, q )      => up1_( p )( q.aux )
+    case Eql( _, _, _, _, q ) => up1_( p )( q.aux )
+  }
+  def up2( p: LKt ): LC = ( p: @unchecked ) match {
+    case Cut( _, _, q2 )  => up2_( p )( q2.aux )
+    case AndR( _, _, q2 ) => up2_( p )( q2.aux )
+  }
+
+  def upS( f: Formula ): LC1
+  def upS( f1: Formula, f2: Formula ): LC2
+}
+class FakeLocalCtx extends ALCtx[FakeLocalCtx] {
+  def up1_( p: LKt ): LC1 = upS( null )
+  def up12_( p: LKt ): LC2 = upS( null, null )
+  def up2_( p: LKt ): LC1 = up1_( p )
+  def renamed( a: Hyp, b: Hyp ): FakeLocalCtx = this
+  def upS( f: Formula ): LC1 = _ => this
+  def upS( f1: Formula, f2: Formula ): LC2 = ( _, _ ) => this
+}
+case object FakeLocalCtx extends FakeLocalCtx

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/makeEqualityExplicit.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/makeEqualityExplicit.scala
@@ -1,0 +1,75 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr.{ All, BetaReduction, Eq, Expr, Formula, Ty, Var, freeVariables, rename }
+
+import scala.collection.mutable
+
+class makeEqualityExplicit( debugging: Boolean ) extends FreshHyp {
+  // (replacement context, ltr) |-> (hyp, eqAxiom)
+  val rwrHyps = mutable.Map[( Expr, Boolean ), ( Hyp, Formula )]()
+
+  // ty |-> (hyp, rflAxiom)
+  val reflHyps = mutable.Map[Ty, ( Hyp, Formula )]()
+
+  def effectiveLCtx( lctx: LocalCtx ): LocalCtx =
+    lctx.updated( rwrHyps.values ).updated( reflHyps.values )
+
+  def apply( p: LKt, lctx: LocalCtx ): ( LKt, LocalCtx ) = {
+    markUsed( p )
+    val q = go( p, lctx )
+    q -> effectiveLCtx( lctx )
+  }
+
+  def go( b: Bound1, lctx: LocalCtx ): Bound1 = b.copy( p = go( b.p, lctx ) )
+  def go( b: Bound2, lctx: LocalCtx ): Bound2 = b.copy( p = go( b.p, lctx ) )
+  def go( b: BoundN, lctx: LocalCtx ): BoundN = b.copy( p = go( b.p, lctx ) )
+  def go( p: LKt, lctx: LocalCtx ): LKt = {
+    val result = p match {
+      case Cut( f, q1, q2 )                      => Cut( f, go( q1, lctx.up1( p ) ), go( q2, lctx.up2( p ) ) )
+      case Ax( _, _ ) | TopR( _ ) | Link( _, _ ) => p
+      case Rfl( main ) =>
+        val Eq( t, _ ) = lctx( main )
+        val rflHyp = reflHyps.getOrElseUpdate( t.ty, {
+          val x = Var( "x", t.ty )
+          ( freshAnt(), All( x, x === x ) )
+        } )._1
+        AllL( rflHyp, t, Bound1( rflHyp, Ax( rflHyp, main ) ) )
+      case NegR( main, q )       => NegR( main, go( q, lctx.up1( p ) ) )
+      case NegL( main, q )       => NegL( main, go( q, lctx.up1( p ) ) )
+      case AndR( main, q1, q2 )  => AndR( main, go( q1, lctx.up1( p ) ), go( q2, lctx.up2( p ) ) )
+      case AndL( main, q )       => AndL( main, go( q, lctx.up1( p ) ) )
+      case AllL( main, term, q ) => AllL( main, term, go( q, lctx.up1( p ) ) )
+      case AllR( main, ev, q )   => AllR( main, ev, go( q, lctx.up1( p ) ) )
+      case Eql( main, eq, ltr, rwCtx, q ) =>
+        val Eq( l, r ) = lctx( eq )
+        val extraVars = freeVariables( rwCtx ).toList
+        val effLtr = ltr == main.inAnt
+        val rwrHyp = rwrHyps.getOrElseUpdate( ( rwCtx, effLtr ), {
+          val nameGen = rename.awayFrom( extraVars )
+          val x = nameGen.fresh( Var( "x", l.ty ) )
+          val y = nameGen.fresh( Var( "y", l.ty ) )
+          val ax = All.Block( extraVars :+ x :+ y, ( x === y ) --> BetaReduction.betaNormalize(
+            if ( effLtr ) rwCtx( x ) --> rwCtx( y ) else rwCtx( y ) --> rwCtx( x ) ) )
+          ( freshAnt(), ax )
+        } )._1
+        val aux = freshSuc()
+        AllLBlock( rwrHyp, extraVars :+ l :+ r, Bound1( rwrHyp, AndR( rwrHyp, Bound1( aux, Ax( eq, aux ) ),
+          Bound1( rwrHyp, AndR(
+            rwrHyp,
+            Bound1( aux, if ( main.inAnt ) Ax( main, aux ) else go( q, lctx.up1( p ) ).inst( aux ) ),
+            Bound1( rwrHyp, if ( main.inSuc ) Ax( rwrHyp, main ) else go( q, lctx.up1( p ) ).inst( rwrHyp ) ) ) ) ) ) )
+      case AllSk( main, term, skDef, q ) => AllSk( main, term, skDef, go( q, lctx.up1( p ) ) )
+      case Def( main, f, q )             => Def( main, f, go( q, lctx.up1( p ) ) )
+      case Ind( main, f, term, cases ) =>
+        Ind( main, f, term, cases.zipWithIndex.map { case ( c, i ) => c.copy( q = go( c.q, lctx.upn( p, i ) ) ) } )
+    }
+    if ( debugging ) check( result, effectiveLCtx( lctx ) )
+    result
+  }
+
+}
+
+object makeEqualityExplicit {
+  def apply( p: LKt, lctx: LocalCtx, debugging: Boolean = false ): ( LKt, LocalCtx ) =
+    new makeEqualityExplicit( debugging ).apply( p, lctx )
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
@@ -27,30 +27,30 @@ class Normalizer[LC <: ALCtx[LC]]( skipAtomicCuts: Boolean = false, skipProposit
 
     def apply( p: LKt, lctx: LC ): LKt = p match {
       case _ if !p.freeHyps( hyp ) => p
-      case Cut( f, q1, q2 )        => Cut( f, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
+      case Cut( f, q1, q2 )        => Cut.f( f, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
       case Ax( m1, m2 ) =>
         if ( hyp == m1 ) by.inst( m2 )
         else if ( hyp == m2 ) by.inst( m1 )
         else p
       case Rfl( main ) if main != hyp     => p
       case TopR( cohyp ) if cohyp != hyp  => p
-      case NegR( main, q ) if main != hyp => NegR( main, apply( q, lctx.up1_( p ) ) )
-      case NegL( main, q ) if main != hyp => NegL( main, apply( q, lctx.up1_( p ) ) )
+      case NegR( main, q ) if main != hyp => NegR.f( main, apply( q, lctx.up1_( p ) ) )
+      case NegL( main, q ) if main != hyp => NegL.f( main, apply( q, lctx.up1_( p ) ) )
       case AndR( main, q1, q2 ) if main != hyp =>
-        AndR( main, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
-      case AndL( main, q ) if main != hyp       => AndL( main, apply( q, lctx.up12_( p ) ) )
-      case AllL( main, term, q ) if main != hyp => AllL( main, term, apply( q, lctx.up1_( p ) ) )
+        AndR.f( main, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
+      case AndL( main, q ) if main != hyp       => AndL.f( main, apply( q, lctx.up12_( p ) ) )
+      case AllL( main, term, q ) if main != hyp => AllL.f( main, term, apply( q, lctx.up1_( p ) ) )
       case AllR( main, ev, q ) if main != hyp =>
-        if ( !by.p.freeVars( ev ) ) AllR( main, ev, apply( q, lctx.up1_( p ) ) ) else {
+        if ( !by.p.freeVars( ev ) ) AllR.f( main, ev, apply( q, lctx.up1_( p ) ) ) else {
           val ev_ = rename( ev, by.p.freeVars union p.freeVars )
-          apply( AllR( main, ev_, Substitution( ev -> ev_ )( q ) ), lctx )
+          apply( AllR.f( main, ev_, Substitution( ev -> ev_ )( q ) ), lctx )
         }
       case Eql( main, eq, ltr, rwCtx, q ) if main != hyp && eq != hyp =>
-        Eql( main, eq, ltr, rwCtx, apply( q, lctx.up1_( p ) ) )
+        Eql.f( main, eq, ltr, rwCtx, apply( q, lctx.up1_( p ) ) )
       case AllSk( main, term, skDef, q ) if main != hyp =>
-        AllSk( main, term, skDef, apply( q, lctx.up1_( p ) ) )
+        AllSk.f( main, term, skDef, apply( q, lctx.up1_( p ) ) )
       case Def( main, f, q ) if main != hyp =>
-        Def( main, f, apply( q, lctx.up1_( p ) ) )
+        Def.f( main, f, apply( q, lctx.up1_( p ) ) )
       case Ind( main, f, t, cases ) if main != hyp =>
         Ind( main, f, t, for ( ( c, n ) <- cases.zipWithIndex ) yield c.copy( q = apply( c.q, lctx.upn_( p, n ) ) ) )
       case Link( mains, _ ) if !mains.contains( hyp ) => p
@@ -68,15 +68,15 @@ class Normalizer[LC <: ALCtx[LC]]( skipAtomicCuts: Boolean = false, skipProposit
     case Cut( f, q1, q2 ) =>
       evalCut( lctx, f, normalize( q1, lctx.up1( p ) ), normalize( q2, lctx.up2( p ) ) )
     case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => p
-    case NegR( main, q )                   => NegR( main, normalize( q, lctx.up1( p ) ) )
-    case NegL( main, q )                   => NegL( main, normalize( q, lctx.up1( p ) ) )
-    case AndR( main, q1, q2 )              => AndR( main, normalize( q1, lctx.up1( p ) ), normalize( q2, lctx.up2( p ) ) )
-    case AndL( main, q )                   => AndL( main, normalize( q, lctx.up1( p ) ) )
-    case AllL( main, term, q )             => AllL( main, term, normalize( q, lctx.up1( p ) ) )
-    case AllR( main, ev, q )               => AllR( main, ev, normalize( q, lctx.up1( p ) ) )
-    case Eql( main, eq, ltr, rwCtx, q )    => Eql( main, eq, ltr, rwCtx, normalize( q, lctx.up1( p ) ) )
-    case AllSk( main, term, skDef, q )     => AllSk( main, term, skDef, normalize( q, lctx.up1( p ) ) )
-    case Def( main, f, q )                 => Def( main, f, normalize( q, lctx.up1( p ) ) )
+    case NegR( main, q )                   => NegR.f( main, normalize( q, lctx.up1( p ) ) )
+    case NegL( main, q )                   => NegL.f( main, normalize( q, lctx.up1( p ) ) )
+    case AndR( main, q1, q2 )              => AndR.f( main, normalize( q1, lctx.up1( p ) ), normalize( q2, lctx.up2( p ) ) )
+    case AndL( main, q )                   => AndL.f( main, normalize( q, lctx.up1( p ) ) )
+    case AllL( main, term, q )             => AllL.f( main, term, normalize( q, lctx.up1( p ) ) )
+    case AllR( main, ev, q )               => AllR.f( main, ev, normalize( q, lctx.up1( p ) ) )
+    case Eql( main, eq, ltr, rwCtx, q )    => Eql.f( main, eq, ltr, rwCtx, normalize( q, lctx.up1( p ) ) )
+    case AllSk( main, term, skDef, q )     => AllSk.f( main, term, skDef, normalize( q, lctx.up1( p ) ) )
+    case Def( main, f, q )                 => Def.f( main, f, normalize( q, lctx.up1( p ) ) )
     case Ind( main, f, t, cases ) =>
       Ind( main, f, t, for ( ( c, i ) <- cases.zipWithIndex )
         yield c.copy( q = normalize( c.q, lctx.upn( p, i ) ) ) )
@@ -93,6 +93,8 @@ class Normalizer[LC <: ALCtx[LC]]( skipAtomicCuts: Boolean = false, skipProposit
   def evalCut( c: Cut, lctx: LC ): LKt = {
     doCheck( c, lctx )
     val Cut( f, q1, q2 ) = c
+    if ( q1.isConst ) return q1.p
+    if ( q2.isConst ) return q2.p
     if ( skipAtomicCuts && isAtom( f ) ) return c
     if ( skipPropositionalCuts && !containsQuantifierOnLogicalLevel( f ) ) return c
     if ( q2.freeHyps( q1.aux ) ) return evalCut( Cut( f, q1.rename( q2.freeHyps ), q2 ), lctx )
@@ -100,9 +102,6 @@ class Normalizer[LC <: ALCtx[LC]]( skipAtomicCuts: Boolean = false, skipProposit
     val lctx1 = lctx.up1( c )
     val lctx2 = lctx.up2( c )
     ( q1.p, q2.p, f ) match {
-      case ( _, _, _ ) if q1.isConst              => q1.p
-      case ( _, _, _ ) if q2.isConst              => q2.p
-
       case ( Ax( h1, c1 ), _, _ ) if c1 == q1.aux => q2.inst( h1 )
       case ( _, Ax( h2, c2 ), _ ) if h2 == q2.aux => q1.inst( c2 )
       case ( NegR( m1, r1 ), NegL( m2, r2 ), Neg( g ) ) if m1 == q1.aux && m2 == q2.aux =>

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
@@ -3,6 +3,7 @@ package at.logic.gapt.proofs.lkt
 import at.logic.gapt.expr._
 import at.logic.gapt.expr.hol.instantiate
 import at.logic.gapt.proofs.Context
+import at.logic.gapt.proofs.lk.LKProof
 import at.logic.gapt.utils.Maybe
 
 class Normalizer[LC <: ALCtx[LC]] {
@@ -119,9 +120,15 @@ class NormalizerWithDebugging( implicit ctx: Maybe[Context] ) extends Normalizer
   }
 }
 
-object normalize {
+class normalize {
   def apply( p: LKt ): LKt =
     new Normalizer[FakeLocalCtx]().normalize( p, FakeLocalCtx )
+  def withDebug( p: LKProof )( implicit ctx: Maybe[Context] ): LKt = {
+    val ( t, lctx ) = LKToLKt( p )
+    withDebug( t, lctx )
+  }
   def withDebug( p: LKt, lctx: LocalCtx )( implicit ctx: Maybe[Context] ): LKt =
     new NormalizerWithDebugging().normalize( p, lctx )
 }
+object normalize extends normalize
+object normalizeLKt extends normalize

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/normalization.scala
@@ -1,0 +1,127 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr._
+import at.logic.gapt.expr.hol.instantiate
+import at.logic.gapt.proofs.Context
+import at.logic.gapt.utils.Maybe
+
+class Normalizer[LC <: ALCtx[LC]] {
+  case class Subst( hyp: Hyp, byF: Formula, by: Bound1 ) {
+    def apply( bnd: Bound1, lctx: B1[LC] ): Bound1 =
+      if ( bnd.aux == hyp ) bnd
+      else if ( !by.freeHyps( bnd.aux ) ) Bound1( bnd.aux, apply( bnd.p, lctx( bnd.aux ) ) )
+      else apply( bnd.rename( by.freeHyps ), lctx )
+    def apply( bnd: Bound2, lctx: B2[LC] ): Bound2 =
+      if ( bnd.aux1 == hyp || bnd.aux2 == hyp ) bnd
+      else if ( !by.freeHyps( bnd.aux1 ) && !by.freeHyps( bnd.aux2 ) )
+        Bound2( bnd.aux1, bnd.aux2, apply( bnd.p, lctx( bnd.aux1, bnd.aux2 ) ) )
+      else apply( bnd.rename( by.freeHyps ), lctx )
+
+    def apply( p: LKt, lctx: LC ): LKt = p match {
+      case _ if !p.freeHyps( hyp ) => p
+      case Cut( f, q1, q2 )        => Cut( f, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
+      case Ax( m1, m2 ) =>
+        if ( hyp == m1 ) by.inst( m2 )
+        else if ( hyp == m2 ) by.inst( m1 )
+        else p
+      case Rfl( main ) if main != hyp     => p
+      case TopR( cohyp ) if cohyp != hyp  => p
+      case NegR( main, q ) if main != hyp => NegR( main, apply( q, lctx.up1_( p ) ) )
+      case NegL( main, q ) if main != hyp => NegL( main, apply( q, lctx.up1_( p ) ) )
+      case AndR( main, q1, q2 ) if main != hyp =>
+        AndR( main, apply( q1, lctx.up1_( p ) ), apply( q2, lctx.up2_( p ) ) )
+      case AndL( main, q ) if main != hyp       => AndL( main, apply( q, lctx.up12_( p ) ) )
+      case AllL( main, term, q ) if main != hyp => AllL( main, term, apply( q, lctx.up1_( p ) ) )
+      case AllR( main, ev, q ) if main != hyp =>
+        if ( !by.p.freeVars( ev ) ) AllR( main, ev, apply( q, lctx.up1_( p ) ) ) else {
+          val ev_ = rename( ev, by.p.freeVars union p.freeVars )
+          apply( AllR( main, ev_, Substitution( ev -> ev_ )( q ) ), lctx )
+        }
+      case Eql( main, eq, ltr, rwCtx, q ) if main != hyp && eq != hyp =>
+        Eql( main, eq, ltr, rwCtx, apply( q, lctx.up1_( p ) ) )
+      case _ =>
+        if ( hyp.inSuc ) evalCut( lctx, byF, Bound1( hyp, p ), by )
+        else evalCut( lctx, byF, by, Bound1( hyp, p ) )
+    }
+  }
+
+  def normalize( bnd: Bound1, lctx: LC ): Bound1 = Bound1( bnd.aux, normalize( bnd.p, lctx ) )
+  def normalize( bnd: Bound2, lctx: LC ): Bound2 = Bound2( bnd.aux1, bnd.aux2, normalize( bnd.p, lctx ) )
+  def normalize( p: LKt, lctx: LC ): LKt = p match {
+    case _ if !p.hasCuts => p
+    case Cut( f, q1, q2 ) =>
+      evalCut( lctx, f, normalize( q1, lctx.up1( p ) ), normalize( q2, lctx.up2( p ) ) )
+    case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => p
+    case NegR( main, q )                   => NegR( main, normalize( q, lctx.up1( p ) ) )
+    case NegL( main, q )                   => NegL( main, normalize( q, lctx.up1( p ) ) )
+    case AndR( main, q1, q2 )              => AndR( main, normalize( q1, lctx.up1( p ) ), normalize( q2, lctx.up2( p ) ) )
+    case AndL( main, q )                   => AndL( main, normalize( q, lctx.up1( p ) ) )
+    case AllL( main, term, q )             => AllL( main, term, normalize( q, lctx.up1( p ) ) )
+    case AllR( main, ev, q )               => AllR( main, ev, normalize( q, lctx.up1( p ) ) )
+    case Eql( main, eq, ltr, rwCtx, q )    => Eql( main, eq, ltr, rwCtx, normalize( q, lctx.up1( p ) ) )
+  }
+
+  def inst( q: Bound1, byF: Formula, by: Bound1, lctx: LC ): LKt = Subst( q.aux, byF, by ).apply( q.p, lctx )
+  def inst1( q: Bound2, byF: Formula, by: Bound1, lctx: LC, g1: Formula, g2: Formula ): Bound1 =
+    Subst( q.aux1, byF, by ).apply( Bound1( q.aux2, q.p ), lctx.upS( g1 )( q.aux1 ).upS( g2 ) )
+
+  def evalCut( lctx: LC, f: Formula, q1: Bound1, q2: Bound1 ): LKt =
+    evalCut( Cut( f, q1, q2 ), lctx )
+
+  def evalCut( c: Cut, lctx: LC ): LKt = {
+    val Cut( f, q1, q2 ) = c
+    val lctx1 = lctx.up1( c )
+    val lctx2 = lctx.up2( c )
+    ( q1.p, q2.p, f ) match {
+      case ( _, _, _ ) if q1.isConst              => q1.p
+      case ( _, _, _ ) if q2.isConst              => q2.p
+
+      case ( Ax( h1, c1 ), _, _ ) if c1 == q1.aux => q2.inst( h1 )
+      case ( _, Ax( h2, c2 ), _ ) if h2 == q2.aux => q1.inst( c2 )
+      case ( NegR( m1, r1 ), NegL( m2, r2 ), Neg( g ) ) if m1 == q1.aux && m2 == q2.aux =>
+        evalCut( lctx, g,
+          Subst( m2, f, q1 ).apply( r2, lctx2.up1_( q2.p ) ),
+          Subst( m1, f, q2 ).apply( r1, lctx1.up1_( q1.p ) ) )
+      case ( AndR( m1, r11, r12 ), AndL( m2, r2 ), And( g1, g2 ) ) if m1 == q1.aux && m2 == q2.aux =>
+        evalCut( lctx, g2,
+          Subst( m1, f, q2 ).apply( r12, lctx1.up2_( q1.p ) ),
+          inst1(
+            Subst( m2, f, q1 ).apply( r2, lctx2.up12_( q2.p ) ),
+            g1, Subst( m1, f, q2 ).apply( r11, lctx1.up1_( q1.p ) ),
+            lctx2, g1, g2 ) )
+      case ( AndL( m1, r1 ), AndR( m2, r21, r22 ), BinConn( g1, g2 ) ) if m1 == q1.aux && m2 == q2.aux =>
+        val r1_ = Subst( m1, f, q2 ).apply( r1, lctx1.up12_( q1.p ) )
+        val r21_ = Subst( m2, f, q1 ).apply( r21, lctx2.up1_( q2.p ) )
+        val r22_ = Subst( m2, f, q1 ).apply( r22, lctx2.up2_( q2.p ) )
+        evalCut( lctx, g2, inst1( r1_, g1, r21_, lctx, g1, g2 ), r22_ )
+      case ( AllR( m1, ev, r1 ), AllL( m2, t, r2 ), _ ) if m1 == q1.aux && m2 == q2.aux =>
+        val inst = BetaReduction.betaNormalize( instantiate( f, t ) )
+        evalCut( lctx, inst,
+          Subst( m1, f, q2 ).apply( Substitution( ev -> t )( r1 ), lctx1.upS( inst ) ),
+          Subst( m2, f, q1 ).apply( r2, lctx2.up1_( q2.p ) ) )
+      case ( AllL( m1, t, r1 ), AllR( m2, ev, r2 ), _ ) if m1 == q1.aux && m2 == q2.aux =>
+        val inst = BetaReduction.betaNormalize( instantiate( f, t ) )
+        evalCut( lctx, inst,
+          Subst( m1, f, q2 ).apply( r1, lctx1.up1_( q1.p ) ),
+          Subst( m2, f, q1 ).apply( Substitution( ev -> t )( r2 ), lctx2.upS( inst ) ) )
+
+      case ( _, _, _ ) if !q2.p.mainHyps.contains( q2.aux ) => inst( q2, f, q1, lctx2 )
+      case ( _, _, _ ) if !q1.p.mainHyps.contains( q1.aux ) => inst( q1, f, q2, lctx1 )
+      case _ => Cut( f, q1, q2 )
+    }
+  }
+}
+
+class NormalizerWithDebugging( implicit ctx: Maybe[Context] ) extends Normalizer[LocalCtx] {
+  override def evalCut( c: Cut, lctx: LocalCtx ): LKt = {
+    check( c, lctx )
+    super.evalCut( c, lctx )
+  }
+}
+
+object normalize {
+  def apply( p: LKt ): LKt =
+    new Normalizer[FakeLocalCtx]().normalize( p, FakeLocalCtx )
+  def withDebug( p: LKt, lctx: LocalCtx )( implicit ctx: Maybe[Context] ): LKt =
+    new NormalizerWithDebugging().normalize( p, lctx )
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
@@ -1,0 +1,13 @@
+package at.logic.gapt.proofs
+
+package object lkt extends ImplicitInstances {
+
+  implicit class HypSet( private val set: Set[Hyp] ) extends AnyVal {
+    private def freshIdx: Int =
+      if ( set.isEmpty ) 1 else set.view.map( h => math.abs( h.idx ) ).max + 1
+    def freshSuc: Hyp = Hyp( freshIdx )
+    def freshAnt: Hyp = Hyp( -freshIdx )
+    def freshSameSide( h: Hyp ): Hyp = if ( h.inAnt ) freshAnt else freshSuc
+  }
+
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
@@ -1,5 +1,7 @@
 package at.logic.gapt.proofs
 
+import at.logic.gapt.expr.Polarity
+
 package object lkt extends ImplicitInstances {
 
   implicit class HypSet( private val set: Set[Hyp] ) extends AnyVal {
@@ -7,6 +9,7 @@ package object lkt extends ImplicitInstances {
       if ( set.isEmpty ) 1 else set.view.map( h => math.abs( h.idx ) ).max + 1
     def freshSuc: Hyp = Hyp( freshIdx )
     def freshAnt: Hyp = Hyp( -freshIdx )
+    def fresh( p: Polarity ): Hyp = if ( p.inAnt ) freshAnt else freshSuc
     def freshSameSide( h: Hyp ): Hyp = if ( h.inAnt ) freshAnt else freshSuc
     def freshSameSide( hs: List[Hyp] ): List[Hyp] =
       ( Stream.from( freshIdx ), hs ).zipped.map( ( i, h ) => if ( h.inAnt ) Hyp( -i ) else Hyp( i ) ).toList

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/package.scala
@@ -8,6 +8,8 @@ package object lkt extends ImplicitInstances {
     def freshSuc: Hyp = Hyp( freshIdx )
     def freshAnt: Hyp = Hyp( -freshIdx )
     def freshSameSide( h: Hyp ): Hyp = if ( h.inAnt ) freshAnt else freshSuc
+    def freshSameSide( hs: List[Hyp] ): List[Hyp] =
+      ( Stream.from( freshIdx ), hs ).zipped.map( ( i, h ) => if ( h.inAnt ) Hyp( -i ) else Hyp( i ) ).toList
   }
 
 }

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
@@ -218,33 +218,33 @@ sealed trait LKt {
       gather( bnd.p )
     }
     def gather( p: LKt ): Unit = p match {
-      case Cut( _, q1, q2 )         =>
+      case Cut( _, q1, q2 ) =>
         gather1( q1 ); gather1( q2 )
-      case Ax( main1, main2 )       =>
+      case Ax( main1, main2 ) =>
         out += main1; out += main2
-      case Rfl( main )              => out += main
-      case TopR( main )             => out += main
-      case NegR( main, q )          =>
+      case Rfl( main )  => out += main
+      case TopR( main ) => out += main
+      case NegR( main, q ) =>
         out += main; gather1( q )
-      case NegL( main, q )          =>
+      case NegL( main, q ) =>
         out += main; gather1( q )
-      case AndR( main, q1, q2 )     =>
+      case AndR( main, q1, q2 ) =>
         out += main; gather1( q1 ); gather1( q2 )
-      case AndL( main, q )          =>
+      case AndL( main, q ) =>
         out += main; gather1( q )
-      case AllL( main, _, q )       =>
+      case AllL( main, _, q ) =>
         out += main; gather1( q )
-      case AllR( main, _, q )       =>
+      case AllR( main, _, q ) =>
         out += main; gather1( q )
       case Eql( main, eq, _, _, q ) =>
         out += main; out += eq; gather1( q )
-      case AllSk( main, _, _, q )   =>
+      case AllSk( main, _, _, q ) =>
         out += main; gather1( q )
-      case Def( main, _, q )        =>
+      case Def( main, _, q ) =>
         out += main; gather1( q )
       case Ind( main, _, _, cases ) =>
         out += main; cases.foreach( c => gather1( c.q ) )
-      case Link( mains, _ )         => out ++= mains
+      case Link( mains, _ ) => out ++= mains
     }
     gather( this )
     out.result()

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
@@ -1,0 +1,235 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.expr._
+import at.logic.gapt.formats.babel.{ BabelExporter, BabelSignature }
+import at.logic.gapt.utils.Doc
+
+case class Hyp( idx: Int ) extends AnyVal {
+  def inAnt = idx < 0
+  def inSuc = !inAnt
+  def polarity = if ( inAnt ) Polarity.InAntecedent else Polarity.InSuccedent
+  def replace( a: Hyp, b: Hyp ): Hyp = if ( this == a ) b else this
+  def toDoc: Doc = toString
+  override def toString = if ( idx < 0 ) idx.toString else "+" + idx.toString
+}
+
+trait Bound {
+  def freeHyps: Set[Hyp]
+  def toDoc( implicit sig: BabelSignature ): Doc
+}
+final case class Bound1( aux: Hyp, p: LKt ) extends Bound {
+  def freeHyps: Set[Hyp] = p.freeHyps - aux
+  def rename( awayFrom: Iterable[Hyp] ): Bound1 = {
+    val aux_ = ( p.freeHyps ++ awayFrom ).freshSameSide( aux )
+    Bound1( aux_, p.replace( aux, aux_ ) )
+  }
+  def replace( a: Hyp, b: Hyp ): Bound1 =
+    if ( a == aux ) this
+    else if ( b == aux ) rename( List( b ) ).replace( a, b )
+    else Bound1( aux, p.replace( a, b ) )
+
+  def inst( b: Hyp ): LKt = p.replace( aux, b )
+  def isConst: Boolean = !p.freeHyps( aux )
+
+  def toDoc( implicit sig: BabelSignature ): Doc =
+    aux.toDoc <> ":" <+> p.toDoc
+}
+final case class Bound2( aux1: Hyp, aux2: Hyp, p: LKt ) extends Bound {
+  require( aux1 != aux2 )
+  def freeHyps: Set[Hyp] = p.freeHyps - aux1 - aux2
+  def rename( awayFrom: Iterable[Hyp] ): Bound2 = {
+    val free = p.freeHyps ++ awayFrom + aux1 + aux2
+    val aux1_ = free.freshSameSide( aux1 )
+    val aux2_ = ( free + aux1_ ).freshSameSide( aux2 )
+    Bound2( aux1_, aux2_, p.replace( aux1, aux1_ ).replace( aux2, aux2_ ) )
+  }
+  def replace( a: Hyp, b: Hyp ): Bound2 =
+    if ( a == aux1 || a == aux2 ) this
+    else if ( b == aux1 || b == aux2 ) rename( Set( b ) ).replace( a, b )
+    else Bound2( aux1, aux2, p.replace( a, b ) )
+
+  def toDoc( implicit sig: BabelSignature ): Doc =
+    aux1.toDoc <> ":" <+> aux2.toDoc <> ":" <+> p.toDoc
+}
+
+sealed trait LKt {
+  def replace( a: Hyp, b: Hyp ): LKt =
+    this match {
+      case _ if !freeHyps( a )            => this
+      case Cut( f, q1, q2 )               => Cut( f, q1.replace( a, b ), q2.replace( a, b ) )
+      case Ax( main1, main2 )             => Ax( main1.replace( a, b ), main2.replace( a, b ) )
+      case Rfl( main )                    => Rfl( main.replace( a, b ) )
+      case TopR( main )                   => TopR( main.replace( a, b ) )
+      case NegR( main, q )                => NegR( main.replace( a, b ), q.replace( a, b ) )
+      case NegL( main, q )                => NegL( main.replace( a, b ), q.replace( a, b ) )
+      case AndR( main, q1, q2 )           => AndR( main.replace( a, b ), q1.replace( a, b ), q2.replace( a, b ) )
+      case AndL( main, q )                => AndL( main.replace( a, b ), q.replace( a, b ) )
+      case AllL( main, term, q )          => AllL( main.replace( a, b ), term, q.replace( a, b ) )
+      case AllR( main, ev, q )            => AllR( main.replace( a, b ), ev, q.replace( a, b ) )
+      case Eql( main, eq, ltr, rwCtx, q ) => Eql( main.replace( a, b ), eq.replace( a, b ), ltr, rwCtx, q.replace( a, b ) )
+    }
+
+  def mainHyps: Seq[Hyp] = this match {
+    case Cut( _, _, _ )           => Seq()
+    case Ax( main1, main2 )       => Seq( main1, main2 )
+    case Rfl( main )              => Seq( main )
+    case TopR( main )             => Seq( main )
+    case NegL( main, _ )          => Seq( main )
+    case NegR( main, _ )          => Seq( main )
+    case AndL( main, _ )          => Seq( main )
+    case AndR( main, _, _ )       => Seq( main )
+    case AllL( main, _, _ )       => Seq( main )
+    case AllR( main, _, _ )       => Seq( main )
+    case Eql( main, eq, _, _, _ ) => Seq( main, eq )
+  }
+
+  val freeHyps: Set[Hyp] = this match {
+    case Cut( _, q1, q2 )         => q1.freeHyps union q2.freeHyps
+    case Ax( main1, main2 )       => Set( main1, main2 )
+    case Rfl( main )              => Set( main )
+    case TopR( main )             => Set( main )
+    case NegL( main, q )          => q.freeHyps + main
+    case NegR( main, q )          => q.freeHyps + main
+    case AndL( main, q )          => q.freeHyps + main
+    case AndR( main, q1, q2 )     => q1.freeHyps union q2.freeHyps + main
+    case AllL( main, _, q )       => q.freeHyps + main
+    case AllR( main, _, q )       => q.freeHyps + main
+    case Eql( main, eq, _, _, q ) => q.freeHyps + main + eq
+  }
+
+  val hasCuts: Boolean = this match {
+    case Cut( _, _, _ )                    => true
+    case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => false
+    case NegL( _, q )                      => q.p.hasCuts
+    case NegR( _, q )                      => q.p.hasCuts
+    case AndL( _, q )                      => q.p.hasCuts
+    case AndR( _, q1, q2 )                 => q1.p.hasCuts || q2.p.hasCuts
+    case AllL( _, _, q )                   => q.p.hasCuts
+    case AllR( _, _, q )                   => q.p.hasCuts
+    case Eql( _, _, _, _, q )              => q.p.hasCuts
+  }
+
+  val freeVars: Set[Var] = this match {
+    case Cut( f, q1, q2 )                  => freeVariables( f ) union q1.p.freeVars union q2.p.freeVars
+    case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => Set()
+    case NegR( _, q )                      => q.p.freeVars
+    case NegL( _, q )                      => q.p.freeVars
+    case AndR( _, q1, q2 )                 => q1.p.freeVars union q2.p.freeVars
+    case AndL( _, q )                      => q.p.freeVars
+    case AllL( _, term, q )                => q.p.freeVars union freeVariables( term )
+    case AllR( _, ev, q )                  => q.p.freeVars - ev
+    case Eql( _, _, _, rwCtx, q )          => q.p.freeVars union freeVariables( rwCtx )
+  }
+
+  def toDoc( implicit sig: BabelSignature ): Doc = {
+    val prod = this.asInstanceOf[Product]
+    ( Doc.text( prod.productPrefix ) <> "(" <> Doc.wordwrap2(
+      prod.productIterator.toSeq.map {
+        case expr: Expr =>
+          new BabelExporter( unicode = true, sig = sig ).
+            show( expr, knownType = false, Set(), Map() )._1.inPrec( 0 )
+        case bnd: Bound => bnd.toDoc
+        case hyp: Hyp   => hyp.toDoc
+        case p: LKt     => p.toDoc
+        case b: Boolean => b.toString: Doc
+      }, "," ) <> ")" ).nest( 1 )
+  }
+
+  def subProofs: Vector[LKt] = {
+    val out = Vector.newBuilder[LKt]
+    def gather( p: LKt ): Unit = {
+      out += p
+      p match {
+        case Cut( _, q1, q2 ) =>
+          gather( q1.p ); gather( q2.p )
+        case Ax( _, _ )   =>
+        case Rfl( _ )     =>
+        case TopR( _ )    =>
+        case NegR( _, q ) => gather( q.p )
+        case NegL( _, q ) => gather( q.p )
+        case AndR( _, q1, q2 ) =>
+          gather( q1.p ); gather( q2.p )
+        case AndL( _, q )         => gather( q.p )
+        case AllL( _, _, q )      => gather( q.p )
+        case AllR( _, _, q )      => gather( q.p )
+        case Eql( _, _, _, _, q ) => gather( q.p )
+      }
+    }
+    gather( this )
+    out.result()
+  }
+
+  override def toString = toDoc.render( 80 )
+}
+case class Cut( f: Formula, q1: Bound1, q2: Bound1 ) extends LKt
+case class Ax( main1: Hyp, main2: Hyp ) extends LKt
+case class Rfl( main: Hyp ) extends LKt
+case class TopR( main: Hyp ) extends LKt
+case class NegR( main: Hyp, q: Bound1 ) extends LKt
+case class NegL( main: Hyp, q: Bound1 ) extends LKt
+case class AndR( main: Hyp, q1: Bound1, q2: Bound1 ) extends LKt
+case class AndL( main: Hyp, q: Bound2 ) extends LKt
+case class AllL( main: Hyp, term: Expr, q: Bound1 ) extends LKt
+case class AllR( main: Hyp, ev: Var, q: Bound1 ) extends LKt
+case class Eql( main: Hyp, eq: Hyp, ltr: Boolean, rwCtx: Expr, q: Bound1 ) extends LKt
+
+trait ImplicitInstances {
+  implicit val closedUnderSubstitutionBound1: ClosedUnderSub[Bound1] =
+    ( sub: Substitution, bnd: Bound1 ) => bnd.copy( p = sub( bnd.p ) )
+  implicit val closedUnderSubstitutionBound2: ClosedUnderSub[Bound2] =
+    ( sub: Substitution, bnd: Bound2 ) => bnd.copy( p = sub( bnd.p ) )
+  implicit val closedUnderSubstitution: ClosedUnderSub[LKt] =
+    ( sub: Substitution, p: LKt ) => p match {
+      case Cut( f, q1, q2 )                  => Cut( sub( f ), sub( q1 ), sub( q2 ) )
+      case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => p
+      case NegR( main, q )                   => NegR( main, sub( q ) )
+      case NegL( main, q )                   => NegL( main, sub( q ) )
+      case AndR( main, q1, q2 )              => AndR( main, sub( q1 ), sub( q2 ) )
+      case AndL( main, q )                   => AndL( main, sub( q ) )
+      case AllL( main, term, q )             => AllL( main, sub( term ), sub( q ) )
+      case AllR( _, ev, _ ) if sub.domain.contains( ev ) =>
+        Substitution( sub.map - ev, sub.typeMap )( p )
+      case AllR( main, ev, q ) if sub.range.contains( ev ) =>
+        val ev_ = rename( ev, q.p.freeVars union sub.range union sub.domain )
+        AllR( main, ev_, Substitution( sub.map + ( ev -> ev_ ), sub.typeMap )( q ) )
+      case AllR( main, ev, q )            => AllR( main, ev, sub( q ) )
+      case Eql( main, eq, ltr, rwCtx, q ) => Eql( main, eq, ltr, sub( rwCtx ), sub( q ) )
+    }
+
+  implicit object replaceableBnd1 extends ClosedUnderReplacement[Bound1] {
+    def replace( bnd: Bound1, repl: PartialFunction[Expr, Expr] ): Bound1 =
+      bnd.copy( p = TermReplacement( bnd.p, repl )( replaceable ) )
+    def names( bnd: Bound1 ): Set[VarOrConst] = containedNames( bnd.p )
+  }
+  implicit object replaceableBnd2 extends ClosedUnderReplacement[Bound2] {
+    def replace( bnd: Bound2, repl: PartialFunction[Expr, Expr] ): Bound2 =
+      bnd.copy( p = TermReplacement( bnd.p, repl )( replaceable ) )
+    def names( bnd: Bound2 ): Set[VarOrConst] = containedNames( bnd.p )
+  }
+  implicit object replaceable extends ClosedUnderReplacement[LKt] {
+    override def replace( p: LKt, repl: PartialFunction[Expr, Expr] ): LKt =
+      p match {
+        case Cut( f, q1, q2 )                  => Cut( TermReplacement( f, repl ), TermReplacement( q1, repl ), TermReplacement( q2, repl ) )
+        case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => p
+        case NegR( main, q )                   => NegR( main, TermReplacement( q, repl ) )
+        case NegL( main, q )                   => NegL( main, TermReplacement( q, repl ) )
+        case AndR( main, q1, q2 )              => AndR( main, TermReplacement( q1, repl ), TermReplacement( q2, repl ) )
+        case AndL( main, q )                   => AndL( main, TermReplacement( q, repl ) )
+        case AllL( main, term, q )             => AllL( main, TermReplacement( term, repl ), TermReplacement( q, repl ) )
+        case AllR( main, ev, q )               => AllR( main, TermReplacement( ev, repl ).asInstanceOf[Var], TermReplacement( q, repl ) )
+        case Eql( main, eq, ltr, rwCtx, q )    => Eql( main, eq, ltr, TermReplacement( rwCtx, repl ).asInstanceOf[Abs], TermReplacement( q, repl ) )
+      }
+    override def names( p: LKt ): Set[VarOrConst] =
+      p match {
+        case Cut( f, q1, q2 )                  => containedNames( f ) union containedNames( q1 ) union containedNames( q2 )
+        case Ax( _, _ ) | Rfl( _ ) | TopR( _ ) => Set()
+        case NegR( _, q )                      => containedNames( q )
+        case NegL( _, q )                      => containedNames( q )
+        case AndR( _, q1, q2 )                 => containedNames( q1 ) union containedNames( q2 )
+        case AndL( _, q )                      => containedNames( q )
+        case AllL( _, term, q )                => containedNames( q ) union containedNames( term )
+        case AllR( _, ev, q )                  => containedNames( q ) + ev
+        case Eql( _, _, _, rwCtx, q )          => containedNames( q ) union containedNames( rwCtx )
+      }
+  }
+}

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
@@ -5,16 +5,15 @@ import at.logic.gapt.formats.babel.{ BabelExporter, BabelSignature }
 import at.logic.gapt.utils.Doc
 
 case class Hyp( idx: Int ) extends AnyVal {
-  def inAnt = idx < 0
-  def inSuc = !inAnt
-  def polarity = if ( inAnt ) Polarity.InAntecedent else Polarity.InSuccedent
+  def polarity = if ( idx < 0 ) Polarity.InAntecedent else Polarity.InSuccedent
+  def inAnt = polarity.inAnt
+  def inSuc = polarity.inSuc
   def replace( a: Hyp, b: Hyp ): Hyp = if ( this == a ) b else this
   def toDoc: Doc = toString
-  override def toString = if ( idx < 0 ) idx.toString else "+" + idx.toString
+  override def toString = if ( inAnt ) idx.toString else "+" + idx.toString
 }
 object Hyp {
-  def mk( idx: Int, polarity: Polarity ): Hyp = mk( idx, polarity.inSuc )
-  def mk( idx: Int, inSuc: Boolean ): Hyp = if ( inSuc ) Hyp( idx ) else Hyp( -idx )
+  def mk( idx: Int, polarity: Polarity ): Hyp = if ( polarity.inSuc ) Hyp( idx ) else Hyp( -idx )
 }
 
 trait Bound {

--- a/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/lkt/terms.scala
@@ -17,10 +17,13 @@ object Hyp {
 }
 
 trait Bound {
+  def auxs: List[Hyp]
+  def p: LKt
   def freeHyps: Set[Hyp]
   def toDoc( implicit sig: BabelSignature ): Doc
 }
 final case class Bound1( aux: Hyp, p: LKt ) extends Bound {
+  def auxs: List[Hyp] = List( aux )
   def freeHyps: Set[Hyp] = p.freeHyps - aux
   def rename( awayFrom: Iterable[Hyp] ): Bound1 = {
     val aux_ = ( p.freeHyps ++ awayFrom ).freshSameSide( aux )
@@ -39,6 +42,7 @@ final case class Bound1( aux: Hyp, p: LKt ) extends Bound {
 }
 final case class Bound2( aux1: Hyp, aux2: Hyp, p: LKt ) extends Bound {
   require( aux1 != aux2 )
+  def auxs: List[Hyp] = List( aux1, aux2 )
   def freeHyps: Set[Hyp] = p.freeHyps - aux1 - aux2
   def rename( awayFrom: Iterable[Hyp] ): Bound2 = {
     val free = p.freeHyps ++ awayFrom + aux1 + aux2

--- a/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
@@ -408,6 +408,12 @@ case class Sequent[+A]( antecedent: Vector[A], succedent: Vector[A] ) {
     case Suc( j ) => Sequent( antecedent, succedent.updated( j, elem ) )
   }
 
+  def updated[B >: A]( updates: Iterable[( SequentIndex, B )] ): Sequent[B] = {
+    var res: Sequent[B] = this
+    for ( ( i, b ) <- updates ) res = res.updated( i, b )
+    res
+  }
+
   def indexOfOption[B >: A]( elem: B ): Option[SequentIndex] = find( _ == elem )
   def indexOf[B >: A]( elem: B ): SequentIndex = indexOfOption( elem ) get
 

--- a/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
+++ b/core/src/main/scala/at/logic/gapt/proofs/sequents.scala
@@ -50,10 +50,7 @@ sealed abstract class SequentIndex extends Ordered[SequentIndex] {
 }
 object SequentIndex {
   def apply( polarity: Polarity, k: Int ): SequentIndex =
-    polarity match {
-      case Positive => Suc( k )
-      case Negative => Ant( k )
-    }
+    if ( polarity.inSuc ) Suc( k ) else Ant( k )
 }
 
 case class Ant( k: Int ) extends SequentIndex {
@@ -307,10 +304,7 @@ case class Sequent[+A]( antecedent: Vector[A], succedent: Vector[A] ) {
    */
   def contains[B]( el: B ): Boolean = elements contains el
 
-  def cedent( polarity: Polarity ) = polarity match {
-    case Positive => succedent
-    case Negative => antecedent
-  }
+  def cedent( polarity: Polarity ) = if ( polarity.inSuc ) succedent else antecedent
 
   def contains[B]( el: B, polarity: Polarity ): Boolean =
     cedent( polarity ).contains( el )

--- a/core/src/main/scala/at/logic/gapt/utils/doc.scala
+++ b/core/src/main/scala/at/logic/gapt/utils/doc.scala
@@ -90,4 +90,6 @@ object Doc {
     ds.view.zipWithIndex.
       map { case ( d, i ) => if ( i == 0 ) d else ( sep <> line <> d ).group }.
       reduceLeftOption( _ <> _ ).getOrElse( "" )
+  def wordwrap2( ds: Iterable[Doc], sep: Doc = "" ): Doc =
+    ds.reduceLeftOption( ( a, b ) => ( a <> sep </> b ).group ).getOrElse( "" )
 }

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -2095,48 +2095,48 @@ gapt> cutFormulas(Pi2Pigeonhole.proof) filter {containsQuantifier(_)} foreach pr
 
 gapt> val acnf = CERES(Pi2Pigeonhole.proof)
 acnf: at.logic.gapt.proofs.lk.LKProof =
-[p477] ∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
-∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0))
+[p477] ∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
+∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0))
 ⊢
 ∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (CutRule(p1, Suc(0), p476, Ant(2)))
-[p476] ∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
-∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
+[p476] ∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
+∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
 0 = 0
 ⊢
 ∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionRightRule(p475, Suc(1), Suc(0)))
-[p475] ∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
-∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
+[p475] ∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
+∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
 0 = 0
 ⊢
 ∃x_1 ∃y_1 (s(x_1) <= y_1 ∧ f(x_1) = f(y_1)),
 ∃x ∃y_1 (s(x) <= y_1 ∧ f(x) = f(y_1))    (ContractionLeftRule(p474, Ant(3), Ant(1)))
-[p474] ∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0)),
-∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
+[p474] ∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0)),
+∀x_1 (f(x_1) = 0 ∨ f(x_1) = s(0)),
 0 = 0,
-∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0))
+∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0))
 ⊢
-∃x_1 ∃...
+∃x_1 ∃y_1 (s(x_1) <= y_1...
 
 gapt> prooftool(acnf)
 
 gapt> val et = LKToExpansionProof(acnf)
 et: at.logic.gapt.proofs.expansion.ExpansionProof =
-∀x_1 ∀y_0 (x_1 <= M(x_1, y_0) ∧ y_0 <= M(x_1, y_0))
-  +^{s(M(x_1, s(M(s(M(x_2, x_3)), x_0))))}
-    ∀y_0
-      (s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))) <=
-          M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), y_0) ∧
-        y_0 <= M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), y_0))
-    +^{s(M(s(M(x_2, x_3)), x_0))}
-      (s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))) <=
-          M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), s(M(s(M(x_2, x_3)), x_0))))- ∧
-      (s(M(s(M(x_2, x_3)), x_0)) <=
-          M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), s(M(s(M(x_2, x_3)), x_0))))-
-  +^{s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0))))))}
-    ∀y_0
-      (s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0)))))) <=
-          M(s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0)))))), y_0) ∧
-        y_0 <= M...
+∀x_0 (f(x_0) = 0 ∨ f(x_0) = s(0))
+  +^{M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), s(M(s(M(x_2, x_3)), x_0)))}
+    ((f(M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), s(M(s(M(x_2, x_3)), x_0)))) =
+          0)- ∨
+      (f(M(s(M(x_1, s(M(s(M(x_2, x_3)), x_0)))), s(M(s(M(x_2, x_3)), x_0)))) =
+          s(0))-)
+  +^{M(s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0)))))),
+        s(M(s(M(x_2, x_3)), x_0)))}
+    ((f(M(s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0)))))),
+                  s(M(s(M(x_2, x_3)), x_0)))) =
+          0)- ∨
+      (f(M(s(M(x_1, s(M(x, s(M(s(M(x_2, x_3)), x_0)))))),
+                  s(M(s(M(x_2, x_3)), x_0)))) =
+          s(0))-)
+  +^{M(s(M(x_1, s(M(x, s(M(x_2, x_3)))))), s(M(x_2, x_3)))}
+    ((f(M(s(M(x_1, s(M(x, s(M(x_2, x_3)))))), s(M(x_...
 
 gapt> prooftool(et)
 

--- a/examples/package.scala
+++ b/examples/package.scala
@@ -3,6 +3,7 @@ package at.logic.gapt
 package object examples {
   val proofSequences = Seq[ProofSequence](
     LinearExampleProof,
+    LinearCutExampleProof,
     LinearEqExampleProof,
     SquareDiagonalExampleProof,
     SquareEdgesExampleProof,

--- a/examples/prime/furstenberg.scala
+++ b/examples/prime/furstenberg.scala
@@ -1,6 +1,7 @@
 package at.logic.gapt.examples.prime
 
 import at.logic.gapt.expr._
+import at.logic.gapt.formats.babel.{ Notation, Precedence }
 import at.logic.gapt.proofs.gaptic._
 import at.logic.gapt.proofs.lk.LKProof
 import at.logic.gapt.proofs._
@@ -12,17 +13,16 @@ import at.logic.gapt.proofs._
  */
 case class furstenberg( k: Int ) extends PrimeDefinitions {
 
-  // The paper says X = Y <-> X subset Y ∧ Y subset X, but the current proof uses the definition
-  // X = Y <-> ∀x (x ∈ X <-> x ∈ Y). Taking the latter for now.
-  ctx += hof"EXT = (∀(X:nat>o) ∀Y ((∀x (X x <-> Y x)) -> X = Y))"
+  ctx += Notation.Infix( "=_s", Precedence.infixRel )
+  ctx += hof"(A =_s B) = (∀(x:nat) (A x ↔ B x))"
 
   /* -------------
    * | Subproofs |
    * -------------
    */
 
-  val deMorgan1 = Lemma( hols"EXT :- compN(union (X:nat>o) Y) = intersection(compN X)(compN Y)" ) {
-    unfold( "EXT" ) in "EXT"; chain( "EXT" ); forget( "EXT" )
+  val deMorgan1 = Lemma( hols":- compN(union (X:nat>o) Y) =_s intersection(compN X)(compN Y)" ) {
+    unfold( "=_s" ).in( "g" )
     allR
     unfold( "compN", "intersection", "union" ) in "g"
     prop
@@ -81,17 +81,20 @@ case class furstenberg( k: Int ) extends PrimeDefinitions {
 
   val unionClosed = Lemma( hols"C(X : nat>o), C(Y), EXT :- C(union X Y)" ) {
     unfold( "C" ) in ( "h_0", "h_1", "g" )
-    cut( "CF", hof" compN(union (X : nat>o) Y) = intersection(compN X)(compN Y)" ) left insert( deMorgan1 )
+    cut( "CF", hof" compN(union (X : nat>o) Y) =_s intersection(compN X)(compN Y)" ) left insert( deMorgan1 )
 
-    eql( "CF", "g" )
-    forget( "CF" )
-    insert( intersectionOpen )
+    cut( "g_2", hof"O(intersection (compN X) (compN Y))" ) left by { insert( intersectionOpen ) }
+
+    // TODO: prove congruence lemmas
+    unfold( "=_s" ).in( "CF" )
+    unfold( "O", "subset" ).in( "g", "g_2" )
+    simp.w( "CF" ).on( "g" )
   }
 
-  val progClosed = Lemma( hols"PRE, REM, '0<l': 0 < l, EXT :- C(ν 0 l)" ) {
-    cut( "CF", hof" U(0,l) = compN(ν 0 l)" ) left by {
+  val progClosed = Lemma( hols"PRE, REM, '0<l': 0 < l :- C(ν 0 l)" ) {
+    cut( "CF", hof" U(0,l) =_s compN(ν 0 l)" ) left by {
       forget( "PRE", "g" )
-      unfold( "EXT" ).in( "EXT" ); chain( "EXT" ); forget( "EXT" )
+      unfold( "=_s" ).in( "CF" )
       allR
       andR
 
@@ -139,7 +142,15 @@ case class furstenberg( k: Int ) extends PrimeDefinitions {
 
     unfold( "C" ) in "g"
     forget( "REM", "EXT" )
-    eql( "CF", "g" )
+
+    // TODO: congruence lemmas
+    cut( "g_2", hof"O(U 0 l)" ) right by {
+      unfold( "O", "subset" ).in( "g", "g_2" )
+      unfold( "=_s" ).in( "CF" )
+      simp.w( "CF" ).on( "g_2" )
+    }
+    forget( "g" ); renameLabel( "g_2" ).to( "g" )
+
     forget( "CF" )
     unfold( "O" ) in "g"
     decompose
@@ -171,29 +182,27 @@ case class furstenberg( k: Int ) extends PrimeDefinitions {
     }
   }
 
-  // Proof that complement(complement(X)) = X (under hof"EXT").
-  val compCompProof = Lemma( hols"EXT :- comp: compN(compN(X : nat>o)) = X" ) {
-    unfold( "EXT" ) in "EXT"; chain( "EXT" ); forget( "EXT" )
+  val compCompProof = Lemma( hols":- comp: compN(compN(X)) =_s X" ) {
+    unfold( "=_s" ).in( "comp" )
     allR( "comp", hov"x:nat" )
     unfold( "compN" ) in "comp"
     prop
   }
 
   // Proof that if complement(X) is closed, X is open (under hof"EXT").
-  val openClosedProof = Lemma( hols"EXT, C: C(compN(X : nat>o)) :- O: O(X)" ) {
+  val openClosedProof = Lemma( hols"C: C(compN(X)) :- O: O(X)" ) {
     unfold( "C" ) in "C"
-    cut( "CF", hof" compN(compN(X: nat>o)) = X" ) left by {
+    cut( "CF", hof" compN(compN(X: nat>o)) =_s X" ) left by {
       //Left subproof of the cut:
       forget( "C", "O" )
       insert( compCompProof )
     }
 
     //Right subproof of the cut:
-    forget( "EXT" )
-    eql( "CF", "C" ).fromLeftToRight
-    forget( "CF" )
-    unfold( "O", "ν", "subset" ) in ( "O", "C" )
-    trivial
+    // TODO: congruence lemmas
+    unfold( "=_s" ).in( "CF" )
+    unfold( "O", "subset" ).in( "C", "O" )
+    simp.w( "CF" ).on( "C" )
   }
 
   // Proof that {1} is nonempty
@@ -409,9 +418,9 @@ case class furstenberg( k: Int ) extends PrimeDefinitions {
       decompose
       insert( lambda( k ) )
     }
-  // Proof of EXT, F[k], PRIME-DIV :- S[k] = comp({1})
-  val psi1: LKProof = Lemma( hols"EXT, Fk: F $k, 'Prime-Div': 'PRIME-DIV' :- S $k = compN(set_1 1)" ) {
-    unfold( "EXT" ) in "EXT"; chain( "EXT" ); forget( "EXT" )
+  // Proof of F[k], PRIME-DIV :- S[k] = comp({1})
+  val psi1: LKProof = Lemma( hols"Fk: F $k, 'Prime-Div': 'PRIME-DIV' :- S $k =_s compN(set_1 1)" ) {
+    unfold( "=_s" ).in( "g" )
     allR( "g" )
     andR( "g" )
     by { insert( psi1Left ) }
@@ -522,22 +531,29 @@ case class furstenberg( k: Int ) extends PrimeDefinitions {
     }
   }
 
-  val psi2: LKProof = Lemma( hols"F $k, REM, EXT, PRE :- C (S $k)" ) {
+  val psi2: LKProof = Lemma( hols"F $k, REM, PRE :- C (S $k)" ) {
     cut( "Q", hof"Q $k" ) left insert( FQ )
     insert( psi2Right( k ) )
   }
 
   val proof: LKProof =
-    Lemma( hols"EXT, F $k, REM, PRE, 'PRIME-DIV' :-" ) {
+    Lemma( hols"F $k, REM, PRE, 'PRIME-DIV' :-" ) {
       cut( "INF {1}", hof" INF (set_1 1)" ) right insert( singletonFinite )
       cut( "nonempty {1}", hof" ¬ empty (set_1 1)" ) left insert( singletonNonempty )
 
       cut( "O {1}", hof" O (set_1 1)" ) right insert( phi2 )
       cut( "C compN{1}", hof" C (compN(set_1 1))" ) right insert( openClosedProof )
-      cut( "CF", hof" S $k = compN(set_1 1)" ) left insert( psi1 )
+      cut( "CF", hof" S $k =_s compN(set_1 1)" ) left insert( psi1 )
 
-      eql( "CF", "C compN{1}" )
-      forget( "CF" )
+      // TODO: congruence lemmas
+      cut( "C", hof"C (S $k)" ) right by {
+        unfold( "=_s", "compN" ).in( "CF" )
+        unfold( "C", "O", "subset", "compN" ).in( "C", "C compN{1}" )
+        simp.w( "CF" ).on( "C" )
+        simp.on( "C compN{1}" )
+      }
+      forget( "C compN{1}" ); renameLabel( "C" ).to( "C compN{1}" )
+
       insert( psi2 )
     }
 }

--- a/testing/src/main/scala/cutredbench.scala
+++ b/testing/src/main/scala/cutredbench.scala
@@ -1,0 +1,93 @@
+package at.logic.gapt.testing
+import at.logic.gapt.cutintro.CutIntroduction
+import at.logic.gapt.expr._
+import at.logic.gapt.examples._
+import at.logic.gapt.expr.fol.Numeral
+import at.logic.gapt.proofs.ceres.CERES
+import at.logic.gapt.proofs.expansion.{ ExpansionProof, eliminateCutsET }
+import at.logic.gapt.proofs.lk.{ LKProof, LKToExpansionProof, ReductiveCutElimination, eliminateDefinitions }
+import at.logic.gapt.proofs.lkt.{ LKToLKt, LKt, normalizeLKt }
+import at.logic.gapt.proofs.resolution.ResolutionToLKProof
+import at.logic.gapt.provers.escargot.Escargot
+
+import scala.concurrent.duration._
+
+object cutReductionBenchmark extends Script {
+  def measure( f: => Unit ): Duration = {
+    val begin = System.nanoTime()
+    f
+    val end = System.nanoTime()
+    ( end - begin ).nanos
+  }
+
+  def robustlyMeasure( f: => Unit ): Duration = {
+    val time0 = measure( f )
+    val extraRuns =
+      math.max( 0, math.min(
+        math.max( 2, math.round( 1.second / time0 ) ),
+        math.floor( 10.seconds / time0 ).toLong ) )
+    val time1 = measure( ( 0L until extraRuns ).foreach( _ => f ) )
+    ( time0 + time1 ) / ( 1 + extraRuns )
+  }
+
+  trait Method {
+    type P
+    def convert( p: LKProof ): P
+    def eliminate( p: P ): Unit
+    def robustlyMeasureElimination( lk: LKProof ): Duration = {
+      val p = convert( lk )
+      robustlyMeasure( eliminate( p ) )
+    }
+  }
+  trait LKMethod extends Method {
+    type P = LKProof
+    def convert( p: LKProof ): P = p
+  }
+  case object LKReductive extends LKMethod { def eliminate( p: LKProof ): Unit = ReductiveCutElimination( p ) }
+  case object LKCERES extends LKMethod { def eliminate( p: LKProof ): Unit = CERES( p ) }
+  case object CERESEXP extends LKMethod { def eliminate( p: LKProof ): Unit = CERES.CERESExpansionProof( p ) }
+  case object ExpCutElim extends Method {
+    type P = ExpansionProof
+    def convert( p: LKProof ): P = LKToExpansionProof( p )
+    def eliminate( p: P ): Unit = eliminateCutsET( p )
+  }
+  case object LKtNorm extends Method {
+    type P = LKt
+    def convert( p: LKProof ): P = LKToLKt( p )._1
+    def eliminate( p: LKt ): Unit = normalizeLKt( p )
+  }
+  val methods = List( LKReductive, LKCERES, CERESEXP, ExpCutElim, LKtNorm )
+
+  // warmup
+  for ( m <- methods ) m.robustlyMeasureElimination( LinearCutExampleProof( 3 ) )
+
+  println( "proof,n," + methods.mkString( "," ) )
+
+  def bench( name: String, n: Int, lk: LKProof, exclude: Set[Method] = Set() ): Unit = {
+    val times = methods.map {
+      case m if exclude( m ) => "NaN"
+      case m                 => m.robustlyMeasureElimination( lk ).toMicros.toString
+    }
+    println( s"$name,$n," + times.mkString( "," ) )
+  }
+
+  bench( "pi2pigeon", -1, Pi2Pigeonhole.proof )
+  bench( "pi3pigeon", -1, Pi3Pigeonhole.proof )
+
+  {
+    import at.logic.gapt.examples.lattice._
+    bench( "lattice", -1, eliminateDefinitions( p ), exclude = Set( LKReductive ) )
+  }
+
+  for ( n <- 0 to 12; p <- CutIntroduction( LinearEqExampleProof( n ) ) ) bench( "ci_lineareq", n, p )
+  for ( n <- 0 to 12; p <- CutIntroduction( LinearExampleProof( n ) ) ) bench( "ci_linear", n, p )
+
+  for ( n <- 0 to 6 ) {
+    val Some( res ) = Escargot.getResolutionProof( fof"P(0) & !x (P(x) -> P(s(x))) -> P${Numeral( n )}" )
+    val lk = ResolutionToLKProof( res )
+    bench( "linearacnf", n, lk )
+  }
+
+  for ( n <- 0 to 8 ) bench( "linear", n, LinearCutExampleProof( n ) )
+
+}

--- a/testing/src/main/scala/cutredbench.scala
+++ b/testing/src/main/scala/cutredbench.scala
@@ -3,6 +3,7 @@ import at.logic.gapt.cutintro.CutIntroduction
 import at.logic.gapt.expr._
 import at.logic.gapt.examples._
 import at.logic.gapt.expr.fol.Numeral
+import at.logic.gapt.proofs.HOLSequent
 import at.logic.gapt.proofs.ceres.CERES
 import at.logic.gapt.proofs.expansion.{ ExpansionProof, eliminateCutsET }
 import at.logic.gapt.proofs.lk.{ LKProof, LKToExpansionProof, ReductiveCutElimination, eliminateDefinitions }
@@ -46,17 +47,28 @@ object cutReductionBenchmark extends Script {
   case object LKReductive extends LKMethod { def eliminate( p: LKProof ): Unit = ReductiveCutElimination( p ) }
   case object LKCERES extends LKMethod { def eliminate( p: LKProof ): Unit = CERES( p ) }
   case object CERESEXP extends LKMethod { def eliminate( p: LKProof ): Unit = CERES.CERESExpansionProof( p ) }
+  case object BogoElim extends Method {
+    type P = HOLSequent
+    def convert( p: LKProof ): P = p.endSequent
+    def eliminate( p: P ): Unit = Escargot.getExpansionProof( p ).get
+  }
   case object ExpCutElim extends Method {
     type P = ExpansionProof
     def convert( p: LKProof ): P = LKToExpansionProof( p )
     def eliminate( p: P ): Unit = eliminateCutsET( p )
   }
-  case object LKtNorm extends Method {
+  class AbstractLKtNorm( skipAtomicCuts: Boolean = false, skipPropositionalCuts: Boolean = false ) extends Method {
     type P = LKt
     def convert( p: LKProof ): P = LKToLKt( p )._1
-    def eliminate( p: LKt ): Unit = normalizeLKt( p )
+    def eliminate( p: LKt ): Unit = normalizeLKt( p, skipAtomicCuts, skipPropositionalCuts )
   }
-  val methods = List( LKReductive, LKCERES, CERESEXP, ExpCutElim, LKtNorm )
+  case object LKtNorm extends AbstractLKtNorm
+  case object LKtNormA extends AbstractLKtNorm( skipAtomicCuts = true )
+  case object LKtNormP extends AbstractLKtNorm( skipPropositionalCuts = true )
+  val methods = List( LKReductive, LKCERES, CERESEXP, BogoElim, ExpCutElim, LKtNorm, LKtNormA, LKtNormP )
+
+  def turnEqualityIntoPredicate[A: ClosedUnderReplacement]( a: A ): A =
+    TermReplacement( a, { case EqC( t ) => Const( "E", t ->: t ->: To ) } )
 
   // warmup
   for ( m <- methods ) m.robustlyMeasureElimination( LinearCutExampleProof( 3 ) )
@@ -66,7 +78,7 @@ object cutReductionBenchmark extends Script {
   def bench( name: String, n: Int, lk: LKProof, exclude: Set[Method] = Set() ): Unit = {
     val times = methods.map {
       case m if exclude( m ) => "NaN"
-      case m                 => m.robustlyMeasureElimination( lk ).toMicros.toString
+      case m                 => m.robustlyMeasureElimination( lk ).toUnit( SECONDS ).toString
     }
     println( s"$name,$n," + times.mkString( "," ) )
   }
@@ -76,13 +88,17 @@ object cutReductionBenchmark extends Script {
 
   {
     import at.logic.gapt.examples.lattice._
-    bench( "lattice", -1, eliminateDefinitions( p ), exclude = Set( LKReductive ) )
+    bench( "lattice", -1, eliminateDefinitions( p ), exclude = Set( LKReductive, BogoElim ) )
   }
 
-  for ( n <- 0 to 12; p <- CutIntroduction( LinearEqExampleProof( n ) ) ) bench( "ci_lineareq", n, p )
-  for ( n <- 0 to 12; p <- CutIntroduction( LinearExampleProof( n ) ) ) bench( "ci_linear", n, p )
+  for ( n <- 0 to 18; p <- CutIntroduction( LinearEqExampleProof( n ) ) )
+    bench( "ci_lineareq", n, turnEqualityIntoPredicate( p ) )
+  for ( n <- 0 to 18; p <- CutIntroduction( LinearExampleProof( n ) ) ) bench( "ci_linear", n, p )
+  for ( n <- 0 to 18; p <- CutIntroduction( SquareDiagonalExampleProof( n ) ) ) bench( "ci_sqdiag", n, p )
+  for ( n <- 0 to 5; p <- CutIntroduction( FactorialFunctionEqualityExampleProof( n ) ) )
+    bench( "ci_fact", n, turnEqualityIntoPredicate( p ), exclude = Set( BogoElim ) )
 
-  for ( n <- 0 to 6 ) {
+  for ( n <- 0 to 10 ) {
     val Some( res ) = Escargot.getResolutionProof( fof"P(0) & !x (P(x) -> P(s(x))) -> P${Numeral( n )}" )
     val lk = ResolutionToLKProof( res )
     bench( "linearacnf", n, lk )

--- a/testing/src/main/scala/regressionTests.scala
+++ b/testing/src/main/scala/regressionTests.scala
@@ -28,6 +28,7 @@ import at.logic.gapt.utils._
 import EitherHelpers._
 import at.logic.gapt.examples.theories.Theory
 import at.logic.gapt.proofs.Context.ProofNames
+import at.logic.gapt.proofs.lkt.{ LKToLKt, normalizeLKt }
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -128,6 +129,7 @@ class TheoryTestCase( name: String ) extends RegressionTestCase( name ) {
     val proof = lemmaHandle.proof --- "proof"
 
     LKToND( proof ) --? "LKToND"
+    normalizeLKt.withDebug( proof ) --? "lkt cut-elim"
 
     LKToExpansionProof( proof ) --? "LKToExpansionProof" foreach { expansion =>
       deskolemizeET( expansion ) --? "deskolemization" foreach { desk =>
@@ -136,6 +138,7 @@ class TheoryTestCase( name: String ) extends RegressionTestCase( name ) {
         ExpansionProofToLK( desk ).get --? "ExpansionProofToLK on deskolemization" foreach { deskLK =>
           deskLK.conclusion.isSubsetOf( proof.conclusion ) !-- "conclusion of ExpansionProofToLK"
           ctx.check( deskLK ) --? "context check of ExpansionProofToLK"
+          normalizeLKt.withDebug( deskLK ) --? "lkt cut-elim (desk)"
           LKToND( deskLK ) --? "LKToND (deskolemization)"
         }
       }
@@ -214,6 +217,7 @@ class Prover9TestCase( f: java.io.File ) extends RegressionTestCase( f.getParent
       }
 
     ReductiveCutElimination( p ) --? "cut-elim (input)"
+    normalizeLKt.withDebug( p ) --? "lkt cut-elim (input)"
 
     cleanStructuralRules( p ) --? "cleanStructuralRules"
 
@@ -223,6 +227,7 @@ class Prover9TestCase( f: java.io.File ) extends RegressionTestCase( f.getParent
         LKToND( q, focus ) --? "LKToND (cut-intro)"
 
         ReductiveCutElimination( q ) --? "cut-elim (cut-intro)"
+        normalizeLKt.withDebug( q ) --? "lkt cut-elim (cut-intro)"
         CERES( q ) --? "CERES (cut-intro)"
         CERES.CERESExpansionProof( q ) --? "CERESExpansionProof"
 

--- a/tests/src/test/scala/at/logic/gapt/proofs/lkt/LktTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/lkt/LktTest.scala
@@ -26,14 +26,16 @@ class LktTest extends Specification with SequentMatchers {
 
   def beGood( implicit ctx: Maybe[Context] ): Matcher[LKProof] = beLike {
     case lk =>
-      val ( p, lctx ) = LKToLKt( lk )
-      check( p, lctx )
-      val q = normalize.withDebug( p, lctx )
-      check( q, lctx )
-      q must beMostlyCutFree
-      val lk2 = LKtToLK( q, lctx )
-      lk2.endSequent must beMultiSetEqual( lk.endSequent )
-      ctx.foreach( _.check( lk2 ) )
+      val ( p0, lctx ) = LKToLKt( lk )
+      check( p0, lctx )
+      val p1 = atomizeEquality( p0, lctx )
+      check( p1, lctx )
+      val p2 = normalize.withDebug( p1, lctx )
+      check( p2, lctx )
+      p2 must beMostlyCutFree
+      val p3 = LKtToLK( p2, lctx )
+      p3.endSequent must beMultiSetEqual( lk.endSequent )
+      ctx.foreach( _.check( p3 ) )
       ok
   }
 

--- a/tests/src/test/scala/at/logic/gapt/proofs/lkt/LktTest.scala
+++ b/tests/src/test/scala/at/logic/gapt/proofs/lkt/LktTest.scala
@@ -1,0 +1,57 @@
+package at.logic.gapt.proofs.lkt
+
+import at.logic.gapt.cutintro.CutIntroduction
+import at.logic.gapt.examples.{ LinearExampleProof, Pi2Pigeonhole, Pi3Pigeonhole }
+import at.logic.gapt.expr._
+import at.logic.gapt.expr.hol.containsQuantifierOnLogicalLevel
+import at.logic.gapt.proofs.lk.{ LKProof, makeInductionExplicit, solvePropositional }
+import at.logic.gapt.proofs.{ SequentMatchers, lk }
+import at.logic.gapt.provers.escargot.Escargot
+import org.specs2.matcher.Matcher
+import org.specs2.mutable.Specification
+
+class LktTest extends Specification with SequentMatchers {
+
+  def beMostlyCutFree: Matcher[LKt] = beLike {
+    case p =>
+      p.subProofs.foreach {
+        case Cut( f, _, _ ) =>
+          require( !containsQuantifierOnLogicalLevel( f ) )
+          containsQuantifierOnLogicalLevel( f ) must_== false
+        case _ =>
+      }
+      ok
+  }
+
+  def beGood: Matcher[LKProof] = beLike {
+    case lk =>
+      val ( p, lctx ) = LKToLKt( lk )
+      check( p, lctx )
+      val q = normalize.withDebug( p, lctx )
+      check( q, lctx )
+      q must beMostlyCutFree
+      LKtToLK( q, lctx ).endSequent must beMultiSetEqual( lk.endSequent )
+      ok
+  }
+
+  "reduce 1" in {
+    val Right( l ) = solvePropositional( hos"a & (a -> b) :- ~ ~b" )
+    val Right( r ) = solvePropositional( hos"~ ~b :- b" )
+    lk.CutRule( l, r, hof"~ ~b" ) must beGood
+  }
+  "fol 1" in {
+    val Some( l ) = Escargot.withDeskolemization.getLKProof( hos"!x (p x -> p (s x)) :- !x (p x -> p (s (s x)))" )
+    val Some( r ) = Escargot.withDeskolemization.getLKProof( hos"!x (p x -> p (s (s x))), p 0 :- p (s (s (s (s 0))))" )
+    lk.CutRule( l, r, hof"!x (p x -> p (s (s x)))" ) must beGood
+  }
+  "fol 2" in {
+    CutIntroduction( LinearExampleProof( 18 ) ).get must beGood
+  }
+  "fol 3" in { Pi2Pigeonhole.proof must beGood }
+  "fol 4" in { Pi3Pigeonhole.proof must beGood }
+  "theory 1" in {
+    import at.logic.gapt.examples.theories.nat._
+    makeInductionExplicit( addcomm.combined() ) must beGood
+  }
+
+}


### PR DESCRIPTION
This PR introduces a syntactic variant of LK using proof terms, to support an efficient implementation of Gentzen-style cut-reduction.

As shown in the empirical evaluation section below, (depending on the proof) this implementation is 10<sup>4</sup>x faster than `ReductiveCutElimination`, 10<sup>2</sup>x faster than CERES, and 10x faster than expansion proof cut-elimination.

## Calculus

The proof system is modeled closely after the calculus described in the paper by Urban and Bierman [1].  The name LKt is new and refers to "*LK* with *t*erms".

Proofs in LKt operate on hypotheses (called names and co-names in [1]), which name formula occurrences in the current sequent.  We have untyped proof terms, and a typing judgment that tells us what sequent a proof proves.  Let us first give (a representative subset of) the syntax for the terms, where `Expr` refers to lambda expressions.  (In the present implementation, there are a few more terms representing inferences for equality, induction, definitions, proof links, and ⊤).
```
Hyp ::= -Nat | +Nat
Term ::= Ax(Hyp, Hyp)
       | Cut(Formula, Hyp: Term, Hyp: Term)
       | NegL(Hyp, Hyp: Term)
       | NegR(Hyp, Hyp: Term)
       | AndL(Hyp, Hyp: Hyp: Term)
       | AndR(Hyp, Hyp: Term, Hyp: Term)
       | AllL(Hyp, Expr, Hyp: Term)
       | AllR(Hyp, Var, Hyp: Term)
```

Notably, we do not have terms for weakening and contraction.  These are implicit: we can use the same hypothesis zero or multiple times.

A negative hypothesis refers to a formula in the antecedent, and a positive hypothesis refers to a formula in the succedent.  The notation `Hyp: Term` means that `Hyp` is bound in `Term`, c.f. the notation of abstract binding trees originating in [3].  This encoding of LK is also very similar to the encoding commonly used in logical frameworks (LF), see [4] for a description of such an approach.

Note that the proof terms only contain new information that is not contained in the end-sequent; only cut formulas, weak quantifier instance terms, and eigenvariables are stored.  We do not repeat the formulas or atoms of the end-sequent.

Let us now define the typing judgment.  We consider labelled sequents, which are set-sequents of hypothesis-formula pairs, such that 1) all hypotheses are distinct, and 2) hypotheses are positive iff they are in the succedent.  The judgment `π :: S` means that `π` proves the labelled sequent `S`.  We only show a few examplary typing rules here, the rest are analogous and correspond to the inferences rules in LK in a natural way.
```
-------------------------------------
 Ax(h₁, h₂)  ::  h₁: φ, Γ ⊢ Δ, h₂: φ


  π  ::  h₃: ψ, h₂: φ, h₁: φ ∧ ψ, Γ ⊢ Δ
-----------------------------------------
AndL(h₁, h₂: h₃: π)  ::  h₁: φ ∧ ψ, Γ ⊢ Δ


 π[x\y]  ::  h₂: φ(y), h₁: ∀x φ(x), Γ ⊢ Δ
------------------------------------------  (where y is not free in the sequent)
AllR(h₁, x, h₂: π)  ::  h₁: ∀x φ(x), Γ ⊢ Δ
```

We use the convention that new hypotheses "overwrite" old ones in labelled sequents, that is `h: φ, h: ψ, Γ ⊢ Δ` is equal to `h: φ, Γ ⊢ Δ`.  In particular, it is not necessary to rename hypotheses for type-checking.  In the present implementation, renaming of eigenvariables is avoided as well by keeping track of a substitution in addition to the sequent in the `LocalCtx` type.

## Cut-normalization

The cut-reduction procedure is very similar to the one presented in [1], so we only give a short overview as well as note important differences.

Rank reduction is implemented using so-called "proof substitutions", these take one side of the cut and directly move it to all inferences in the other side where the cut formula occurs as the main formula.  Grade reduction works as you would expect.  Note that since contraction is implicit, the cut rule behaves more like the mix rule in [5].

In contrast to [1], cut-normalization is not strongly normalizing in our calculus.  This is due to the fact that cuts can get "stuck" on certain inferences (equality, reflexivity, induction, definitions, proof links, skolem rules).

In the present implementation, we use a big-step normalization approach: we always directly compute normal forms.  There is a function `evalCut` that takes a cut where both sides are already normalized and then returns a normal form.  Proof substitutions call `evalCut` instead of inserting cut terms.

## Empirical evaluation

We now compare the performance of several cut-elimination procedures on benchmarks used in [2], with a few differences:
 * We measure time in seconds, not in 10<sup>4</sup> milliseconds.
 * We use a consistent color scheme for the different procedures.
 * The proofs generated using `CutIntroduction(LinearEqExampleProof(n))` and `CutIntroduction(FactorialFunctionEqualityExampleProof(n))` have been modified so that they use a binary `E` relation instead of the equality predicate.  This ensures that the CERES methods produce proofs without equational inferences for these proofs.
 * We use a logarithmic scale to compare the runtimes, which differ by several orders of magnitude.

The benchmarks compare the following cut-elimination procedures (the abbreviation is used in the legend of the plots):
 * `LKReductive`: `ReductiveCutElimination`
 * `LKCERES`: `CERES` method that produces proofs in LK
 * `CERESEXP`: `CERES` method that produces expansion proofs, see [1]
 * `BogoElim`: eliminates cuts by forgetting the proof, and generating a new cut-free proof using Escargot.
 * `ExpCutElim`: cut-elimination in expansion proofs, see [6]
 * `LKtNorm`: cut-normalization in LKt
 * `LKtNormA`: cut-normalization in LKt where atomic cuts are not reduced
 * `LKtNormP`: cut-normalization in LKt where propositional cuts are not reduced

### Linear example after cut-introduction

These proofs are generated using `CutIntroduction(LinearExampleProof(n))`.  All of the LKt normalization procedures are faster than the CERES variants by a factor of ~100.  Even BogoElim is faster.  LKt normalization is also faster than expansion proof cut-elimination by a factor of ~10.

![ci_linear](https://user-images.githubusercontent.com/313929/36476021-eb4ad290-16fc-11e8-955d-29c0c117d663.png)

### Linear example proof with manual cuts

Cut-introduction often produces unnecessarily complicated lemmas, resulting in irregularity when used in proof sequences.  It is also limited to small proofs.  To produce a more regular sequence and obtain larger proofs, we formalized natural proofs of `P(0), ∀x (P(x) → P(s(x)) ⊢ P(s^{2^n}(x))` using `n` Π₁-cuts.

![linear](https://user-images.githubusercontent.com/313929/36476025-f31ca80e-16fc-11e8-92c9-b7e66d335b47.png)

The results are similar to the proofs obtained with cut-introduction, although we observe new phenomena at both ends of the sequence: for n=0, the proofs consist of a single axiom.  Here, the LKt-based procedures produce a cut-free proof in about 15 nanoseconds.  On the other end, at n>=6, we finally see CERES becoming faster than BogoElim.

### Linear example proof with atomic cuts

To complete the discussion of the linear example proof, we also consider a proof sequence in ACNF.  Interestingly, atomic cut-elimination is surprisingly cheap in this example: the LKt-based normalization only takes 10 microseconds.  On the other hand, the CERES-based methods require as much time as they do for the proofs with Π₁-cuts.  It is unclear where the runtime is spent.

![linearacnf](https://user-images.githubusercontent.com/313929/36476034-f91b0c3c-16fc-11e8-9cc0-7b0993804164.png)

### Square diagonal proof after cut-introduction

These proofs are generated using `CutIntroduction(SquareDiagonalExampleProof(n))`.  LKt normalization upto propositional cuts is an order of magnitude faster than expansion proof cut-elimination, and two orders of magnitude faster than CERES.

![ci_sqdiag](https://user-images.githubusercontent.com/313929/36476048-fecae120-16fc-11e8-94a8-c1e4baa59aba.png)

### Linear equality example proof after cut-introduction

These proofs are generated using `CutIntroduction(LinearEqExampleProof(n))`.  Note that we replaced the equality predicate by a binary `E` relation to prevent accidental introduction of equational inferences.  Again, LKt normalization upto propositional cuts is 10x faster than expansion proof cut elimination, which is 10x faster than CERES.

![ci_lineareq](https://user-images.githubusercontent.com/313929/36476054-0418a220-16fd-11e8-8db0-d7bea2a46dab.png)

The astute reader will have noticed the spikes in the runtime of the reductive cut-elimination procedures at n ∈ {7,9,11,13,17}.  These spikes are due to convoluted cut formulas.  For example at n=17, the cut formula is `∀x ((E(f(x), a) → E(f^3(x), a)) ∧ (E(x, a) → E(f(x), a)))` and we use it to prove `E(a,a) → E(f^17(a), a)`--this proof is almost as complicated on the propositional level as the cut-free proof, even though it has a lower quantifier complexity.

## Future work

 * Investigate whether other classical reduction systems such as λμ-calculus or natural deduction (with a suitable normalization relation) can achieve even greater performance.

 * Compare against functional interpretation as in [7].

 * Renaming hypothesis and applying expression substitutions incurs a significant cost in the benchmarks.  An obvious solution is to introduce an explicit substitution inference to implement these operations without the need to traverse the proof term.  Investigate how much this improves performance, or even if.

 * As a cheap optimization, we could grade-reduce blocks of quantifier inferences in a single substitution.

 * We used named variables as a binding strategy since this is traditionally used in GAPT.  Investigate the performance effects of other binding strategies such as DB or LN.

 * Proof assistants such as Coq and Lean also provide functions to normalize proofs.  How does their performance compare to GAPT?  As a realistic upper bound for the performance of cut-normalization, we could also manually convert natural deduction proofs to programs in Scala and measure their runtime.

## References

[1] C. Urban and G. M. Bierman, Strong normalization of cut-elimination in classical logic, Fundamentae Informaticae 44 (2000), 1-34.
[2] A. Leitsch and A. Lolic, Extraction of expansion trees, Journal of Automated Reasoning (2018).
[3] P. Aczel, A general Church-Rosser theorem, Technical Report, University of Manchester (1978).
[4] F. Pfenning, Structural cut elimination, LICS 1995.
[5] G. Takeuti, Proof theory (2013).
[6] S. Hetzl and D. Weller, Expansion trees with cut (2013), [preprint](https://arxiv.org/abs/1308.0428).
[7] P. Gerhardy and U. Kohlenbach, Extracting Herbrand disjunctions by functional interpretation, Archive for Mathematical Logic 44.5 (2005), 633-644.