### PR TITLE
leancop: support 2.1 compact output

### DIFF
--- a/core/src/main/scala/gapt/formats/leancop/LeanCoP21Parser.scala
+++ b/core/src/main/scala/gapt/formats/leancop/LeanCoP21Parser.scala
@@ -1,0 +1,68 @@
+package gapt.formats.leancop
+
+import gapt.expr.formula.{ Atom, Eq }
+import gapt.expr.formula.fol.{ FOLAtom, FOLFunction, FOLTerm }
+import gapt.proofs.FOLClause
+
+object LeanCoP21Parser {
+  sealed trait Lit
+  case class Pos( atom: FOLAtom ) extends Lit
+  case class Neg( atom: FOLAtom ) extends Lit
+  case object Hash extends Lit
+  case object NegHash extends Lit
+
+  case class Clause( literals: Lit* ) {
+    override def toString = s"Clause(${literals.mkString( ", " )})"
+
+    def toFOLClause: FOLClause =
+      FOLClause(
+        literals.collect { case Neg( a ) => a },
+        literals.collect { case Pos( a ) => a } )
+  }
+
+  case class Proof( main: Clause, sides: List[Proof] ) {
+    def clauses: List[Clause] =
+      main :: sides.flatMap( _.clauses )
+
+    def toFOLClauses: Seq[FOLClause] =
+      clauses.map( _.toFOLClause )
+  }
+
+  import fastparse._, MultiLineWhitespace._
+
+  def stdout[_: P]: P[Proof] =
+    P( ( AnyChar ~ !"ompact Proof" ).rep ~
+      "Compact Proof:\n--------------" ~ proof ~ "--------------" )
+
+  def proof[_: P]: P[Proof] =
+    P( "[" ~ clause ~ ( "," ~/ proof ).rep ~ "]" ).map {
+      case ( main, sides ) => Proof( main, sides.toList )
+    }
+
+  def clause[_: P]: P[Clause] =
+    P( "[" ~ lit.rep( sep = "," ) ~ "]" ).map( Clause( _: _* ) )
+
+  def lit[_: P]: P[Lit] = P( pos | neg | hash | negHash )
+  def pos[_: P]: P[Lit] = P( atom ).map( Pos )
+  def neg[_: P]: P[Lit] = P( "-" ~ atom ).map( Neg )
+  def hash[_: P]: P[Lit] = P( "#" ).map( _ => Hash )
+  def negHash[_: P]: P[Lit] = P( "-" ~ "#" ).map( _ => NegHash )
+
+  def atom[_: P]: P[FOLAtom] = P( ( ident ~ ( "(" ~ term.rep( sep = "," ) ~ ")" ).? ~ ( "=" ~ term ).? )
+    .map {
+      case ( n, as, None )        => FOLAtom( n, as.getOrElse( Nil ) )
+      case ( n, as, Some( rhs ) ) => Eq( FOLFunction( n, as.getOrElse( Nil ) ), rhs )
+    } | ( "(" ~ atom ~ ")" ) )
+
+  def term[_: P]: P[FOLTerm] = P( ident ~ ( "(" ~ term.rep( sep = "," ) ~ ")" ).? )
+    .map { case ( n, as ) => FOLFunction( n, as.getOrElse( Nil ) ) }
+
+  def ident[_: P]: P[String] = P( CharsWhile( c => c.isLetterOrDigit || c == '_', 1 ).! )
+
+  def parse( stdout: String ): Either[String, Proof] =
+    fastparse.parse( stdout, LeanCoP21Parser.stdout( _ ) ) match {
+      case Parsed.Success( prf, _ ) => Right( prf )
+      case fail: Parsed.Failure     => Left( fail.msg )
+    }
+
+}

--- a/tests/src/test/scala/gapt/provers/leancop/leancopTest.scala
+++ b/tests/src/test/scala/gapt/provers/leancop/leancopTest.scala
@@ -18,51 +18,46 @@ import org.specs2.mutable._
 class LeanCoPProverTest extends Specification with SatMatchers {
   args( skipAll = !LeanCoP.isInstalled )
 
-  "LeanCoP" should {
-    "LEM" in {
-      val a = FOLAtom( "a" )
-      val f = Or( a, Neg( a ) )
-      LeanCoP.isValid( f ) must beTrue
-    }
-
-    "a |- a" in {
-      val a = FOLAtom( "a" )
-      val s = HOLSequent( Seq( a ), Seq( a ) )
-
-      LeanCoP.getExpansionProof( s ) must beSome
-    }
-
-    "forall x, P(x) |- P(0)" in {
-      val f = All( FOLVar( "x" ), FOLAtom( "P", FOLVar( "x" ) ) )
-      val g = FOLAtom( "P", FOLConst( "0" ) )
-
-      LeanCoP.getExpansionProof( HOLSequent( Seq( f ), Seq( g ) ) ) must beSome
-    }
-
-    "x + 0 = x, x + s(y) = s(x+y) |- x + s(0) = s(x)" in {
-      val seq = hof"!x x+0 = x" +: hof"!x !y x+s(y) = s(x+y)" +: Sequent() :+ hof"k+s(0) = s(k)"
-      LeanCoP.getExpansionProof( seq ) must beSome
-    }
-
-    "P,P->Q |- Q" in {
-      val seq = HOLSequent( Seq( FOLAtom( "P" ), Imp( FOLAtom( "P" ), FOLAtom( "Q" ) ) ), Seq( FOLAtom( "Q" ) ) )
-      LeanCoP.getExpansionProof( seq ) must beSome
-    }
-
-    "linear example" in {
-      LeanCoP getExpansionProof hof"p 0 & !x (p x -> p (s x)) -> p (s (s (s 0)))" must beLike {
-        case Some( expansion ) =>
-          expansion.deep must beValidSequent
-      }
-    }
-
-    "validate the buss tautology for n=2" in { LeanCoP.isValid( BussTautology( 2 ) ) must beTrue }
-
-    "not prove a or b" in { LeanCoP getExpansionProof hof"a | b" must beNone }
-
-    "prove top" in { LeanCoP.getLKProof( Sequent() :+ Top() ) must beSome }
-    "not prove bottom" in { LeanCoP.getLKProof( Sequent() :+ Bottom() ) must beNone }
-    "not refute top" in { LeanCoP.getLKProof( Top() +: Sequent() ) must beNone }
-    "refute bottom" in { LeanCoP.getLKProof( Bottom() +: Sequent() ) must beSome }
+  "LEM" in {
+    val a = FOLAtom( "a" )
+    val f = Or( a, Neg( a ) )
+    LeanCoP.isValid( f ) must beTrue
   }
+
+  "taut" in {
+    val a = FOLAtom( "a" )
+    val s = HOLSequent( Seq( a ), Seq( a ) )
+
+    LeanCoP.getExpansionProof( s ) must beSome( havingTautDeepSequent )
+  }
+
+  "forall x, P(x) |- P(0)" in {
+    val f = All( FOLVar( "x" ), FOLAtom( "P", FOLVar( "x" ) ) )
+    val g = FOLAtom( "P", FOLConst( "0" ) )
+
+    LeanCoP.getExpansionProof( HOLSequent( Seq( f ), Seq( g ) ) ) must beSome( havingTautDeepSequent )
+  }
+
+  "plus one equals succ" in {
+    val seq = hos"!x x+0 = x, !x !y x+s(y) = s(x+y) :- k+s(0) = s(k)"
+    LeanCoP.getExpansionProof( seq ) must beSome( havingQTautDeepSequent )
+  }
+
+  "P,P->Q |- Q" in {
+    val seq = HOLSequent( Seq( FOLAtom( "P" ), Imp( FOLAtom( "P" ), FOLAtom( "Q" ) ) ), Seq( FOLAtom( "Q" ) ) )
+    LeanCoP.getExpansionProof( seq ) must beSome( havingTautDeepSequent )
+  }
+
+  "linear example" in {
+    LeanCoP getExpansionProof hof"p 0 & !x (p x -> p (s x)) -> p (s (s (s 0)))" must beSome( havingTautDeepSequent )
+  }
+
+  "validate the buss tautology for n=2" in { LeanCoP.isValid( BussTautology( 2 ) ) must beTrue }
+
+  "not prove a or b" in { LeanCoP getExpansionProof hof"a | b" must beNone }
+
+  "prove top" in { LeanCoP.getLKProof( Sequent() :+ Top() ) must beSome }
+  "not prove bottom" in { LeanCoP.getLKProof( Sequent() :+ Bottom() ) must beNone }
+  "not refute top" in { LeanCoP.getLKProof( Top() +: Sequent() ) must beNone }
+  "refute bottom" in { LeanCoP.getLKProof( Bottom() +: Sequent() ) must beSome }
 }

--- a/tests/src/test/scala/gapt/utils/SatMatchers.scala
+++ b/tests/src/test/scala/gapt/utils/SatMatchers.scala
@@ -2,6 +2,7 @@ package gapt.utils
 
 import gapt.expr.formula.Formula
 import gapt.proofs.HOLSequent
+import gapt.proofs.expansion.ExpansionProof
 import gapt.provers.escargot.Escargot
 import gapt.provers.renameConstantsToFi
 import gapt.provers.sat.Sat4j
@@ -29,5 +30,8 @@ trait SatMatchers extends OptionMatchers {
     }
   def beEUnsat = beEValid ^^ { ( f: Formula ) => -f }
   def beEValidSequent = beEValid ^^ { ( sequent: HOLSequent ) => sequent.toDisjunction }
+
+  def havingTautDeepSequent = beValidSequent ^^ { ( ep: ExpansionProof ) => ep.deep }
+  def havingQTautDeepSequent = beEValidSequent ^^ { ( ep: ExpansionProof ) => ep.deep }
 
 }


### PR DESCRIPTION
This adds support for the new leancop 2.1 proof output in the prover interface.  For now, only the "compact" output mode is supported (which needs to be enabled by modifying the leancop file...).

cc @Ermine516 