### PR TITLE
Make build compatible with JDK 21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val root = project.in( file( "." ) ).
     scalacOptions in ( ScalaUnidoc, unidoc ) ++= Seq(
       "-doc-title", "gapt",
       "-doc-version", version.value,
-      "-doc-source-url", s"https://github.com/gapt/gapt/blob/${"git rev-parse HEAD" !!}/€{FILE_PATH}.scala",
+      "-doc-source-url", s"https://github.com/gapt/gapt/blob/${("git rev-parse HEAD" !!).strip}/€{FILE_PATH}.scala",
       "-doc-root-content", ( baseDirectory.value / "doc" / "rootdoc.txt" ).getAbsolutePath,
       "-sourcepath", baseDirectory.value.getAbsolutePath,
       "-skip-packages", "ammonite:ammonite.ops",

--- a/build.sbt
+++ b/build.sbt
@@ -16,10 +16,10 @@ lazy val commonSettings = Seq(
   autoAPIMappings := true,
   publishMavenStyle := true,
 
-  publishTo := (if ( isSnapshot.value )
-      Opts.resolver.sonatypeOssSnapshots.headOption
-    else
-      Some(Opts.resolver.sonatypeStaging )),
+  publishTo := ( if ( isSnapshot.value )
+    Opts.resolver.sonatypeOssSnapshots.headOption
+  else
+    Some( Opts.resolver.sonatypeStaging ) ),
 
   scmInfo := Some( ScmInfo(
     browseUrl = url( "https://github.com/gapt/gapt" ),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import java.io.ByteArrayOutputStream
 
 import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveOutputStream }
-import scalariform.formatter.preferences._
 import sys.process._
 
 val Version = "2.17.0-SNAPSHOT"
@@ -57,14 +56,7 @@ lazy val commonSettings = Seq(
   run / baseDirectory := file( "." ),
 
   sourcesInBase := false // people like to keep scripts lying around
-) ++ scalariformSettings
-
-lazy val scalariformSettings =
-  Seq( scalariformPreferences := scalariformPreferences.value
-    .setPreference( AlignParameters, true )
-    .setPreference( AlignSingleLineCaseStatements, true )
-    .setPreference( DoubleIndentConstructorArguments, true )
-    .setPreference( SpaceInsideParentheses, true ) )
+)
 
 val specs2Version = "4.16.0"
 lazy val testSettings = Seq(
@@ -88,10 +80,6 @@ lazy val root = project.in( file( "." ) ).
 
     publish / skip := true,
     packagedArtifacts := Map(),
-
-    inConfig( BuildSbtConfig )( SbtScalariform.configScalariformSettings ++ scalariformSettings ),
-    sourceDirectories in ( BuildSbtConfig, scalariformFormat ) := Seq( baseDirectory.value ),
-    includeFilter in ( BuildSbtConfig, scalariformFormat ) := ( "*.sbt": FileFilter ),
 
     apiURL := Some( url( "https://logic.at/gapt/api/" ) ),
     scalacOptions in ( ScalaUnidoc, unidoc ) ++= Seq(
@@ -264,7 +252,7 @@ lazy val cli = project.in( file( "cli" ) ).
     publish / skip := true,
     packagedArtifacts := Map() )
 
-addCommandAlias( "format", "; scalariformFormat ; buildsbt:scalariformFormat" )
+addCommandAlias( "format", ";" )
 
 lazy val testing = project.in( file( "testing" ) ).
   dependsOn( core, examples ).

--- a/build.sbt
+++ b/build.sbt
@@ -16,18 +16,17 @@ lazy val commonSettings = Seq(
   autoAPIMappings := true,
   publishMavenStyle := true,
 
-  publishTo := Some(
-    if ( isSnapshot.value )
-      Opts.resolver.sonatypeSnapshots
+  publishTo := (if ( isSnapshot.value )
+      Opts.resolver.sonatypeOssSnapshots.headOption
     else
-      Opts.resolver.sonatypeStaging ),
+      Some(Opts.resolver.sonatypeStaging )),
 
   scmInfo := Some( ScmInfo(
     browseUrl = url( "https://github.com/gapt/gapt" ),
     connection = "scm:git:https://github.com/gapt/gapt.git",
     devConnection = Some( "scm:git:git@github.com:gapt/gapt.git" ) ) ),
 
-  scalaVersion := "2.13.8",
+  scalaVersion := "2.13.12",
 
   developers := List(
     Developer(
@@ -46,7 +45,7 @@ lazy val commonSettings = Seq(
       email = "gebner@gebner.org",
       url = url( "https://gebner.org/" ) ) ),
 
-  scalacOptions in Compile ++= Seq(
+  Compile / scalacOptions ++= Seq(
     "-deprecation",
     "-language:postfixOps",
     "-language:implicitConversions",
@@ -55,7 +54,7 @@ lazy val commonSettings = Seq(
 
   javaOptions ++= Seq( "-Xss40m", "-Xmx1g" ),
   fork := true,
-  baseDirectory in run := file( "." ),
+  run / baseDirectory := file( "." ),
 
   sourcesInBase := false // people like to keep scripts lying around
 ) ++ scalariformSettings
@@ -69,8 +68,8 @@ lazy val scalariformSettings =
 
 val specs2Version = "4.16.0"
 lazy val testSettings = Seq(
-  testOptions in Test += Tests.Argument( TestFrameworks.Specs2, "junitxml", "console" ),
-  javaOptions in Test += "-Xmx2g",
+  Test / testOptions += Tests.Argument( TestFrameworks.Specs2, "junitxml", "console" ),
+  Test / javaOptions += "-Xmx2g",
   libraryDependencies ++= Seq(
     "org.specs2" %% "specs2-core" % specs2Version,
     "org.specs2" %% "specs2-junit" % specs2Version, // needed for junitxml output
@@ -84,8 +83,8 @@ lazy val root = project.in( file( "." ) ).
   settings( commonSettings: _* ).
   enablePlugins( ScalaUnidocPlugin ).
   settings(
-    fork in console := true,
-    initialCommands in console := IO.read( resourceDirectory.in( cli, Compile ).value / "gapt-cli-prelude.scala" ),
+    console / fork := true,
+    console / initialCommands := IO.read( resourceDirectory.in( cli, Compile ).value / "gapt-cli-prelude.scala" ),
 
     publish / skip := true,
     packagedArtifacts := Map(),
@@ -127,8 +126,8 @@ lazy val root = project.in( file( "." ) ).
     },
 
     // Release stuff
-    mainClass in assembly := Some( "gapt.cli.CLIMain" ),
-    aggregate in assembly := false,
+    assembly / mainClass := Some( "gapt.cli.CLIMain" ),
+    assembly / aggregate := false,
     releaseDist := {
       val baseDir = file( "." )
       val version = Keys.version.value
@@ -192,7 +191,7 @@ lazy val core = project.in( file( "core" ) ).
     name := "gapt",
     description := "General Architecture for Proof Theory",
 
-    scalacOptions in Compile += "-Xfatal-warnings",
+    Compile / scalacOptions += "-Xfatal-warnings",
 
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
@@ -229,8 +228,8 @@ lazy val examples = project.in( file( "examples" ) ).
   settings( commonSettings: _* ).
   settings(
     name := "gapt-examples",
-    unmanagedSourceDirectories in Compile := Seq( baseDirectory.value ),
-    resourceDirectory in Compile := baseDirectory.value,
+    Compile / unmanagedSourceDirectories := Seq( baseDirectory.value ),
+    Compile / resourceDirectory := baseDirectory.value,
     excludeFilter in ( Compile, unmanagedResources ) := {
       val target = ( baseDirectory.value / "target" ).getCanonicalPath
       new SimpleFileFilter( _.getCanonicalPath startsWith target )
@@ -250,7 +249,7 @@ lazy val userManual = project.in( file( "doc" ) ).
   dependsOn( cli ).
   settings( commonSettings: _* ).
   settings(
-    unmanagedSourceDirectories in Compile := Seq( baseDirectory.value ),
+    Compile / unmanagedSourceDirectories := Seq( baseDirectory.value ),
     publish / skip := true,
     packagedArtifacts := Map() )
 
@@ -259,7 +258,7 @@ lazy val cli = project.in( file( "cli" ) ).
   settings( commonSettings: _* ).
   settings(
     mainClass := Some( "gapt.cli.CLIMain" ),
-    scalacOptions in Compile += "-Xfatal-warnings",
+    Compile / scalacOptions += "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value ),
     publish / skip := true,
@@ -273,7 +272,7 @@ lazy val testing = project.in( file( "testing" ) ).
   settings(
     name := "gapt-testing",
     description := "gapt extended regression tests",
-    scalacOptions in Compile += "-Xfatal-warnings",
+    Compile / scalacOptions += "-Xfatal-warnings",
     publish / skip := true,
     packagedArtifacts := Map() )
 

--- a/core/src/main/scala/gapt/expr/BetaReduction.scala
+++ b/core/src/main/scala/gapt/expr/BetaReduction.scala
@@ -133,7 +133,7 @@ object normalize {
 
 object BetaReduction extends Normalizer( Set() ) {
   def betaNormalize( expression: Expr ): Expr =
-    normalize( expression )
+    this.normalize( expression )
 
   def betaNormalize( f: Formula ): Formula =
     betaNormalize( f: Expr ).asInstanceOf[Formula]

--- a/core/src/main/scala/gapt/expr/util/ExpressionParseHelper.scala
+++ b/core/src/main/scala/gapt/expr/util/ExpressionParseHelper.scala
@@ -39,7 +39,7 @@ object ExpressionParseHelper {
  * @param sc A StringContext
  */
 class ExpressionParseHelper( sc: StringContext, file: sourcecode.File, line: sourcecode.Line, sig: BabelSignature ) {
-  private implicit def _sig = sig
+  private implicit def _sig: BabelSignature = sig
 
   private def interpolateHelper( expressions: Seq[Splice[Expr]] ): ( String, preExpr.Expr => preExpr.Expr ) = {
     def repls( name: String ): preExpr.Expr =

--- a/core/src/main/scala/gapt/proofs/Checkable.scala
+++ b/core/src/main/scala/gapt/proofs/Checkable.scala
@@ -92,7 +92,7 @@ object Checkable {
       new ExpressionChecker().check( expr )
   }
 
-  implicit def sequentIsCheckable[T: Checkable] = new Checkable[Sequent[T]] {
+  implicit def sequentIsCheckable[T: Checkable]: Checkable[Sequent[T]] = new Checkable[Sequent[T]] {
     def check( sequent: Sequent[T] )( implicit context: Context ) =
       sequent.foreach( context.check( _ ) )
   }

--- a/core/src/main/scala/gapt/proofs/lkt/unfoldInduction.scala
+++ b/core/src/main/scala/gapt/proofs/lkt/unfoldInduction.scala
@@ -32,7 +32,7 @@ case class SimplifierSimpAdapter( simp: Simplifier, lctx: LocalCtx ) extends Sim
 }
 
 class unfoldInduction( simp: SimpAdapter, ctx0: ImmutableContext ) {
-  implicit val ctx = ctx0
+  implicit val ctx: ImmutableContext = ctx0
   var unfolded = false
 
   val simpHyps = simp.hyps

--- a/core/src/main/scala/gapt/proofs/sequents.scala
+++ b/core/src/main/scala/gapt/proofs/sequents.scala
@@ -479,11 +479,11 @@ object Sequent {
    */
   def apply( m: Int, n: Int ): Sequent[SequentIndex] = ( 0 until m ).map { Ant } ++: Sequent() :++ ( 0 until n ).map { Suc }
 
-  implicit val SequentFunctor = new Functor[Sequent] {
+  implicit val SequentFunctor: Functor[Sequent] = new Functor[Sequent] {
     def map[A, B]( fa: Sequent[A] )( f: A => B ): Sequent[B] = fa.map( f )
   }
 
-  implicit def SequentMonoid[A] = new Monoid[Sequent[A]] {
+  implicit def SequentMonoid[A]: Monoid[Sequent[A]] = new Monoid[Sequent[A]] {
     override def empty = Sequent()
     override def combine( s1: Sequent[A], s2: Sequent[A] ): Sequent[A] = s1 ++ s2
   }

--- a/core/src/main/scala/gapt/provers/viper/aip/AnalyticInductionProver.scala
+++ b/core/src/main/scala/gapt/provers/viper/aip/AnalyticInductionProver.scala
@@ -55,7 +55,7 @@ object AnalyticInductionProver {
 
 class AnalyticInductionProver( options: ProverOptions ) {
 
-  private implicit def labeledSequentToHOLSequent( sequent: Sequent[( String, Formula )] ) =
+  private implicit def labeledSequentToHOLSequent( sequent: Sequent[( String, Formula )] ): Sequent[Formula] =
     sequent map { case ( _, f ) => f }
 
   /**

--- a/core/src/main/scala/gapt/provers/viper/grammars/TreeGrammarProver.scala
+++ b/core/src/main/scala/gapt/provers/viper/grammars/TreeGrammarProver.scala
@@ -357,8 +357,8 @@ class TreeGrammarInductionTactic( options: TreeGrammarProverOptions = TreeGramma
       val viper = new TreeGrammarProver( ctx2, groundGoal, options )
       viper.solve()
     } ) catch {
-      case t: TimeOutException => throw t
-      case t: ThreadDeath      => throw t
+      case t: TimeOutException     => throw t
+      case t: InterruptedException => throw t
       case t: Throwable =>
         TacticFailure( this, ExceptionUtils.getStackTrace( t ) )
     }

--- a/core/src/main/scala/gapt/utils/help.scala
+++ b/core/src/main/scala/gapt/utils/help.scala
@@ -1,6 +1,6 @@
 package gapt.utils
 
-import java.net.{ HttpURLConnection, URL }
+import java.net.{ HttpURLConnection, URI, URL }
 import java.nio.file.{ Files, Paths }
 
 /**
@@ -31,7 +31,7 @@ object help {
       path.fold( false )( Files.exists( _ ) )
     } else {
       val classNameURL = name.replace( '.', '/' ) ++ ".html"
-      val url = new URL( websitePath + classNameURL )
+      val url = new URI( websitePath + classNameURL ).toURL
       val huc = url.openConnection().asInstanceOf[HttpURLConnection]
       huc.setRequestMethod( "GET" )
       huc.connect()

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -758,7 +758,7 @@ The \cli{Context.default} object contains only the sort \cli{o} (truth values) a
 symbols. An example for a context is:
 \begin{tacticslisting}[bare]
 object ContextExample {
-  implicit val ctx = MutableContext.default()
+  implicit val ctx: MutableContext = MutableContext.default()
   ctx += InductiveType("Nat", hoc" 0: Nat", hoc" s: Nat > Nat") //Adding a type declaration
   ctx += hoc" '+' : Nat>Nat>Nat" //Adding a constant declaration
   ctx += "plus_zero" -> hos" :- ∀n (n + 0 = n)" //Adding a theory axiom

--- a/examples/epsilon/epsilon.scala
+++ b/examples/epsilon/epsilon.scala
@@ -7,7 +7,7 @@ import gapt.proofs.epsilon.epsilonize
 import gapt.provers.escargot.Escargot
 
 object epsilon extends Script {
-  implicit val ctx = MutableContext.default()
+  implicit val ctx: MutableContext = MutableContext.default()
   ctx += hoc"ε{?a} : (?a>o)>?a"
   ctx += Ti
   ctx += hoc"P: i>i>i>o"

--- a/examples/lk_to_nd_examples.scala
+++ b/examples/lk_to_nd_examples.scala
@@ -514,7 +514,7 @@ object negLeft extends Script {
 }
 
 object proofLink extends Script {
-  implicit var ctx = Context.default
+  implicit var ctx: Context = Context.default
   ctx += Sort( "i" )
   ctx += hoc"'<': i>i>o"
   ctx += hoc"'+': i>i>i"
@@ -552,7 +552,7 @@ object proofLink2 extends Script {
 }
 
 object proofLink3 extends Script {
-  implicit var ctx = Context.default
+  implicit var ctx: Context = Context.default
   ctx += Sort( "i" )
   ctx += hoc"'<': i>i>o"
   ctx += hoc"'1': i"
@@ -611,7 +611,7 @@ object inductionRule extends Script {
 
   val ax1 = LogicalAxiom( P0 )
 
-  implicit var ctx = Context.default
+  implicit var ctx: Context = Context.default
   ctx += InductiveType( "i", hoc"0: i", hoc"s: i>i" )
   ctx += hoc"'th': i>i"
   ctx += hoc"'P': i>o"

--- a/examples/ntape/nTape6.scala
+++ b/examples/ntape/nTape6.scala
@@ -1,7 +1,8 @@
 package gapt.examples
 
-import java.io._
+import gapt.formats.llk.LLKTypes
 
+import java.io._
 import gapt.formats.llk.short._
 import gapt.formats.tptp.TptpHOLExporter
 import gapt.proofs.HOLSequent
@@ -42,7 +43,7 @@ object nTape6 {
    * Contains all the formulas used.
    */
   object formulas {
-    implicit val signature =
+    implicit val signature: LLKTypes.LLKSignature =
       sig(
         """var X:o; var U,V:i; var H:i>i; var x,y:i;
               const zero:i; const s:i>i;  const h:i>i;

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.9.6

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,14 +3,12 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.apache.commons" % "commons-compress" % "1.21"
 
-addSbtPlugin( "org.scoverage" %% "sbt-scoverage" % "1.9.3" )
+addSbtPlugin( "org.scoverage" %% "sbt-scoverage" % "2.0.9" )
 
 // Provides an assembly task which produces a fat jar with all dependencies included.
 addSbtPlugin( "com.eed3si9n" % "sbt-assembly" % "1.2.0" )
 
 addSbtPlugin( "com.github.sbt" % "sbt-unidoc" % "0.5.0" )
-
-addSbtPlugin( "org.scalariform" % "sbt-scalariform" % "1.8.3" )
 
 addSbtPlugin( "org.xerial.sbt" % "sbt-sonatype" % "3.9.13" )
 

--- a/testing/src/main/scala/utils.scala
+++ b/testing/src/main/scala/utils.scala
@@ -70,7 +70,7 @@ abstract class RegressionTestCase( val name: String ) extends Serializable {
       val runtime = ( endTime - beginTime ) nanos
 
       val ( exception, isTimeout ) = result match {
-        case Left( t @ ( _: TimeOutException | _: ThreadDeath | _: OutOfMemoryError |
+        case Left( t @ ( _: TimeOutException | _: InterruptedException | _: OutOfMemoryError |
           _: InterruptedException | _: StackOverflowError | _: BootstrapMethodError |
           _: ClosedByInterruptException ) ) => ( Some( t ), true )
         case Left( t )  => ( Some( t ), false )

--- a/tests/src/test/scala/gapt/provers/viper/aip/GeneralInductionAxiomsTest.scala
+++ b/tests/src/test/scala/gapt/provers/viper/aip/GeneralInductionAxiomsTest.scala
@@ -12,7 +12,7 @@ import org.specs2.mutable.Specification
 
 class GeneralInductionAxiomsTest extends Specification with ThrownMessages {
 
-  implicit var ctx = MutableContext.default()
+  implicit var ctx: MutableContext = MutableContext.default()
   ctx += InductiveType( "nat", hoc"0:nat", hoc"s:nat>nat" )
   ctx += hoc"P:nat>nat>o"
 

--- a/tests/src/test/scala/gapt/utils/timeoutTest.scala
+++ b/tests/src/test/scala/gapt/utils/timeoutTest.scala
@@ -1,0 +1,21 @@
+package gapt.utils
+
+import org.specs2.execute.{ Failure, Success }
+import org.specs2.mutable.Specification
+import org.specs2.matcher.Matchers._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+class timeoutTest extends Specification {
+  "Running a thread with a timeout" in {
+    "should be able to interrupt an infinite loop" in {
+      val d = Duration( 10, TimeUnit.MILLISECONDS )
+      //val d = Duration.Inf
+      withTimeout( d )(
+        while ( true ) {
+          /* do nothing */
+        } ) must throwA[TimeOutException]
+    }
+  }
+
+}


### PR DESCRIPTION
Sbt 1.6.2 and Scala 2.13.8 seem to crash with strange internal exceptions under JDK 21. Bump the versions to current ones that are compatible. Also ThreadDeath / Thread.stop() have been [deprecated](https://docs.oracle.com/javase/8/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html) for a while and the workaround with the StoppableWithoutDeprecationWarning trait seems to fail. Replace it by the recommended Thread.interrupt() and InterruptedException. The test case for java code succeeds but I have not thested if this also works with external processes like EProver. Also make type annotations of implicit val / var / def explicit to comply with portability warnings regarding Scala 3. 